### PR TITLE
Don't use turns: urls with Edge.

### DIFF
--- a/lib/handlers/Edge11.js
+++ b/lib/handlers/Edge11.js
@@ -325,9 +325,16 @@ export default class Edge11 extends EnhancedEventEmitter
 
 	_setIceGatherer(settings)
 	{
+		// NOTE: Edge halts the connection with InvalidAccessError when presented with a turns: server.
+		// Downgrade them to plain turn: until MS gets their stuff together.
+		const turnServers = (settings.turnServers || []).map((srv) =>
+		{
+			const urls = (srv.urls || []).map((url) => url.replace(/^(turn)s:/, '$1:')); 
+			return {...srv, urls};
+		});
 		const iceGatherer = new RTCIceGatherer(
 			{
-				iceServers   : settings.turnServers || [],
+				iceServers   : turnServers,
 				gatherPolicy : settings.iceTransportPolicy
 			});
 


### PR DESCRIPTION
Microsoft Edge aborts the ICE gathering with `InvalidAccessError` if you supply a `turns:...` URL in the turnServers option.

Until Edge implements turns properly, downgrade all the `turns:...` URLs to just `turn:...`.