### PR TITLE
add sdpSemantics: 'plan-b'

### DIFF
--- a/lib/handlers/Chrome67.js
+++ b/lib/handlers/Chrome67.js
@@ -22,7 +22,8 @@ class Handler extends EnhancedEventEmitter
 				iceServers         : settings.turnServers || [],
 				iceTransportPolicy : settings.iceTransportPolicy,
 				bundlePolicy       : 'max-bundle',
-				rtcpMuxPolicy      : 'require'
+				rtcpMuxPolicy      : 'require',
+				sdpSemantics       : 'plan-b'
 			});
 
 		// Generic sending RTP parameters for audio and video.


### PR DESCRIPTION
to make the plan-b choice independent of Chromes default behaviour.