### PR TITLE
parseInt on packetization mode

### DIFF
--- a/lib/ortc.js
+++ b/lib/ortc.js
@@ -429,7 +429,7 @@ function matchCapCodecs(aCodec, bCodec)
 		const aPacketizationMode = (aCodec.parameters || {})['packetization-mode'] || 0;
 		const bPacketizationMode = (bCodec.parameters || {})['packetization-mode'] || 0;
 
-		if (aPacketizationMode !== bPacketizationMode)
+		if (parseInt(aPacketizationMode) !== parseInt(bPacketizationMode))
 			return false;
 	}
 


### PR DESCRIPTION
Edge provides local capability parameters as strings, so H264 gets caught as not supported.

I didn't see contribution guidelines on the repo, so I'm just adding this to the src to be added at your discretion.