### PR TITLE
RN and simulcast

### DIFF
--- a/lib/handlers/ReactNative.js
+++ b/lib/handlers/ReactNative.js
@@ -137,7 +137,9 @@ class SendHandler extends Handler
 					'addProducer() | calling pc.setLocalDescription() [offer:%o]',
 					offer);
 
-				return this._pc.setLocalDescription(offer);
+				const offerDesc = new RTCSessionDescription(offer);
+
+				return this._pc.setLocalDescription(offerDesc);
 			})
 			.then(() =>
 			{
@@ -303,7 +305,9 @@ class SendHandler extends Handler
 					'replaceProducerTrack() | calling pc.setLocalDescription() [offer:%o]',
 					offer);
 
-				return this._pc.setLocalDescription(offer);
+				const offerDesc = new RTCSessionDescription(offer);
+
+				return this._pc.setLocalDescription(offerDesc);
 			})
 			.then(() =>
 			{


### PR DESCRIPTION
I've detected 2 issues playing with react-native-webrtc and simulcast, first one is missing RTCSessionDescription wrapping in setLocalDescription. I'm not so sure about the second one so let me paste monkeypatch and let me know what you think:

```
diff --git a/lib/Producer.js b/lib/Producer.js
index b0a5d70..081e039 100644
--- a/lib/Producer.js
+++ b/lib/Producer.js
@@ -64,7 +64,7 @@ export default class Producer extends EnhancedEventEmitter
                this._simulcast = false;

                if (options.simulcast)
-                       this._simulcast = Object.assign({}, SIMULCAST_DEFAULT, options.simulcast);
+                       this._simulcast = Object.assign({}, SIMULCAST_DEFAULT, options);

                // Associated Transport.
                // @type {Transport}
```

Without this change I'm getting "In this environment the sources for assign MUST be an object. This error is a performance optimization and not spec compliant." in that Object.assign statement.

Thanks in advance