### PR TITLE
Handle Safari 12.1 sdp semantics

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,10 @@ module.exports =
 		node: true,
 		'jest/globals': true
 	},
+	globals:
+	{
+		RTCRtpTransceiver: true
+	},
 	plugins:
 	[
 		'jest'

--- a/lib/detectDevice.js
+++ b/lib/detectDevice.js
@@ -69,7 +69,13 @@ module.exports = function()
 		// Safari (desktop and mobile).
 		else if (browser.satisfies({ safari: '>=12.1' }))
 		{
-			return Safari12;
+			// And also enables unified-plan
+			if (RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection'))
+			{
+				return Safari12;
+			}
+
+			return Safari11;
 		}
 		else if (browser.satisfies({ safari: '>=11' }))
 		{


### PR DESCRIPTION
Safari 12.1 may use `unified-plan` sdp and also `plan-b` sdp.
It depends on user settings.

In stable release, default sdp semantics is not a `unified-plan`.
In Technology Preview, `unified-plan` is default.

To handle it correctly, we need to check it in `detectBrowser`.

> https://webkit.org/blog/8672/on-the-road-to-webrtc-1-0-including-vp8/

(+ `eslint` does not have `RTCRtpTransciver` as its global variables.)

Feel free to close this if you already working on it. 👌 