### PR TITLE
MS Edge 18 support

### DIFF
--- a/lib/detectDevice.js
+++ b/lib/detectDevice.js
@@ -74,7 +74,8 @@ module.exports = function()
 			return Safari11;
 		}
 		// Old Edge with ORTC support.
-		else if (browser.satisfies({ 'microsoft edge': '~11' }))
+		else if (browser.satisfies({ 'microsoft edge': '>=11' }) &&
+				 browser.satisfies({ 'microsoft edge': '<=18' }))
 		{
 			return Edge11;
 		}

--- a/lib/detectDevice.js
+++ b/lib/detectDevice.js
@@ -75,7 +75,7 @@ module.exports = function()
 		}
 		// Old Edge with ORTC support.
 		else if (browser.satisfies({ 'microsoft edge': '>=11' }) &&
-				 browser.satisfies({ 'microsoft edge': '<=18' }))
+                 browser.satisfies({ 'microsoft edge': '<=18' }))
 		{
 			return Edge11;
 		}

--- a/lib/handlers/Edge11.js
+++ b/lib/handlers/Edge11.js
@@ -182,9 +182,10 @@ class Edge11 extends EnhancedEventEmitter
 		await rtpSender.send(edgeRtpParameters);
 
 		// Store it.
+		const localId = track.id;
 		this._rtpSenders.set(track.id, rtpSender);
 
-		return rtpParameters;
+		return { localId, rtpParameters };
 	}
 
 	async stopSending({ localId })

--- a/lib/handlers/Edge11.js
+++ b/lib/handlers/Edge11.js
@@ -181,8 +181,9 @@ class Edge11 extends EnhancedEventEmitter
 
 		await rtpSender.send(edgeRtpParameters);
 
-		// Store it.
 		const localId = track.id;
+		
+		// Store it.
 		this._rtpSenders.set(track.id, rtpSender);
 
 		return { localId, rtpParameters };

--- a/lib/handlers/ortc/edgeUtils.js
+++ b/lib/handlers/ortc/edgeUtils.js
@@ -75,6 +75,11 @@ exports.mangleRtpParameters = function(rtpParameters)
 			delete codec.channels;
 		}
 
+		if(codec.mimeType && !codec.name)
+		{
+			codec.name = codec.mimeType.split('/')[1]
+		}
+
 		// Remove mimeType.
 		delete codec.mimeType;
 	}

--- a/lib/handlers/ortc/edgeUtils.js
+++ b/lib/handlers/ortc/edgeUtils.js
@@ -75,9 +75,9 @@ exports.mangleRtpParameters = function(rtpParameters)
 			delete codec.channels;
 		}
 
-		if(codec.mimeType && !codec.name)
+		if (codec.mimeType && !codec.name)
 		{
-			codec.name = codec.mimeType.split('/')[1]
+			codec.name = codec.mimeType.split('/')[1];
 		}
 
 		// Remove mimeType.


### PR DESCRIPTION
Works with MS Edge 18 after these small changes.
The missing codec.name  causes InvalidAccessError in Edge.