### PR TITLE
Fix an error of producing with `react-native-webrtc`

### DIFF
--- a/lib/handlers/ReactNative.js
+++ b/lib/handlers/ReactNative.js
@@ -171,7 +171,10 @@ class SendHandler extends Handler
 		this._stream.addTrack(track);
 		this._pc.addStream(this._stream);
 
-		let offer = await this._pc.createOffer();
+		let offer = await this._pc.createOffer({
+			offerToReceiveAudio : false,
+			offerToReceiveVideo : false
+		});
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 		let offerMediaObject;
 		const sendingRtpParameters =


### PR DESCRIPTION
When creating an offer(`rtcPeerConnection.createOffer()`),
the default argument is `{ offerToReceiveAudio: true, offerToReceiveVideo: true }`.

https://github.com/react-native-webrtc/react-native-webrtc/blob/master/RTCPeerConnection.js#L121

and using this causes an error like below on setting remote description.

```
{
  name: "SetRemoteDescriptionFailed",
  message: ""Failed to set remote answer sdp: The order of m-lines in answer doesn't match order in offer. Rejecting answer.""
}
```

From what I understand, mediasoup does not allow a sending transport to receive media at the same time.
So it seems that offering to receive at the same time was not accepted by mediasoup server.
