### PR TITLE
fix race condition when new transports are getting created

### DIFF
--- a/lib/handlers/Chrome55.js
+++ b/lib/handlers/Chrome55.js
@@ -78,6 +78,9 @@ class SendHandler extends Handler
 		// @type {Boolean}
 		this._transportReady = false;
 
+		// @type {Boolean}
+		this._transportCreating = false;
+
 		// Local stream.
 		// @type {MediaStream}
 		this._stream = new MediaStream();
@@ -131,7 +134,7 @@ class SendHandler extends Handler
 			})
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -344,6 +347,8 @@ class SendHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -373,6 +378,7 @@ class SendHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportReady = true;
+				this._transportCreating = false;
 			});
 	}
 }
@@ -386,6 +392,10 @@ class RecvHandler extends Handler
 		// Got transport remote parameters.
 		// @type {Boolean}
 		this._transportCreated = false;
+
+		// Transport creating
+		// @type {Boolean}
+		this._transportCreating = false;
 
 		// Got transport local parameters.
 		// @type {Boolean}
@@ -433,7 +443,7 @@ class RecvHandler extends Handler
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportCreated)
+				if (!this._transportCreated && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -551,6 +561,8 @@ class RecvHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -565,6 +577,7 @@ class RecvHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportCreated = true;
+				this._transportCreating = false;
 			});
 	}
 

--- a/lib/handlers/Chrome67.js
+++ b/lib/handlers/Chrome67.js
@@ -79,6 +79,9 @@ class SendHandler extends Handler
 		// @type {Boolean}
 		this._transportReady = false;
 
+		// @type {Boolean}
+		this._transportCreating = false;
+
 		// Local stream.
 		// @type {MediaStream}
 		this._stream = new MediaStream();
@@ -132,7 +135,7 @@ class SendHandler extends Handler
 			})
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -294,6 +297,8 @@ class SendHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -323,6 +328,7 @@ class SendHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportReady = true;
+				this._transportCreating = false;
 			});
 	}
 }
@@ -336,6 +342,9 @@ class RecvHandler extends Handler
 		// Got transport remote parameters.
 		// @type {Boolean}
 		this._transportCreated = false;
+
+		// @type {Boolean}
+		this._transportCreating = false;
 
 		// Got transport local parameters.
 		// @type {Boolean}
@@ -383,7 +392,7 @@ class RecvHandler extends Handler
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportCreated)
+				if (!this._transportCreated && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -501,6 +510,8 @@ class RecvHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -515,6 +526,7 @@ class RecvHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportCreated = true;
+				this._transportCreating = false;
 			});
 	}
 

--- a/lib/handlers/Chrome69.js
+++ b/lib/handlers/Chrome69.js
@@ -79,6 +79,9 @@ class SendHandler extends Handler
 		// @type {Boolean}
 		this._transportReady = false;
 
+		// @type {Boolean}
+		this._transportCreating = false;
+
 		// Local stream.
 		// @type {MediaStream}
 		this._stream = new MediaStream();
@@ -133,7 +136,7 @@ class SendHandler extends Handler
 			})
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -304,6 +307,8 @@ class SendHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -333,6 +338,7 @@ class SendHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportReady = true;
+				this._transportCreating = false;
 			});
 	}
 }
@@ -346,6 +352,9 @@ class RecvHandler extends Handler
 		// Got transport remote parameters.
 		// @type {Boolean}
 		this._transportCreated = false;
+
+		// @type {Boolean}
+		this._transportCreating = false;
 
 		// Got transport local parameters.
 		// @type {Boolean}
@@ -393,7 +402,7 @@ class RecvHandler extends Handler
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportCreated)
+				if (!this._transportCreated && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -518,6 +527,8 @@ class RecvHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -532,6 +543,7 @@ class RecvHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportCreated = true;
+				this._transportCreating = false;
 			});
 	}
 

--- a/lib/handlers/Edge11.js
+++ b/lib/handlers/Edge11.js
@@ -44,6 +44,9 @@ export default class Edge11 extends EnhancedEventEmitter
 		// @type {Boolean}
 		this._transportReady = false;
 
+		// @type {Boolean}
+		this._transportCreating = false;
+
 		// ICE gatherer.
 		this._iceGatherer = null;
 
@@ -117,7 +120,7 @@ export default class Edge11 extends EnhancedEventEmitter
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -230,7 +233,7 @@ export default class Edge11 extends EnhancedEventEmitter
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -434,6 +437,8 @@ export default class Edge11 extends EnhancedEventEmitter
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -491,6 +496,7 @@ export default class Edge11 extends EnhancedEventEmitter
 				this._dtlsTransport.start(remoteDtlsParameters);
 
 				this._transportReady = true;
+				this._transportCreating = false;
 			});
 	}
 }

--- a/lib/handlers/Firefox50.js
+++ b/lib/handlers/Firefox50.js
@@ -78,6 +78,9 @@ class SendHandler extends Handler
 		// @type {Boolean}
 		this._transportReady = false;
 
+		// @type {Boolean}
+		this._transportCreating = false;
+
 		// Local stream.
 		// @type {MediaStream}
 		this._stream = new MediaStream();
@@ -171,7 +174,7 @@ class SendHandler extends Handler
 			})
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -328,6 +331,8 @@ class SendHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -357,6 +362,7 @@ class SendHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportReady = true;
+				this._transportCreating = false;
 			});
 	}
 }
@@ -370,6 +376,9 @@ class RecvHandler extends Handler
 		// Got transport remote parameters.
 		// @type {Boolean}
 		this._transportCreated = false;
+
+		// @type {Boolean}
+		this._transportCreating = false;
 
 		// Got transport local parameters.
 		// @type {Boolean}
@@ -431,7 +440,7 @@ class RecvHandler extends Handler
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportCreated)
+				if (!this._transportCreated && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -558,6 +567,8 @@ class RecvHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -572,6 +583,7 @@ class RecvHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportCreated = true;
+				this._transportCreating = false;
 			});
 	}
 

--- a/lib/handlers/Firefox59.js
+++ b/lib/handlers/Firefox59.js
@@ -78,6 +78,9 @@ class SendHandler extends Handler
 		// @type {Boolean}
 		this._transportReady = false;
 
+		// @type {Boolean}
+		this._transportCreating = false;
+
 		// Local stream.
 		// @type {MediaStream}
 		this._stream = new MediaStream();
@@ -172,7 +175,7 @@ class SendHandler extends Handler
 			})
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -329,6 +332,8 @@ class SendHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -358,6 +363,7 @@ class SendHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportReady = true;
+				this._transportCreating = false;
 			});
 	}
 }
@@ -371,6 +377,9 @@ class RecvHandler extends Handler
 		// Got transport remote parameters.
 		// @type {Boolean}
 		this._transportCreated = false;
+
+		// @type {Boolean}
+		this._transportCreating = false;
 
 		// Got transport local parameters.
 		// @type {Boolean}
@@ -417,7 +426,7 @@ class RecvHandler extends Handler
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportCreated)
+				if (!this._transportCreated && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -549,6 +558,8 @@ class RecvHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -563,6 +574,7 @@ class RecvHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportCreated = true;
+				this._transportCreating = false;
 			});
 	}
 

--- a/lib/handlers/ReactNative.js
+++ b/lib/handlers/ReactNative.js
@@ -78,6 +78,9 @@ class SendHandler extends Handler
 		// @type {Boolean}
 		this._transportReady = false;
 
+		// @type {Boolean}
+		this._transportCreating = false;
+
 		// Handled tracks.
 		// @type {Set<MediaStreamTrack>}
 		this._tracks = new Set();
@@ -143,7 +146,7 @@ class SendHandler extends Handler
 			})
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -385,6 +388,8 @@ class SendHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -414,6 +419,7 @@ class SendHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportReady = true;
+				this._transportCreating = false;
 			});
 	}
 }
@@ -427,6 +433,9 @@ class RecvHandler extends Handler
 		// Got transport remote parameters.
 		// @type {Boolean}
 		this._transportCreated = false;
+
+		// @type {Boolean}
+		this._transportCreating = false;
 
 		// Got transport local parameters.
 		// @type {Boolean}
@@ -474,7 +483,7 @@ class RecvHandler extends Handler
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportCreated)
+				if (!this._transportCreated && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -603,6 +612,8 @@ class RecvHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -617,6 +628,7 @@ class RecvHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportCreated = true;
+				this._transportCreating = false;
 			});
 	}
 

--- a/lib/handlers/Safari11.js
+++ b/lib/handlers/Safari11.js
@@ -78,6 +78,9 @@ class SendHandler extends Handler
 		// @type {Boolean}
 		this._transportReady = false;
 
+		// @type {Boolean}
+		this._transportCreating = false;
+
 		// Local stream.
 		// @type {MediaStream}
 		this._stream = new MediaStream();
@@ -118,7 +121,7 @@ class SendHandler extends Handler
 			})
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -289,6 +292,8 @@ class SendHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = false;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -318,6 +323,7 @@ class SendHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportReady = true;
+				this._transportCreating = false;
 			});
 	}
 }
@@ -331,6 +337,9 @@ class RecvHandler extends Handler
 		// Got transport remote parameters.
 		// @type {Boolean}
 		this._transportCreated = false;
+
+		// @type {Boolean}
+		this._transportCreating = false;
 
 		// Got transport local parameters.
 		// @type {Boolean}
@@ -378,7 +387,7 @@ class RecvHandler extends Handler
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportCreated)
+				if (!this._transportCreated && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -503,6 +512,8 @@ class RecvHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -517,6 +528,7 @@ class RecvHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportCreated = true;
+				this._transportCreating = false;
 			});
 	}
 

--- a/lib/handlers/Safari12.js
+++ b/lib/handlers/Safari12.js
@@ -78,6 +78,9 @@ class SendHandler extends Handler
 		// @type {Boolean}
 		this._transportReady = false;
 
+		// @type {Boolean}
+		this._transportCreating = false;
+
 		// Local stream.
 		// @type {MediaStream}
 		this._stream = new MediaStream();
@@ -132,7 +135,7 @@ class SendHandler extends Handler
 			})
 			.then(() =>
 			{
-				if (!this._transportReady)
+				if (!this._transportReady && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -303,6 +306,8 @@ class SendHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -332,6 +337,7 @@ class SendHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportReady = true;
+				this._transportCreating = false;
 			});
 	}
 }
@@ -345,6 +351,9 @@ class RecvHandler extends Handler
 		// Got transport remote parameters.
 		// @type {Boolean}
 		this._transportCreated = false;
+
+		// @type {Boolean}
+		this._transportCreating = false;
 
 		// Got transport local parameters.
 		// @type {Boolean}
@@ -392,7 +401,7 @@ class RecvHandler extends Handler
 		return Promise.resolve()
 			.then(() =>
 			{
-				if (!this._transportCreated)
+				if (!this._transportCreated && !this._transportCreating)
 					return this._setupTransport();
 			})
 			.then(() =>
@@ -517,6 +526,8 @@ class RecvHandler extends Handler
 
 	_setupTransport()
 	{
+		this._transportCreating = true;
+
 		logger.debug('_setupTransport()');
 
 		return Promise.resolve()
@@ -531,6 +542,7 @@ class RecvHandler extends Handler
 				this._remoteSdp.setTransportRemoteParameters(transportRemoteParameters);
 
 				this._transportCreated = true;
+				this._transportCreating = false;
 			});
 	}
 


### PR DESCRIPTION
Every so often we would see "Transport with same transportId already exists". Tracked it down to when we a user joined a room with multiple existing consumers. There is a race condition where _setupTransport was getting called multiple times. This PR adds some state to protect against calling _setupTransport multiple times. 