### PR TITLE
Make mediasoup-client compatible with react-native-webrtc

### DIFF
--- a/lib/handlers/ReactNative.js
+++ b/lib/handlers/ReactNative.js
@@ -9,6 +9,7 @@ import RemotePlanBSdp from './sdp/RemotePlanBSdp';
 
 // We try to load react-native-webrtc library that should be available if we are using this handler.
 let webrtc = {};
+const currentPeerConnections = new Map();
 
 try
 {
@@ -18,6 +19,27 @@ try
 	
 	// We will need to override the addTrack method of the MediaStream object.
 	MediaStream.prototype.oldAddTrack = MediaStream.prototype.addTrack;
+
+	MediaStream.prototype.addTrack = function(track)
+	{
+		// If the track doesn't come from an existing stream, we use the current stream tag as
+		// streamReactTag, or we create one if it doesn't exist yet
+		if (!track.streamReactTag) 
+		{
+			track.streamReactTag = this.reactTag || Date.now();
+		}
+		// If the current stream doesn't have a react tag, we use the stream tag of the track
+		// we are adding. This will make us able to extract a track from a stream.
+		if (!this.reactTag) 
+		{
+			this.reactTag = track.streamReactTag;
+			this.id = this.reactTag;
+		}
+		// We call the original function.
+		this.oldAddTrack(track);
+		// We make sure that the current stream is accessible by every RTCPeerConnection.
+		currentPeerConnections.forEach((pc) => pc.addStream(this));
+	};
 }
 catch (err) {}
 
@@ -38,31 +60,10 @@ class Handler extends EnhancedEventEmitter
 				bundlePolicy       : 'max-bundle',
 				rtcpMuxPolicy      : 'require'
 			});
-
-		const self = this;
+		
 		// Each time we add a track to a MediaStream, we need to add it to the list of streams
 		// accessible by the RTCPeerConnection provided by react-native-webrtc
-
-		MediaStream.prototype.addTrack = function(track) 
-		{
-			// If the track doesn't come from an existing stream, we use the current stream tag as
-			// streamReactTag, or we create one if it doesn't exist yet
-			if (!track.streamReactTag) 
-			{
-				track.streamReactTag = this.reactTag || Date.now();
-			}
-			// If the current stream doesn't have a react tag, we use the stream tag of the track
-			// we are adding. This will make us able to extract a track from a stream.
-			if (!this.reactTag) 
-			{
-				this.reactTag = track.streamReactTag;
-				this.id = this.reactTag;
-			}
-			// We call the original function.
-			this.oldAddTrack(track);
-			// We make sure that the current stream is accessible by the RTCPeerConnection.
-			self._pc.addStream(this);
-		};
+		currentPeerConnections.set(this, this._pc);
 
 		// Generic sending RTP parameters for audio and video.
 		// @type {Object}
@@ -100,6 +101,7 @@ class Handler extends EnhancedEventEmitter
 	close()
 	{
 		logger.debug('close()');
+		currentPeerConnections.delete(this);
 
 		// Close RTCPeerConnection.
 		try { this._pc.close(); }

--- a/lib/handlers/ReactNative.js
+++ b/lib/handlers/ReactNative.js
@@ -9,36 +9,37 @@ import RemotePlanBSdp from './sdp/RemotePlanBSdp';
 
 // We try to load react-native-webrtc library that should be available if we are using this handler.
 let webrtc = {};
-const currentPeerConnections = new Map();
 
 try
 {
 	webrtc = require('react-native-webrtc');
 	// We make react-native-webrtc API available from the global object.
 	Object.assign(global, webrtc);
-	
-	// We will need to override the addTrack method of the MediaStream object.
-	MediaStream.prototype.oldAddTrack = MediaStream.prototype.addTrack;
 
-	MediaStream.prototype.addTrack = function(track)
+	// We extend MediaStream class.
+	global.MediaStream=class MediaStream extends webrtc.MediaStream {};
+
+	// Streams containing video need to track the stream registered in the peerConnection and denoted by 
+	// track.streamReactTag.
+	global.MediaStream.addTrack = function(track) 
 	{
-		// If the track doesn't come from an existing stream, we use the current stream tag as
-		// streamReactTag, or we create one if it doesn't exist yet
-		if (!track.streamReactTag) 
-		{
-			track.streamReactTag = this.reactTag || Date.now();
-		}
-		// If the current stream doesn't have a react tag, we use the stream tag of the track
-		// we are adding. This will make us able to extract a track from a stream.
-		if (!this.reactTag) 
+		if (track.kind === 'video') 
 		{
 			this.reactTag = track.streamReactTag;
 			this.id = this.reactTag;
 		}
-		// We call the original function.
-		this.oldAddTrack(track);
-		// We make sure that the current stream is accessible by every RTCPeerConnection.
-		currentPeerConnections.forEach((pc) => pc.addStream(this));
+		super.addTrack(track);
+	};
+
+	// Streams created with getUserMedia should contain a streamReactTag.
+	global.getUserMedia=function(constraints, success, error) 
+	{
+		return webrtc.getUserMedia(constraints, success, error).then((stream) => 
+		{
+			stream.getTracks().forEach((track) => (track.streamReactTag=stream.reactTag));
+			
+			return stream;
+		});
 	};
 }
 catch (err) {}
@@ -61,10 +62,6 @@ class Handler extends EnhancedEventEmitter
 				rtcpMuxPolicy      : 'require'
 			});
 		
-		// Each time we add a track to a MediaStream, we need to add it to the list of streams
-		// accessible by the RTCPeerConnection provided by react-native-webrtc
-		currentPeerConnections.set(this, this._pc);
-
 		// Generic sending RTP parameters for audio and video.
 		// @type {Object}
 		this._rtpParametersByKind = rtpParametersByKind;
@@ -101,7 +98,6 @@ class Handler extends EnhancedEventEmitter
 	close()
 	{
 		logger.debug('close()');
-		currentPeerConnections.delete(this);
 
 		// Close RTCPeerConnection.
 		try { this._pc.close(); }

--- a/lib/handlers/ReactNative.js
+++ b/lib/handlers/ReactNative.js
@@ -7,18 +7,19 @@ import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpPlanBUtils from './sdp/planBUtils';
 import RemotePlanBSdp from './sdp/RemotePlanBSdp';
 
-//We try to load react-native-webrtc library that should be available if we are using this handler
+// We try to load react-native-webrtc library that should be available if we are using this handler.
 let webrtc = {};
-try {
-  webrtc = require('react-native-webrtc');
-} catch (err) {}
 
-//We make react-native-webrtc API available from the global object
-Object.assign(global, webrtc);
-
-//We will need to override the addTrack method of the MediaStream object
-MediaStream.prototype.oldAddTrack = MediaStream.prototype.addTrack;
-
+try
+{
+	webrtc = require('react-native-webrtc');
+	// We make react-native-webrtc API available from the global object.
+	Object.assign(global, webrtc);
+	
+	// We will need to override the addTrack method of the MediaStream object.
+	MediaStream.prototype.oldAddTrack = MediaStream.prototype.addTrack;
+}
+catch (err) {}
 
 const logger = new Logger('ReactNative');
 
@@ -39,24 +40,27 @@ class Handler extends EnhancedEventEmitter
 			});
 
 		const self = this;
-		//Each time we add a track to a MediaStream, we need to add it to the list
-		//of streams accessible by the RTCPeerConnection provided by react-native-webrtc
-		MediaStream.prototype.addTrack = function(track) {
-			//If the track doesn't come from an existing stream, we use the current
-			//stream tag as streamReactTag, or we create one if it doesn't exist yet
-			if (!track.streamReactTag) {
+		// Each time we add a track to a MediaStream, we need to add it to the list of streams
+		// accessible by the RTCPeerConnection provided by react-native-webrtc
+
+		MediaStream.prototype.addTrack = function(track) 
+		{
+			// If the track doesn't come from an existing stream, we use the current stream tag as
+			// streamReactTag, or we create one if it doesn't exist yet
+			if (!track.streamReactTag) 
+			{
 				track.streamReactTag = this.reactTag || Date.now();
 			}
-			//If the current stream doesn't have a react tag, we use the stream tag
-			//of the track we are adding. This will make us able to extract a track
-			//from a stream.
-			if (!this.reactTag) {
+			// If the current stream doesn't have a react tag, we use the stream tag of the track
+			// we are adding. This will make us able to extract a track from a stream.
+			if (!this.reactTag) 
+			{
 				this.reactTag = track.streamReactTag;
 				this.id = this.reactTag;
 			}
-			//We call the original function
+			// We call the original function.
 			this.oldAddTrack(track);
-			//We make sure that the current stream is accessible by the RTCPeerConnection
+			// We make sure that the current stream is accessible by the RTCPeerConnection.
 			self._pc.addStream(this);
 		};
 

--- a/lib/handlers/ReactNative.js
+++ b/lib/handlers/ReactNative.js
@@ -7,6 +7,19 @@ import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpPlanBUtils from './sdp/planBUtils';
 import RemotePlanBSdp from './sdp/RemotePlanBSdp';
 
+//We try to load react-native-webrtc library that should be available if we are using this handler
+let webrtc = {};
+try {
+  webrtc = require('react-native-webrtc');
+} catch (err) {}
+
+//We make react-native-webrtc API available from the global object
+Object.assign(global, webrtc);
+
+//We will need to override the addTrack method of the MediaStream object
+MediaStream.prototype.oldAddTrack = MediaStream.prototype.addTrack;
+
+
 const logger = new Logger('ReactNative');
 
 class Handler extends EnhancedEventEmitter
@@ -24,6 +37,28 @@ class Handler extends EnhancedEventEmitter
 				bundlePolicy       : 'max-bundle',
 				rtcpMuxPolicy      : 'require'
 			});
+
+		const self = this;
+		//Each time we add a track to a MediaStream, we need to add it to the list
+		//of streams accessible by the RTCPeerConnection provided by react-native-webrtc
+		MediaStream.prototype.addTrack = function(track) {
+			//If the track doesn't come from an existing stream, we use the current
+			//stream tag as streamReactTag, or we create one if it doesn't exist yet
+			if (!track.streamReactTag) {
+				track.streamReactTag = this.reactTag || Date.now();
+			}
+			//If the current stream doesn't have a react tag, we use the stream tag
+			//of the track we are adding. This will make us able to extract a track
+			//from a stream.
+			if (!this.reactTag) {
+				this.reactTag = track.streamReactTag;
+				this.id = this.reactTag;
+			}
+			//We call the original function
+			this.oldAddTrack(track);
+			//We make sure that the current stream is accessible by the RTCPeerConnection
+			self._pc.addStream(this);
+		};
 
 		// Generic sending RTP parameters for audio and video.
 		// @type {Object}


### PR DESCRIPTION
extends MediaStream to make mediasoup-client fully and immediately compatible with react-native-webrtc