### PR TITLE
ReactNative: Requiring RTCPeerConnection, RTCSessionDescription, and MediaStream

### DIFF
--- a/lib/handlers/ReactNative.js
+++ b/lib/handlers/ReactNative.js
@@ -7,6 +7,11 @@ const ortc = require('../ortc');
 const sdpCommonUtils = require('./sdp/commonUtils');
 const sdpPlanBUtils = require('./sdp/planBUtils');
 const RemoteSdp = require('./sdp/RemoteSdp');
+const {
+	RTCPeerConnection,
+	RTCSessionDescription,
+	MediaStream
+} = require('react-native-webrtc');
 
 const logger = new Logger('ReactNative');
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jest": "^24.9.0",
     "jest-tobetype": "^1.2.3",
     "node-mediastreamtrack": "0.1.0",
+    "react-native-webrtc": "^1.75.0",
     "uuid": "^3.3.3"
   }
 }


### PR DESCRIPTION
@ibc I am not sure where there is an error while building a project in React Native because it worked perfectly when I tried your example with Chrome.

If you don't require RTCPeerConnection, RTCSessionDescription, and MediaStream, it throws an error saying that those three are not defined.

Since you have worked hard to make mediasoup compatible with react-native-webrtc, I required RTCPeerConnection, RTCSessionDescription, and MediaStream from react-native-webrtc and got it to work. Please let me know if you think there is a better way to deal with the problem.

![RTCPeerConnection error](https://scontent-icn1-1.xx.fbcdn.net/v/t1.0-9/69465651_10219692226317087_8848928356968693760_n.jpg?_nc_cat=102&_nc_oc=AQlIpDi4XG-6UuO6CVvHGvm5zl60Oo76li9ZpfJWnq1EAy_20c2aUTnHjipgzUFHP3I&_nc_ht=scontent-icn1-1.xx&oh=33c5487bbed43ac64c3f91efb00fdafa&oe=5E034F3F)