### PR TITLE
Reuse SDP m= sections for sending media (fixes #63)

### DIFF
--- a/lib/detectDevice.js
+++ b/lib/detectDevice.js
@@ -29,7 +29,7 @@ module.exports = function()
 
 		return ReactNative;
 	}
-	// browser.
+	// Browser.
 	else if (typeof navigator === 'object' && typeof navigator.userAgent === 'string')
 	{
 		const ua = navigator.userAgent;

--- a/lib/handlers/Chrome70.js
+++ b/lib/handlers/Chrome70.js
@@ -545,7 +545,7 @@ class RecvHandler extends Handler
 		if (!transceiver)
 			throw new Error('associated RTCRtpTransceiver not found');
 
-		this._remoteSdp.disableMediaSection(transceiver.mid);
+		this._remoteSdp.closeMediaSection(transceiver.mid);
 
 		const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
 

--- a/lib/handlers/Chrome70.js
+++ b/lib/handlers/Chrome70.js
@@ -163,6 +163,7 @@ class SendHandler extends Handler
 	{
 		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
 
+		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(
 			track, { direction: 'sendonly', streams: [ this._stream ] });
 		let offer = await this._pc.createOffer();
@@ -179,8 +180,7 @@ class SendHandler extends Handler
 			logger.debug('send() | enabling legacy simulcast');
 
 			localSdpObject = sdpTransform.parse(offer.sdp);
-			// We know that our media section is the last one.
-			offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
+			offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
 			sdpUnifiedPlanUtils.addLegacySimulcast(
 				{
@@ -208,8 +208,7 @@ class SendHandler extends Handler
 
 			hackVp9Svc = true;
 			localSdpObject = sdpTransform.parse(offer.sdp);
-			// We know that our media section is the last one.
-			offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
+			offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
 			sdpUnifiedPlanUtils.addLegacySimulcast(
 				{
@@ -232,7 +231,7 @@ class SendHandler extends Handler
 		sendingRtpParameters.mid = localId;
 
 		localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-		offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
+		offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
 		// Set RTCP CNAME.
 		sendingRtpParameters.rtcp.cname =
@@ -275,6 +274,7 @@ class SendHandler extends Handler
 		this._remoteSdp.send(
 			{
 				offerMediaObject,
+				reuseMid            : mediaSectionIdx.reuseMid,
 				offerRtpParameters  : sendingRtpParameters,
 				answerRtpParameters : this._sendingRemoteRtpParametersByKind[track.kind],
 				codecOptions
@@ -304,7 +304,7 @@ class SendHandler extends Handler
 
 		transceiver.sender.replaceTrack(null);
 		this._pc.removeTrack(transceiver.sender);
-		this._remoteSdp.disableMediaSection(transceiver.mid);
+		this._remoteSdp.closeMediaSection(transceiver.mid);
 
 		const offer = await this._pc.createOffer();
 

--- a/lib/handlers/Chrome74.js
+++ b/lib/handlers/Chrome74.js
@@ -171,6 +171,7 @@ class SendHandler extends Handler
 			});
 		}
 
+		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(
 			track,
 			{
@@ -207,8 +208,7 @@ class SendHandler extends Handler
 
 			hackVp9Svc = true;
 			localSdpObject = sdpTransform.parse(offer.sdp);
-			// We know that our media section is the last one.
-			offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
+			offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
 			sdpUnifiedPlanUtils.addLegacySimulcast(
 				{
@@ -228,7 +228,7 @@ class SendHandler extends Handler
 		sendingRtpParameters.mid = localId;
 
 		localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-		offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
+		offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
 		// Set RTCP CNAME.
 		sendingRtpParameters.rtcp.cname =
@@ -280,6 +280,7 @@ class SendHandler extends Handler
 		this._remoteSdp.send(
 			{
 				offerMediaObject,
+				reuseMid            : mediaSectionIdx.reuseMid,
 				offerRtpParameters  : sendingRtpParameters,
 				answerRtpParameters : this._sendingRemoteRtpParametersByKind[track.kind],
 				codecOptions
@@ -309,7 +310,7 @@ class SendHandler extends Handler
 
 		transceiver.sender.replaceTrack(null);
 		this._pc.removeTrack(transceiver.sender);
-		this._remoteSdp.disableMediaSection(transceiver.mid);
+		this._remoteSdp.closeMediaSection(transceiver.mid);
 
 		const offer = await this._pc.createOffer();
 
@@ -550,7 +551,7 @@ class RecvHandler extends Handler
 		if (!transceiver)
 			throw new Error('associated RTCRtpTransceiver not found');
 
-		this._remoteSdp.disableMediaSection(transceiver.mid);
+		this._remoteSdp.closeMediaSection(transceiver.mid);
 
 		const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
 

--- a/lib/handlers/Firefox60.js
+++ b/lib/handlers/Firefox60.js
@@ -173,6 +173,7 @@ class SendHandler extends Handler
 			reverseEncodings = utils.clone(encodings).reverse();
 		}
 
+		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(
 			track, { direction: 'sendonly', streams: [ this._stream ] });
 
@@ -209,7 +210,7 @@ class SendHandler extends Handler
 
 		localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
 
-		const offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
+		const offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
 		// Set RTCP CNAME.
 		sendingRtpParameters.rtcp.cname =
@@ -257,6 +258,7 @@ class SendHandler extends Handler
 		this._remoteSdp.send(
 			{
 				offerMediaObject,
+				reuseMid            : mediaSectionIdx.reuseMid,
 				offerRtpParameters  : sendingRtpParameters,
 				answerRtpParameters : this._sendingRemoteRtpParametersByKind[track.kind],
 				codecOptions
@@ -286,7 +288,7 @@ class SendHandler extends Handler
 
 		transceiver.sender.replaceTrack(null);
 		this._pc.removeTrack(transceiver.sender);
-		this._remoteSdp.disableMediaSection(transceiver.mid);
+		this._remoteSdp.closeMediaSection(transceiver.mid);
 
 		const offer = await this._pc.createOffer();
 
@@ -530,7 +532,7 @@ class RecvHandler extends Handler
 		if (!transceiver)
 			throw new Error('associated transceiver not found');
 
-		this._remoteSdp.disableMediaSection(transceiver.mid);
+		this._remoteSdp.closeMediaSection(transceiver.mid);
 
 		const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
 

--- a/lib/handlers/Safari12.js
+++ b/lib/handlers/Safari12.js
@@ -161,6 +161,7 @@ class SendHandler extends Handler
 	{
 		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
 
+		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(
 			track, { direction: 'sendonly', streams: [ this._stream ] });
 		let offer = await this._pc.createOffer();
@@ -177,8 +178,7 @@ class SendHandler extends Handler
 			logger.debug('send() | enabling legacy simulcast');
 
 			localSdpObject = sdpTransform.parse(offer.sdp);
-			// We know that our media section is the last one.
-			offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
+			offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
 			sdpUnifiedPlanUtils.addLegacySimulcast(
 				{
@@ -201,7 +201,7 @@ class SendHandler extends Handler
 		sendingRtpParameters.mid = localId;
 
 		localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-		offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
+		offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
 
 		// Set RTCP CNAME.
 		sendingRtpParameters.rtcp.cname =
@@ -240,6 +240,7 @@ class SendHandler extends Handler
 		this._remoteSdp.send(
 			{
 				offerMediaObject,
+				reuseMid            : mediaSectionIdx.reuseMid,
 				offerRtpParameters  : sendingRtpParameters,
 				answerRtpParameters : this._sendingRemoteRtpParametersByKind[track.kind],
 				codecOptions
@@ -269,7 +270,7 @@ class SendHandler extends Handler
 
 		transceiver.sender.replaceTrack(null);
 		this._pc.removeTrack(transceiver.sender);
-		this._remoteSdp.disableMediaSection(transceiver.mid);
+		this._remoteSdp.closeMediaSection(transceiver.mid);
 
 		const offer = await this._pc.createOffer();
 
@@ -509,7 +510,7 @@ class RecvHandler extends Handler
 		if (!transceiver)
 			throw new Error('associated RTCRtpTransceiver not found');
 
-		this._remoteSdp.disableMediaSection(transceiver.mid);
+		this._remoteSdp.closeMediaSection(transceiver.mid);
 
 		const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
 

--- a/lib/handlers/sdp/MediaSection.js
+++ b/lib/handlers/sdp/MediaSection.js
@@ -62,7 +62,15 @@ class MediaSection
 	 */
 	get mid()
 	{
-		return this._mediaObject.mid;
+		return String(this._mediaObject.mid);
+	}
+
+	/**
+	 * @returns {Boolean}
+	 */
+	get closed()
+	{
+		return this._mediaObject.port === 0;
 	}
 
 	/**
@@ -92,6 +100,22 @@ class MediaSection
 		delete this._mediaObject.simulcast;
 		delete this._mediaObject.simulcast_03;
 		delete this._mediaObject.rids;
+	}
+
+	close()
+	{
+		this._mediaObject.direction = 'inactive';
+
+		this._mediaObject.port = 0;
+
+		delete this._mediaObject.ext;
+		delete this._mediaObject.ssrcs;
+		delete this._mediaObject.ssrcGroups;
+		delete this._mediaObject.simulcast;
+		delete this._mediaObject.simulcast_03;
+		delete this._mediaObject.rids;
+		delete this._mediaObject.ext;
+		delete this._mediaObject.extmapAllowMixed;
 	}
 }
 

--- a/lib/handlers/sdp/RemoteSdp.js
+++ b/lib/handlers/sdp/RemoteSdp.js
@@ -241,7 +241,7 @@ class RemoteSdp
 		// bundled transport, so let's avoid it.
 		if (String(mid) === this._firstMid)
 		{
-			logger.warn(
+			logger.debug(
 				'closeMediaSection() | cannot close first media section, disabling it instead [mid:%s]',
 				mid);
 

--- a/lib/handlers/sdp/RemoteSdp.js
+++ b/lib/handlers/sdp/RemoteSdp.js
@@ -49,6 +49,10 @@ class RemoteSdp
 		// @type {Map<String, MediaSection>}
 		this._mediaSections = new Map();
 
+		// First MID.
+		// @type {String}
+		this._firstMid = null;
+
 		// SDP object.
 		// @type {Object}
 		this._sdpObject =
@@ -126,9 +130,27 @@ class RemoteSdp
 		}
 	}
 
+	getNextMediaSectionIdx()
+	{
+		let idx = -1;
+
+		// If a closed media section is found, return its index.
+		for (const mediaSection of this._mediaSections.values())
+		{
+			idx++;
+
+			if (mediaSection.closed)
+				return { idx, reuseMid: mediaSection.mid };
+		}
+
+		// If no closed media section is found, return next one.
+		return { idx: this._mediaSections.size, reuseMid: null };
+	}
+
 	send(
 		{
 			offerMediaObject,
+			reuseMid,
 			offerRtpParameters,
 			answerRtpParameters,
 			codecOptions
@@ -148,12 +170,17 @@ class RemoteSdp
 				codecOptions
 			});
 
-		// Unified-Plan or different media kind.
-		if (!this._mediaSections.has(mediaSection.mid))
+		// Unified-Plan with closed media section replacement.
+		if (reuseMid)
+		{
+			this._replaceMediaSection(mediaSection, reuseMid);
+		}
+		// Unified-Plan or Plan-B with different media kind.
+		else if (!this._mediaSections.has(mediaSection.mid))
 		{
 			this._addMediaSection(mediaSection);
 		}
-		// Plan-B.
+		// Plan-B with same media kind.
 		else
 		{
 			this._replaceMediaSection(mediaSection);
@@ -206,6 +233,29 @@ class RemoteSdp
 		mediaSection.disable();
 	}
 
+	closeMediaSection(mid)
+	{
+		const mediaSection = this._mediaSections.get(mid);
+
+		// NOTE: Closing the first m section is a pain since it invalidates the
+		// bundled transport, so let's avoid it.
+		if (String(mid) === this._firstMid)
+		{
+			logger.warn(
+				'closeMediaSection() | cannot close first media section, disabling it instead [mid:%s]',
+				mid);
+
+			this.disableMediaSection(mid);
+
+			return;
+		}
+
+		mediaSection.close();
+
+		// Regenerate BUNDLE mids.
+		this._regenerateBundleMids();
+	}
+
 	planBStopReceiving({ mid, offerRtpParameters })
 	{
 		const mediaSection = this._mediaSections.get(mid);
@@ -254,35 +304,61 @@ class RemoteSdp
 		return sdpTransform.write(this._sdpObject);
 	}
 
-	_addMediaSection(mediaSection)
+	_addMediaSection(newMediaSection)
 	{
+		if (!this._firstMid)
+			this._firstMid = newMediaSection.mid;
+
 		// Store it in the map.
-		this._mediaSections.set(mediaSection.mid, mediaSection);
+		this._mediaSections.set(newMediaSection.mid, newMediaSection);
 
 		// Update SDP object.
-		this._sdpObject.media.push(mediaSection.getObject());
+		this._sdpObject.media.push(newMediaSection.getObject());
 
-		if (this._dtlsParameters)
-		{
-			this._sdpObject.groups[0].mids =
-				`${this._sdpObject.groups[0].mids} ${mediaSection.mid}`.trim();
-		}
+		// Regenerate BUNDLE mids.
+		this._regenerateBundleMids();
 	}
 
-	_replaceMediaSection(mediaSection)
+	_replaceMediaSection(newMediaSection, reuseMid)
 	{
 		// Store it in the map.
-		this._mediaSections.set(mediaSection.mid, mediaSection);
+		if (reuseMid)
+		{
+			const newMediaSections = new Map();
+
+			for (const mediaSection of this._mediaSections.values())
+			{
+				if (mediaSection.mid === reuseMid)
+					newMediaSections.set(newMediaSection.mid, newMediaSection);
+				else
+					newMediaSections.set(mediaSection.mid, mediaSection);
+			}
+
+			// Regenerate media sections.
+			this._mediaSections = newMediaSections;
+
+			// Regenerate BUNDLE mids.
+			this._regenerateBundleMids();
+		}
+		else
+		{
+			this._mediaSections.set(newMediaSection.mid, newMediaSection);
+		}
 
 		// Update SDP object.
-		this._sdpObject.media = this._sdpObject.media
-			.map((m) =>
-			{
-				if (String(m.mid) === mediaSection.mid)
-					return mediaSection.getObject();
-				else
-					return m;
-			});
+		this._sdpObject.media = Array.from(this._mediaSections.values())
+			.map((mediaSection) => mediaSection.getObject());
+	}
+
+	_regenerateBundleMids()
+	{
+		if (!this._dtlsParameters)
+			return;
+
+		this._sdpObject.groups[0].mids = Array.from(this._mediaSections.values())
+			.filter((mediaSection) => !mediaSection.closed)
+			.map((mediaSection) => mediaSection.mid)
+			.join(' ');
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "sdp-transform": "^2.12.0"
   },
   "devDependencies": {
-    "eslint": "^6.3.0",
+    "eslint": "^6.4.0",
     "eslint-plugin-jest": "^22.17.0",
     "jest": "^24.9.0",
     "jest-tobetype": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "awaitqueue": "^1.0.0",
-    "bowser": "^2.5.3",
+    "bowser": "^2.6.0",
     "debug": "^4.1.1",
     "events": "^3.0.0",
     "h264-profile-level-id": "^1.0.0",
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "eslint": "^6.3.0",
-    "eslint-plugin-jest": "^22.16.0",
+    "eslint-plugin-jest": "^22.17.0",
     "jest": "^24.9.0",
     "jest-tobetype": "^1.2.3",
     "node-mediastreamtrack": "0.1.0",


### PR DESCRIPTION
Instead of disabling (by setting `a=inactive`) sending transceivers, close them with remote m= port 0 to later reuse it when creating a new sending transceiver (`pc.addTransceiver()`).

Fixes #63