### PR TITLE
Update tsconfig not to polyfill async/await

### DIFF
--- a/lib/Consumer.js
+++ b/lib/Consumer.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const Logger_1 = require("./Logger");
 const EnhancedEventEmitter_1 = require("./EnhancedEventEmitter");
@@ -127,12 +118,10 @@ class Consumer extends EnhancedEventEmitter_1.EnhancedEventEmitter {
     /**
      * Get associated RTCRtpReceiver stats.
      */
-    getStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (this._closed)
-                throw new errors_1.InvalidStateError('closed');
-            return this.safeEmitAsPromise('@getstats');
-        });
+    async getStats() {
+        if (this._closed)
+            throw new errors_1.InvalidStateError('closed');
+        return this.safeEmitAsPromise('@getstats');
     }
     /**
      * Pauses receiving media.

--- a/lib/Device.js
+++ b/lib/Device.js
@@ -1,14 +1,5 @@
 "use strict";
 /* global RTCRtpTransceiver */
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -230,46 +221,44 @@ class Device {
     /**
      * Initialize the Device.
      */
-    load({ routerRtpCapabilities } = {}) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('load() [routerRtpCapabilities:%o]', routerRtpCapabilities);
-            // Temporal handler to get its capabilities.
-            let handler;
-            try {
-                if (this._loaded)
-                    throw new errors_1.InvalidStateError('already loaded');
-                // This may throw.
-                ortc.validateRtpCapabilities(routerRtpCapabilities);
-                handler = this._handlerFactory();
-                const nativeRtpCapabilities = yield handler.getNativeRtpCapabilities();
-                logger.debug('load() | got native RTP capabilities:%o', nativeRtpCapabilities);
-                // This may throw.
-                ortc.validateRtpCapabilities(nativeRtpCapabilities);
-                // Get extended RTP capabilities.
-                this._extendedRtpCapabilities = ortc.getExtendedRtpCapabilities(nativeRtpCapabilities, routerRtpCapabilities);
-                logger.debug('load() | got extended RTP capabilities:%o', this._extendedRtpCapabilities);
-                // Check whether we can produce audio/video.
-                this._canProduceByKind.audio =
-                    ortc.canSend('audio', this._extendedRtpCapabilities);
-                this._canProduceByKind.video =
-                    ortc.canSend('video', this._extendedRtpCapabilities);
-                // Generate our receiving RTP capabilities for receiving media.
-                this._recvRtpCapabilities =
-                    ortc.getRecvRtpCapabilities(this._extendedRtpCapabilities);
-                logger.debug('load() | got receiving RTP capabilities:%o', this._recvRtpCapabilities);
-                // Generate our SCTP capabilities.
-                this._sctpCapabilities = yield handler.getNativeSctpCapabilities();
-                logger.debug('load() | got native SCTP capabilities:%o', this._sctpCapabilities);
-                logger.debug('load() succeeded');
-                this._loaded = true;
+    async load({ routerRtpCapabilities } = {}) {
+        logger.debug('load() [routerRtpCapabilities:%o]', routerRtpCapabilities);
+        // Temporal handler to get its capabilities.
+        let handler;
+        try {
+            if (this._loaded)
+                throw new errors_1.InvalidStateError('already loaded');
+            // This may throw.
+            ortc.validateRtpCapabilities(routerRtpCapabilities);
+            handler = this._handlerFactory();
+            const nativeRtpCapabilities = await handler.getNativeRtpCapabilities();
+            logger.debug('load() | got native RTP capabilities:%o', nativeRtpCapabilities);
+            // This may throw.
+            ortc.validateRtpCapabilities(nativeRtpCapabilities);
+            // Get extended RTP capabilities.
+            this._extendedRtpCapabilities = ortc.getExtendedRtpCapabilities(nativeRtpCapabilities, routerRtpCapabilities);
+            logger.debug('load() | got extended RTP capabilities:%o', this._extendedRtpCapabilities);
+            // Check whether we can produce audio/video.
+            this._canProduceByKind.audio =
+                ortc.canSend('audio', this._extendedRtpCapabilities);
+            this._canProduceByKind.video =
+                ortc.canSend('video', this._extendedRtpCapabilities);
+            // Generate our receiving RTP capabilities for receiving media.
+            this._recvRtpCapabilities =
+                ortc.getRecvRtpCapabilities(this._extendedRtpCapabilities);
+            logger.debug('load() | got receiving RTP capabilities:%o', this._recvRtpCapabilities);
+            // Generate our SCTP capabilities.
+            this._sctpCapabilities = await handler.getNativeSctpCapabilities();
+            logger.debug('load() | got native SCTP capabilities:%o', this._sctpCapabilities);
+            logger.debug('load() succeeded');
+            this._loaded = true;
+            handler.close();
+        }
+        catch (error) {
+            if (handler)
                 handler.close();
-            }
-            catch (error) {
-                if (handler)
-                    handler.close();
-                throw error;
-            }
-        });
+            throw error;
+        }
     }
     /**
      * Whether we can produce audio/video.

--- a/lib/EnhancedEventEmitter.js
+++ b/lib/EnhancedEventEmitter.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const events_1 = require("events");
 const Logger_1 = require("./Logger");
@@ -27,10 +18,8 @@ class EnhancedEventEmitter extends events_1.EventEmitter {
             return Boolean(numListeners);
         }
     }
-    safeEmitAsPromise(event, ...args) {
-        return __awaiter(this, void 0, void 0, function* () {
-            return new Promise((resolve, reject) => (this.safeEmit(event, ...args, resolve, reject)));
-        });
+    async safeEmitAsPromise(event, ...args) {
+        return new Promise((resolve, reject) => (this.safeEmit(event, ...args, resolve, reject)));
     }
 }
 exports.EnhancedEventEmitter = EnhancedEventEmitter;

--- a/lib/Producer.js
+++ b/lib/Producer.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 const Logger_1 = require("./Logger");
 const EnhancedEventEmitter_1 = require("./EnhancedEventEmitter");
@@ -133,12 +124,10 @@ class Producer extends EnhancedEventEmitter_1.EnhancedEventEmitter {
     /**
      * Get associated RTCRtpSender stats.
      */
-    getStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (this._closed)
-                throw new errors_1.InvalidStateError('closed');
-            return this.safeEmitAsPromise('@getstats');
-        });
+    async getStats() {
+        if (this._closed)
+            throw new errors_1.InvalidStateError('closed');
+        return this.safeEmitAsPromise('@getstats');
     }
     /**
      * Pauses sending media.
@@ -167,74 +156,68 @@ class Producer extends EnhancedEventEmitter_1.EnhancedEventEmitter {
     /**
      * Replaces the current track with a new one.
      */
-    replaceTrack({ track }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('replaceTrack() [track:%o]', track);
-            if (this._closed) {
-                // This must be done here. Otherwise there is no chance to stop the given
-                // track.
-                if (this._stopTracks) {
-                    try {
-                        track.stop();
-                    }
-                    catch (error) { }
+    async replaceTrack({ track }) {
+        logger.debug('replaceTrack() [track:%o]', track);
+        if (this._closed) {
+            // This must be done here. Otherwise there is no chance to stop the given
+            // track.
+            if (this._stopTracks) {
+                try {
+                    track.stop();
                 }
-                throw new errors_1.InvalidStateError('closed');
+                catch (error) { }
             }
-            else if (!track) {
-                throw new TypeError('missing track');
-            }
-            else if (track.readyState === 'ended') {
-                throw new errors_1.InvalidStateError('track ended');
-            }
-            // Do nothing if this is the same track as the current handled one.
-            if (track === this._track) {
-                logger.debug('replaceTrack() | same track, ignored');
-                return;
-            }
-            yield this.safeEmitAsPromise('@replacetrack', track);
-            // Destroy the previous track.
-            this._destroyTrack();
-            // Set the new track.
-            this._track = track;
-            // If this Producer was paused/resumed and the state of the new
-            // track does not match, fix it.
-            if (!this._paused)
-                this._track.enabled = true;
-            else
-                this._track.enabled = false;
-            // Handle the effective track.
-            this._handleTrack();
-        });
+            throw new errors_1.InvalidStateError('closed');
+        }
+        else if (!track) {
+            throw new TypeError('missing track');
+        }
+        else if (track.readyState === 'ended') {
+            throw new errors_1.InvalidStateError('track ended');
+        }
+        // Do nothing if this is the same track as the current handled one.
+        if (track === this._track) {
+            logger.debug('replaceTrack() | same track, ignored');
+            return;
+        }
+        await this.safeEmitAsPromise('@replacetrack', track);
+        // Destroy the previous track.
+        this._destroyTrack();
+        // Set the new track.
+        this._track = track;
+        // If this Producer was paused/resumed and the state of the new
+        // track does not match, fix it.
+        if (!this._paused)
+            this._track.enabled = true;
+        else
+            this._track.enabled = false;
+        // Handle the effective track.
+        this._handleTrack();
     }
     /**
      * Sets the video max spatial layer to be sent.
      */
-    setMaxSpatialLayer(spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (this._closed)
-                throw new errors_1.InvalidStateError('closed');
-            else if (this._track.kind !== 'video')
-                throw new errors_1.UnsupportedError('not a video Producer');
-            else if (typeof spatialLayer !== 'number')
-                throw new TypeError('invalid spatialLayer');
-            if (spatialLayer === this._maxSpatialLayer)
-                return;
-            yield this.safeEmitAsPromise('@setmaxspatiallayer', spatialLayer);
-            this._maxSpatialLayer = spatialLayer;
-        });
+    async setMaxSpatialLayer(spatialLayer) {
+        if (this._closed)
+            throw new errors_1.InvalidStateError('closed');
+        else if (this._track.kind !== 'video')
+            throw new errors_1.UnsupportedError('not a video Producer');
+        else if (typeof spatialLayer !== 'number')
+            throw new TypeError('invalid spatialLayer');
+        if (spatialLayer === this._maxSpatialLayer)
+            return;
+        await this.safeEmitAsPromise('@setmaxspatiallayer', spatialLayer);
+        this._maxSpatialLayer = spatialLayer;
     }
     /**
      * Sets the DSCP value.
      */
-    setRtpEncodingParameters(params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (this._closed)
-                throw new errors_1.InvalidStateError('closed');
-            else if (typeof params !== 'object')
-                throw new TypeError('invalid params');
-            yield this.safeEmitAsPromise('@setrtpencodingparameters', params);
-        });
+    async setRtpEncodingParameters(params) {
+        if (this._closed)
+            throw new errors_1.InvalidStateError('closed');
+        else if (typeof params !== 'object')
+            throw new TypeError('invalid params');
+        await this.safeEmitAsPromise('@setrtpencodingparameters', params);
     }
     _onTrackEnded() {
         logger.debug('track "ended" event');

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -162,266 +153,252 @@ class Transport extends EnhancedEventEmitter_1.EnhancedEventEmitter {
      *
      * @returns {RTCStatsReport}
      */
-    getStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (this._closed)
-                throw new errors_1.InvalidStateError('closed');
-            return this._handler.getTransportStats();
-        });
+    async getStats() {
+        if (this._closed)
+            throw new errors_1.InvalidStateError('closed');
+        return this._handler.getTransportStats();
     }
     /**
      * Restart ICE connection.
      */
-    restartIce({ iceParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            if (this._closed)
-                throw new errors_1.InvalidStateError('closed');
-            else if (!iceParameters)
-                throw new TypeError('missing iceParameters');
-            // Enqueue command.
-            return this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () { return this._handler.restartIce(iceParameters); }));
-        });
+    async restartIce({ iceParameters }) {
+        logger.debug('restartIce()');
+        if (this._closed)
+            throw new errors_1.InvalidStateError('closed');
+        else if (!iceParameters)
+            throw new TypeError('missing iceParameters');
+        // Enqueue command.
+        return this._awaitQueue.push(async () => this._handler.restartIce(iceParameters));
     }
     /**
      * Update ICE servers.
      */
-    updateIceServers({ iceServers } = {}) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('updateIceServers()');
-            if (this._closed)
-                throw new errors_1.InvalidStateError('closed');
-            else if (!Array.isArray(iceServers))
-                throw new TypeError('missing iceServers');
-            // Enqueue command.
-            return this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () { return this._handler.updateIceServers(iceServers); }));
-        });
+    async updateIceServers({ iceServers } = {}) {
+        logger.debug('updateIceServers()');
+        if (this._closed)
+            throw new errors_1.InvalidStateError('closed');
+        else if (!Array.isArray(iceServers))
+            throw new TypeError('missing iceServers');
+        // Enqueue command.
+        return this._awaitQueue.push(async () => this._handler.updateIceServers(iceServers));
     }
     /**
      * Create a Producer.
      */
-    produce({ track, encodings, codecOptions, stopTracks = true, appData = {} } = {}) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('produce() [track:%o]', track);
-            if (!track)
-                throw new TypeError('missing track');
-            else if (this._direction !== 'send')
-                throw new errors_1.UnsupportedError('not a sending Transport');
-            else if (!this._canProduceByKind[track.kind])
-                throw new errors_1.UnsupportedError(`cannot produce ${track.kind}`);
-            else if (track.readyState === 'ended')
-                throw new errors_1.InvalidStateError('track ended');
-            else if (this.listenerCount('connect') === 0 && this._connectionState === 'new')
-                throw new TypeError('no "connect" listener set into this transport');
-            else if (this.listenerCount('produce') === 0)
-                throw new TypeError('no "produce" listener set into this transport');
-            else if (appData && typeof appData !== 'object')
-                throw new TypeError('if given, appData must be an object');
-            // Enqueue command.
-            return this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () {
-                let normalizedEncodings;
-                if (encodings && !Array.isArray(encodings)) {
-                    throw TypeError('encodings must be an array');
-                }
-                else if (encodings && encodings.length === 0) {
-                    normalizedEncodings = undefined;
-                }
-                else if (encodings) {
-                    normalizedEncodings = encodings
-                        .map((encoding) => {
-                        const normalizedEncoding = { active: true };
-                        if (encoding.active === false)
-                            normalizedEncoding.active = false;
-                        if (typeof encoding.maxBitrate === 'number')
-                            normalizedEncoding.maxBitrate = encoding.maxBitrate;
-                        if (typeof encoding.maxFramerate === 'number')
-                            normalizedEncoding.maxFramerate = encoding.maxFramerate;
-                        if (typeof encoding.scaleResolutionDownBy === 'number')
-                            normalizedEncoding.scaleResolutionDownBy = encoding.scaleResolutionDownBy;
-                        if (typeof encoding.dtx === 'boolean')
-                            normalizedEncoding.dtx = encoding.dtx;
-                        if (typeof encoding.scalabilityMode === 'string')
-                            normalizedEncoding.scalabilityMode = encoding.scalabilityMode;
-                        if (typeof encoding.priority === 'string')
-                            normalizedEncoding.priority = encoding.priority;
-                        if (typeof encoding.networkPriority === 'string')
-                            normalizedEncoding.networkPriority = encoding.networkPriority;
-                        return normalizedEncoding;
-                    });
-                }
-                const { localId, rtpParameters, rtpSender } = yield this._handler.send({
-                    track,
-                    encodings: normalizedEncodings,
-                    codecOptions
+    async produce({ track, encodings, codecOptions, stopTracks = true, appData = {} } = {}) {
+        logger.debug('produce() [track:%o]', track);
+        if (!track)
+            throw new TypeError('missing track');
+        else if (this._direction !== 'send')
+            throw new errors_1.UnsupportedError('not a sending Transport');
+        else if (!this._canProduceByKind[track.kind])
+            throw new errors_1.UnsupportedError(`cannot produce ${track.kind}`);
+        else if (track.readyState === 'ended')
+            throw new errors_1.InvalidStateError('track ended');
+        else if (this.listenerCount('connect') === 0 && this._connectionState === 'new')
+            throw new TypeError('no "connect" listener set into this transport');
+        else if (this.listenerCount('produce') === 0)
+            throw new TypeError('no "produce" listener set into this transport');
+        else if (appData && typeof appData !== 'object')
+            throw new TypeError('if given, appData must be an object');
+        // Enqueue command.
+        return this._awaitQueue.push(async () => {
+            let normalizedEncodings;
+            if (encodings && !Array.isArray(encodings)) {
+                throw TypeError('encodings must be an array');
+            }
+            else if (encodings && encodings.length === 0) {
+                normalizedEncodings = undefined;
+            }
+            else if (encodings) {
+                normalizedEncodings = encodings
+                    .map((encoding) => {
+                    const normalizedEncoding = { active: true };
+                    if (encoding.active === false)
+                        normalizedEncoding.active = false;
+                    if (typeof encoding.maxBitrate === 'number')
+                        normalizedEncoding.maxBitrate = encoding.maxBitrate;
+                    if (typeof encoding.maxFramerate === 'number')
+                        normalizedEncoding.maxFramerate = encoding.maxFramerate;
+                    if (typeof encoding.scaleResolutionDownBy === 'number')
+                        normalizedEncoding.scaleResolutionDownBy = encoding.scaleResolutionDownBy;
+                    if (typeof encoding.dtx === 'boolean')
+                        normalizedEncoding.dtx = encoding.dtx;
+                    if (typeof encoding.scalabilityMode === 'string')
+                        normalizedEncoding.scalabilityMode = encoding.scalabilityMode;
+                    if (typeof encoding.priority === 'string')
+                        normalizedEncoding.priority = encoding.priority;
+                    if (typeof encoding.networkPriority === 'string')
+                        normalizedEncoding.networkPriority = encoding.networkPriority;
+                    return normalizedEncoding;
                 });
-                try {
-                    // This will fill rtpParameters's missing fields with default values.
-                    ortc.validateRtpParameters(rtpParameters);
-                    const { id } = yield this.safeEmitAsPromise('produce', {
-                        kind: track.kind,
-                        rtpParameters,
-                        appData
-                    });
-                    const producer = new Producer_1.Producer({ id, localId, rtpSender, track, rtpParameters, stopTracks, appData });
-                    this._producers.set(producer.id, producer);
-                    this._handleProducer(producer);
-                    return producer;
-                }
-                catch (error) {
-                    this._handler.stopSending(localId)
-                        .catch(() => { });
-                    throw error;
-                }
-            }))
-                // This catch is needed to stop the given track if the command above
-                // failed due to closed Transport.
-                .catch((error) => {
-                if (stopTracks) {
-                    try {
-                        track.stop();
-                    }
-                    catch (error2) { }
-                }
-                throw error;
+            }
+            const { localId, rtpParameters, rtpSender } = await this._handler.send({
+                track,
+                encodings: normalizedEncodings,
+                codecOptions
             });
+            try {
+                // This will fill rtpParameters's missing fields with default values.
+                ortc.validateRtpParameters(rtpParameters);
+                const { id } = await this.safeEmitAsPromise('produce', {
+                    kind: track.kind,
+                    rtpParameters,
+                    appData
+                });
+                const producer = new Producer_1.Producer({ id, localId, rtpSender, track, rtpParameters, stopTracks, appData });
+                this._producers.set(producer.id, producer);
+                this._handleProducer(producer);
+                return producer;
+            }
+            catch (error) {
+                this._handler.stopSending(localId)
+                    .catch(() => { });
+                throw error;
+            }
+        })
+            // This catch is needed to stop the given track if the command above
+            // failed due to closed Transport.
+            .catch((error) => {
+            if (stopTracks) {
+                try {
+                    track.stop();
+                }
+                catch (error2) { }
+            }
+            throw error;
         });
     }
     /**
      * Create a Consumer to consume a remote Producer.
      */
-    consume({ id, producerId, kind, rtpParameters, appData = {} } = {}) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('consume()');
-            if (this._closed)
-                throw new errors_1.InvalidStateError('closed');
-            else if (this._direction !== 'recv')
-                throw new errors_1.UnsupportedError('not a receiving Transport');
-            else if (typeof id !== 'string')
-                throw new TypeError('missing id');
-            else if (typeof producerId !== 'string')
-                throw new TypeError('missing producerId');
-            else if (kind !== 'audio' && kind !== 'video')
-                throw new TypeError(`invalid kind '${kind}'`);
-            else if (this.listenerCount('connect') === 0 && this._connectionState === 'new')
-                throw new TypeError('no "connect" listener set into this transport');
-            else if (appData && typeof appData !== 'object')
-                throw new TypeError('if given, appData must be an object');
-            // Enqueue command.
-            return this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () {
-                // Ensure the device can consume it.
-                const canConsume = ortc.canReceive(rtpParameters, this._extendedRtpCapabilities);
-                if (!canConsume)
-                    throw new errors_1.UnsupportedError('cannot consume this Producer');
-                const { localId, rtpReceiver, track } = yield this._handler.receive({ trackId: id, kind, rtpParameters });
-                const consumer = new Consumer_1.Consumer({ id, localId, producerId, rtpReceiver, track, rtpParameters, appData });
-                this._consumers.set(consumer.id, consumer);
-                this._handleConsumer(consumer);
-                // If this is the first video Consumer and the Consumer for RTP probation
-                // has not yet been created, create it now.
-                if (!this._probatorConsumerCreated && kind === 'video') {
-                    try {
-                        const probatorRtpParameters = ortc.generateProbatorRtpParameters(consumer.rtpParameters);
-                        yield this._handler.receive({
-                            trackId: 'probator',
-                            kind: 'video',
-                            rtpParameters: probatorRtpParameters
-                        });
-                        logger.debug('consume() | Consumer for RTP probation created');
-                        this._probatorConsumerCreated = true;
-                    }
-                    catch (error) {
-                        logger.error('consume() | failed to create Consumer for RTP probation:%o', error);
-                    }
+    async consume({ id, producerId, kind, rtpParameters, appData = {} } = {}) {
+        logger.debug('consume()');
+        if (this._closed)
+            throw new errors_1.InvalidStateError('closed');
+        else if (this._direction !== 'recv')
+            throw new errors_1.UnsupportedError('not a receiving Transport');
+        else if (typeof id !== 'string')
+            throw new TypeError('missing id');
+        else if (typeof producerId !== 'string')
+            throw new TypeError('missing producerId');
+        else if (kind !== 'audio' && kind !== 'video')
+            throw new TypeError(`invalid kind '${kind}'`);
+        else if (this.listenerCount('connect') === 0 && this._connectionState === 'new')
+            throw new TypeError('no "connect" listener set into this transport');
+        else if (appData && typeof appData !== 'object')
+            throw new TypeError('if given, appData must be an object');
+        // Enqueue command.
+        return this._awaitQueue.push(async () => {
+            // Ensure the device can consume it.
+            const canConsume = ortc.canReceive(rtpParameters, this._extendedRtpCapabilities);
+            if (!canConsume)
+                throw new errors_1.UnsupportedError('cannot consume this Producer');
+            const { localId, rtpReceiver, track } = await this._handler.receive({ trackId: id, kind, rtpParameters });
+            const consumer = new Consumer_1.Consumer({ id, localId, producerId, rtpReceiver, track, rtpParameters, appData });
+            this._consumers.set(consumer.id, consumer);
+            this._handleConsumer(consumer);
+            // If this is the first video Consumer and the Consumer for RTP probation
+            // has not yet been created, create it now.
+            if (!this._probatorConsumerCreated && kind === 'video') {
+                try {
+                    const probatorRtpParameters = ortc.generateProbatorRtpParameters(consumer.rtpParameters);
+                    await this._handler.receive({
+                        trackId: 'probator',
+                        kind: 'video',
+                        rtpParameters: probatorRtpParameters
+                    });
+                    logger.debug('consume() | Consumer for RTP probation created');
+                    this._probatorConsumerCreated = true;
                 }
-                return consumer;
-            }));
+                catch (error) {
+                    logger.error('consume() | failed to create Consumer for RTP probation:%o', error);
+                }
+            }
+            return consumer;
         });
     }
     /**
      * Create a DataProducer
      */
-    produceData({ ordered = true, maxPacketLifeTime, maxRetransmits, priority = 'low', label = '', protocol = '', appData = {} } = {}) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('produceData()');
-            if (this._direction !== 'send')
-                throw new errors_1.UnsupportedError('not a sending Transport');
-            else if (!this._maxSctpMessageSize)
-                throw new errors_1.UnsupportedError('SCTP not enabled by remote Transport');
-            else if (!['very-low', 'low', 'medium', 'high'].includes(priority))
-                throw new TypeError('wrong priority');
-            else if (this.listenerCount('connect') === 0 && this._connectionState === 'new')
-                throw new TypeError('no "connect" listener set into this transport');
-            else if (this.listenerCount('producedata') === 0)
-                throw new TypeError('no "producedata" listener set into this transport');
-            else if (appData && typeof appData !== 'object')
-                throw new TypeError('if given, appData must be an object');
-            if (maxPacketLifeTime || maxRetransmits)
-                ordered = false;
-            // Enqueue command.
-            return this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () {
-                const { dataChannel, sctpStreamParameters } = yield this._handler.sendDataChannel({
-                    ordered,
-                    maxPacketLifeTime,
-                    maxRetransmits,
-                    priority,
-                    label,
-                    protocol
-                });
-                // This will fill sctpStreamParameters's missing fields with default values.
-                ortc.validateSctpStreamParameters(sctpStreamParameters);
-                const { id } = yield this.safeEmitAsPromise('producedata', {
-                    sctpStreamParameters,
-                    label,
-                    protocol,
-                    appData
-                });
-                const dataProducer = new DataProducer_1.DataProducer({ id, dataChannel, sctpStreamParameters, appData });
-                this._dataProducers.set(dataProducer.id, dataProducer);
-                this._handleDataProducer(dataProducer);
-                return dataProducer;
-            }));
+    async produceData({ ordered = true, maxPacketLifeTime, maxRetransmits, priority = 'low', label = '', protocol = '', appData = {} } = {}) {
+        logger.debug('produceData()');
+        if (this._direction !== 'send')
+            throw new errors_1.UnsupportedError('not a sending Transport');
+        else if (!this._maxSctpMessageSize)
+            throw new errors_1.UnsupportedError('SCTP not enabled by remote Transport');
+        else if (!['very-low', 'low', 'medium', 'high'].includes(priority))
+            throw new TypeError('wrong priority');
+        else if (this.listenerCount('connect') === 0 && this._connectionState === 'new')
+            throw new TypeError('no "connect" listener set into this transport');
+        else if (this.listenerCount('producedata') === 0)
+            throw new TypeError('no "producedata" listener set into this transport');
+        else if (appData && typeof appData !== 'object')
+            throw new TypeError('if given, appData must be an object');
+        if (maxPacketLifeTime || maxRetransmits)
+            ordered = false;
+        // Enqueue command.
+        return this._awaitQueue.push(async () => {
+            const { dataChannel, sctpStreamParameters } = await this._handler.sendDataChannel({
+                ordered,
+                maxPacketLifeTime,
+                maxRetransmits,
+                priority,
+                label,
+                protocol
+            });
+            // This will fill sctpStreamParameters's missing fields with default values.
+            ortc.validateSctpStreamParameters(sctpStreamParameters);
+            const { id } = await this.safeEmitAsPromise('producedata', {
+                sctpStreamParameters,
+                label,
+                protocol,
+                appData
+            });
+            const dataProducer = new DataProducer_1.DataProducer({ id, dataChannel, sctpStreamParameters, appData });
+            this._dataProducers.set(dataProducer.id, dataProducer);
+            this._handleDataProducer(dataProducer);
+            return dataProducer;
         });
     }
     /**
      * Create a DataConsumer
      */
-    consumeData({ id, dataProducerId, sctpStreamParameters, label = '', protocol = '', appData = {} }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('consumeData()');
-            if (this._closed)
-                throw new errors_1.InvalidStateError('closed');
-            else if (this._direction !== 'recv')
-                throw new errors_1.UnsupportedError('not a receiving Transport');
-            else if (!this._maxSctpMessageSize)
-                throw new errors_1.UnsupportedError('SCTP not enabled by remote Transport');
-            else if (typeof id !== 'string')
-                throw new TypeError('missing id');
-            else if (typeof dataProducerId !== 'string')
-                throw new TypeError('missing dataProducerId');
-            else if (this.listenerCount('connect') === 0 && this._connectionState === 'new')
-                throw new TypeError('no "connect" listener set into this transport');
-            else if (appData && typeof appData !== 'object')
-                throw new TypeError('if given, appData must be an object');
-            // This may throw.
-            ortc.validateSctpStreamParameters(sctpStreamParameters);
-            // Enqueue command.
-            return this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () {
-                const { dataChannel } = yield this._handler.receiveDataChannel({
-                    sctpStreamParameters,
-                    label,
-                    protocol
-                });
-                const dataConsumer = new DataConsumer_1.DataConsumer({
-                    id,
-                    dataProducerId,
-                    dataChannel,
-                    sctpStreamParameters,
-                    appData
-                });
-                this._dataConsumers.set(dataConsumer.id, dataConsumer);
-                this._handleDataConsumer(dataConsumer);
-                return dataConsumer;
-            }));
+    async consumeData({ id, dataProducerId, sctpStreamParameters, label = '', protocol = '', appData = {} }) {
+        logger.debug('consumeData()');
+        if (this._closed)
+            throw new errors_1.InvalidStateError('closed');
+        else if (this._direction !== 'recv')
+            throw new errors_1.UnsupportedError('not a receiving Transport');
+        else if (!this._maxSctpMessageSize)
+            throw new errors_1.UnsupportedError('SCTP not enabled by remote Transport');
+        else if (typeof id !== 'string')
+            throw new TypeError('missing id');
+        else if (typeof dataProducerId !== 'string')
+            throw new TypeError('missing dataProducerId');
+        else if (this.listenerCount('connect') === 0 && this._connectionState === 'new')
+            throw new TypeError('no "connect" listener set into this transport');
+        else if (appData && typeof appData !== 'object')
+            throw new TypeError('if given, appData must be an object');
+        // This may throw.
+        ortc.validateSctpStreamParameters(sctpStreamParameters);
+        // Enqueue command.
+        return this._awaitQueue.push(async () => {
+            const { dataChannel } = await this._handler.receiveDataChannel({
+                sctpStreamParameters,
+                label,
+                protocol
+            });
+            const dataConsumer = new DataConsumer_1.DataConsumer({
+                id,
+                dataProducerId,
+                dataChannel,
+                sctpStreamParameters,
+                appData
+            });
+            this._dataConsumers.set(dataConsumer.id, dataConsumer);
+            this._handleDataConsumer(dataConsumer);
+            return dataConsumer;
         });
     }
     _handleHandler() {
@@ -447,25 +424,21 @@ class Transport extends EnhancedEventEmitter_1.EnhancedEventEmitter {
             this._producers.delete(producer.id);
             if (this._closed)
                 return;
-            this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () { return this._handler.stopSending(producer.localId); }))
+            this._awaitQueue.push(async () => this._handler.stopSending(producer.localId))
                 .catch((error) => logger.warn('producer.close() failed:%o', error));
         });
         producer.on('@replacetrack', (track, callback, errback) => {
-            this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () { return this._handler.replaceTrack(producer.localId, track); }))
+            this._awaitQueue.push(async () => this._handler.replaceTrack(producer.localId, track))
                 .then(callback)
                 .catch(errback);
         });
         producer.on('@setmaxspatiallayer', (spatialLayer, callback, errback) => {
-            this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () {
-                return (this._handler.setMaxSpatialLayer(producer.localId, spatialLayer));
-            }))
+            this._awaitQueue.push(async () => (this._handler.setMaxSpatialLayer(producer.localId, spatialLayer)))
                 .then(callback)
                 .catch(errback);
         });
         producer.on('@setrtpencodingparameters', (params, callback, errback) => {
-            this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () {
-                return (this._handler.setRtpEncodingParameters(producer.localId, params));
-            }))
+            this._awaitQueue.push(async () => (this._handler.setRtpEncodingParameters(producer.localId, params)))
                 .then(callback)
                 .catch(errback);
         });
@@ -482,7 +455,7 @@ class Transport extends EnhancedEventEmitter_1.EnhancedEventEmitter {
             this._consumers.delete(consumer.id);
             if (this._closed)
                 return;
-            this._awaitQueue.push(() => __awaiter(this, void 0, void 0, function* () { return this._handler.stopReceiving(consumer.localId); }))
+            this._awaitQueue.push(async () => this._handler.stopReceiving(consumer.localId))
                 .catch(() => { });
         });
         consumer.on('@getstats', (callback, errback) => {

--- a/lib/handlers/Chrome55.js
+++ b/lib/handlers/Chrome55.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -65,45 +56,41 @@ class Chrome55 extends HandlerInterface_1.HandlerInterface {
             catch (error) { }
         }
     }
-    getNativeRtpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeRtpCapabilities()');
-            const pc = new RTCPeerConnection({
-                iceServers: [],
-                iceTransportPolicy: 'all',
-                bundlePolicy: 'max-bundle',
-                rtcpMuxPolicy: 'require',
-                sdpSemantics: 'plan-b'
+    async getNativeRtpCapabilities() {
+        logger.debug('getNativeRtpCapabilities()');
+        const pc = new RTCPeerConnection({
+            iceServers: [],
+            iceTransportPolicy: 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'plan-b'
+        });
+        try {
+            const offer = await pc.createOffer({
+                offerToReceiveAudio: true,
+                offerToReceiveVideo: true
             });
             try {
-                const offer = yield pc.createOffer({
-                    offerToReceiveAudio: true,
-                    offerToReceiveVideo: true
-                });
-                try {
-                    pc.close();
-                }
-                catch (error) { }
-                const sdpObject = sdpTransform.parse(offer.sdp);
-                const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
-                return nativeRtpCapabilities;
+                pc.close();
             }
-            catch (error) {
-                try {
-                    pc.close();
-                }
-                catch (error2) { }
-                throw error;
+            catch (error) { }
+            const sdpObject = sdpTransform.parse(offer.sdp);
+            const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+            return nativeRtpCapabilities;
+        }
+        catch (error) {
+            try {
+                pc.close();
             }
-        });
+            catch (error2) { }
+            throw error;
+        }
     }
-    getNativeSctpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeSctpCapabilities()');
-            return {
-                numStreams: SCTP_NUM_STREAMS
-            };
-        });
+    async getNativeSctpCapabilities() {
+        logger.debug('getNativeSctpCapabilities()');
+        return {
+            numStreams: SCTP_NUM_STREAMS
+        };
     }
     run({ direction, iceParameters, iceCandidates, dtlsParameters, sctpParameters, iceServers, iceTransportPolicy, additionalSettings, proprietaryConstraints, extendedRtpCapabilities }) {
         logger.debug('run()');
@@ -125,7 +112,14 @@ class Chrome55 extends HandlerInterface_1.HandlerInterface {
                 audio: ortc.getSendingRemoteRtpParameters('audio', extendedRtpCapabilities),
                 video: ortc.getSendingRemoteRtpParameters('video', extendedRtpCapabilities)
             };
-        this._pc = new RTCPeerConnection(Object.assign({ iceServers: iceServers || [], iceTransportPolicy: iceTransportPolicy || 'all', bundlePolicy: 'max-bundle', rtcpMuxPolicy: 'require', sdpSemantics: 'plan-b' }, additionalSettings), proprietaryConstraints);
+        this._pc = new RTCPeerConnection({
+            iceServers: iceServers || [],
+            iceTransportPolicy: iceTransportPolicy || 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'plan-b',
+            ...additionalSettings
+        }, proprietaryConstraints);
         // Handle RTCPeerConnection connection status.
         this._pc.addEventListener('iceconnectionstatechange', () => {
             switch (this._pc.iceConnectionState) {
@@ -148,323 +142,293 @@ class Chrome55 extends HandlerInterface_1.HandlerInterface {
             }
         });
     }
-    updateIceServers(iceServers) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('updateIceServers()');
-            const configuration = this._pc.getConfiguration();
-            configuration.iceServers = iceServers;
-            this._pc.setConfiguration(configuration);
-        });
+    async updateIceServers(iceServers) {
+        logger.debug('updateIceServers()');
+        const configuration = this._pc.getConfiguration();
+        configuration.iceServers = iceServers;
+        this._pc.setConfiguration(configuration);
     }
-    restartIce(iceParameters) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            // Provide the remote SDP handler with new remote ICE parameters.
-            this._remoteSdp.updateIceParameters(iceParameters);
-            if (!this._transportReady)
-                return;
-            if (this._direction === 'send') {
-                const offer = yield this._pc.createOffer({ iceRestart: true });
-                logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-            }
-            else {
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-            }
-        });
+    async restartIce(iceParameters) {
+        logger.debug('restartIce()');
+        // Provide the remote SDP handler with new remote ICE parameters.
+        this._remoteSdp.updateIceParameters(iceParameters);
+        if (!this._transportReady)
+            return;
+        if (this._direction === 'send') {
+            const offer = await this._pc.createOffer({ iceRestart: true });
+            logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+        }
+        else {
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+        }
     }
-    getTransportStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this._pc.getStats();
-        });
+    async getTransportStats() {
+        return this._pc.getStats();
     }
-    send({ track, encodings, codecOptions }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
-            this._sendStream.addTrack(track);
-            this._pc.addStream(this._sendStream);
-            let offer = yield this._pc.createOffer();
-            let localSdpObject = sdpTransform.parse(offer.sdp);
-            let offerMediaObject;
-            const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-            if (track.kind === 'video' && encodings && encodings.length > 1) {
-                logger.debug('send() | enabling simulcast');
-                localSdpObject = sdpTransform.parse(offer.sdp);
-                offerMediaObject = localSdpObject.media.find((m) => m.type === 'video');
-                sdpPlanBUtils.addLegacySimulcast({
-                    offerMediaObject,
-                    track,
-                    numStreams: encodings.length
-                });
-                offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
-            }
-            logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            offerMediaObject = localSdpObject.media
-                .find((m) => m.type === track.kind);
-            // Set RTCP CNAME.
-            sendingRtpParameters.rtcp.cname =
-                sdpCommonUtils.getCname({ offerMediaObject });
-            // Set RTP encodings.
-            sendingRtpParameters.encodings =
-                sdpPlanBUtils.getRtpEncodings({ offerMediaObject, track });
-            // Complete encodings with given values.
-            if (encodings) {
-                for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
-                    if (encodings[idx])
-                        Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
-                }
-            }
-            // If VP8 and there is effective simulcast, add scalabilityMode to each
-            // encoding.
-            if (sendingRtpParameters.encodings.length > 1 &&
-                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8') {
-                for (const encoding of sendingRtpParameters.encodings) {
-                    encoding.scalabilityMode = 'S1T3';
-                }
-            }
-            this._remoteSdp.send({
+    async send({ track, encodings, codecOptions }) {
+        this._assertSendDirection();
+        logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+        this._sendStream.addTrack(track);
+        this._pc.addStream(this._sendStream);
+        let offer = await this._pc.createOffer();
+        let localSdpObject = sdpTransform.parse(offer.sdp);
+        let offerMediaObject;
+        const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+        if (track.kind === 'video' && encodings && encodings.length > 1) {
+            logger.debug('send() | enabling simulcast');
+            localSdpObject = sdpTransform.parse(offer.sdp);
+            offerMediaObject = localSdpObject.media.find((m) => m.type === 'video');
+            sdpPlanBUtils.addLegacySimulcast({
                 offerMediaObject,
-                offerRtpParameters: sendingRtpParameters,
-                answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
-                codecOptions
+                track,
+                numStreams: encodings.length
             });
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-            const localId = String(this._nextSendLocalId);
-            this._nextSendLocalId++;
-            // Insert into the map.
-            this._mapSendLocalIdTrack.set(localId, track);
-            return {
-                localId: localId,
-                rtpParameters: sendingRtpParameters
-            };
+            offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
+        }
+        logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        offerMediaObject = localSdpObject.media
+            .find((m) => m.type === track.kind);
+        // Set RTCP CNAME.
+        sendingRtpParameters.rtcp.cname =
+            sdpCommonUtils.getCname({ offerMediaObject });
+        // Set RTP encodings.
+        sendingRtpParameters.encodings =
+            sdpPlanBUtils.getRtpEncodings({ offerMediaObject, track });
+        // Complete encodings with given values.
+        if (encodings) {
+            for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
+                if (encodings[idx])
+                    Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
+            }
+        }
+        // If VP8 and there is effective simulcast, add scalabilityMode to each
+        // encoding.
+        if (sendingRtpParameters.encodings.length > 1 &&
+            sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8') {
+            for (const encoding of sendingRtpParameters.encodings) {
+                encoding.scalabilityMode = 'S1T3';
+            }
+        }
+        this._remoteSdp.send({
+            offerMediaObject,
+            offerRtpParameters: sendingRtpParameters,
+            answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
+            codecOptions
         });
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+        const localId = String(this._nextSendLocalId);
+        this._nextSendLocalId++;
+        // Insert into the map.
+        this._mapSendLocalIdTrack.set(localId, track);
+        return {
+            localId: localId,
+            rtpParameters: sendingRtpParameters
+        };
     }
-    stopSending(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('stopSending() [localId:%s]', localId);
-            const track = this._mapSendLocalIdTrack.get(localId);
-            if (!track)
-                throw new Error('track not found');
-            this._mapSendLocalIdTrack.delete(localId);
-            this._sendStream.removeTrack(track);
-            this._pc.addStream(this._sendStream);
-            const offer = yield this._pc.createOffer();
-            logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
-            try {
-                yield this._pc.setLocalDescription(offer);
-            }
-            catch (error) {
-                // NOTE: If there are no sending tracks, setLocalDescription() will fail with
-                // "Failed to create channels". If so, ignore it.
-                if (this._sendStream.getTracks().length === 0) {
-                    logger.warn('stopSending() | ignoring expected error due no sending tracks: %s', error.toString());
-                    return;
-                }
-                throw error;
-            }
-            if (this._pc.signalingState === 'stable')
+    async stopSending(localId) {
+        this._assertSendDirection();
+        logger.debug('stopSending() [localId:%s]', localId);
+        const track = this._mapSendLocalIdTrack.get(localId);
+        if (!track)
+            throw new Error('track not found');
+        this._mapSendLocalIdTrack.delete(localId);
+        this._sendStream.removeTrack(track);
+        this._pc.addStream(this._sendStream);
+        const offer = await this._pc.createOffer();
+        logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
+        try {
+            await this._pc.setLocalDescription(offer);
+        }
+        catch (error) {
+            // NOTE: If there are no sending tracks, setLocalDescription() will fail with
+            // "Failed to create channels". If so, ignore it.
+            if (this._sendStream.getTracks().length === 0) {
+                logger.warn('stopSending() | ignoring expected error due no sending tracks: %s', error.toString());
                 return;
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-        });
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    replaceTrack(localId, track) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
-        });
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    setMaxSpatialLayer(localId, spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError(' not implemented');
-        });
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    setRtpEncodingParameters(localId, params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not supported');
-        });
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    getSenderStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
-        });
-    }
-    sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const options = {
-                negotiated: true,
-                id: this._nextSendSctpStreamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmitTime: maxPacketLifeTime,
-                maxRetransmits,
-                protocol,
-                priority
-            };
-            logger.debug('sendDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // Increase next id.
-            this._nextSendSctpStreamId =
-                ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
-            // If this is the first DataChannel we need to create the SDP answer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                const offer = yield this._pc.createOffer();
-                const localSdpObject = sdpTransform.parse(offer.sdp);
-                const offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'application');
-                if (!this._transportReady)
-                    yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-                logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                this._remoteSdp.sendSctpAssociation({ offerMediaObject });
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-                this._hasDataChannelMediaSection = true;
             }
-            const sctpStreamParameters = {
-                streamId: options.id,
-                ordered: options.ordered,
-                maxPacketLifeTime: options.maxPacketLifeTime,
-                maxRetransmits: options.maxRetransmits
-            };
-            return { dataChannel, sctpStreamParameters };
-        });
+            throw error;
+        }
+        if (this._pc.signalingState === 'stable')
+            return;
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
     }
-    receive({ trackId, kind, rtpParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
-            const localId = trackId;
-            const mid = kind;
-            const streamId = rtpParameters.rtcp.cname;
-            this._remoteSdp.receive({
-                mid,
-                kind,
-                offerRtpParameters: rtpParameters,
-                streamId,
-                trackId
-            });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            let answer = yield this._pc.createAnswer();
-            const localSdpObject = sdpTransform.parse(answer.sdp);
-            const answerMediaObject = localSdpObject.media
-                .find((m) => String(m.mid) === mid);
-            // May need to modify codec parameters in the answer based on codec
-            // parameters in the offer.
-            sdpCommonUtils.applyCodecParameters({
-                offerRtpParameters: rtpParameters,
-                answerMediaObject
-            });
-            answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async replaceTrack(localId, track) {
+        throw new errors_1.UnsupportedError('not implemented');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async setMaxSpatialLayer(localId, spatialLayer) {
+        throw new errors_1.UnsupportedError(' not implemented');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async setRtpEncodingParameters(localId, params) {
+        throw new errors_1.UnsupportedError('not supported');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async getSenderStats(localId) {
+        throw new errors_1.UnsupportedError('not implemented');
+    }
+    async sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
+        this._assertSendDirection();
+        const options = {
+            negotiated: true,
+            id: this._nextSendSctpStreamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmitTime: maxPacketLifeTime,
+            maxRetransmits,
+            protocol,
+            priority
+        };
+        logger.debug('sendDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // Increase next id.
+        this._nextSendSctpStreamId =
+            ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+        // If this is the first DataChannel we need to create the SDP answer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            const offer = await this._pc.createOffer();
+            const localSdpObject = sdpTransform.parse(offer.sdp);
+            const offerMediaObject = localSdpObject.media
+                .find((m) => m.type === 'application');
             if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-            logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-            const stream = this._pc.getRemoteStreams()
-                .find((s) => s.id === streamId);
-            const track = stream.getTrackById(localId);
-            if (!track)
-                throw new Error('remote track not found');
-            // Insert into the map.
-            this._mapRecvLocalIdInfo.set(localId, { mid, rtpParameters });
-            return { localId, track };
-        });
+                await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+            logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            this._remoteSdp.sendSctpAssociation({ offerMediaObject });
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        const sctpStreamParameters = {
+            streamId: options.id,
+            ordered: options.ordered,
+            maxPacketLifeTime: options.maxPacketLifeTime,
+            maxRetransmits: options.maxRetransmits
+        };
+        return { dataChannel, sctpStreamParameters };
     }
-    stopReceiving(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('stopReceiving() [localId:%s]', localId);
-            const { mid, rtpParameters } = this._mapRecvLocalIdInfo.get(localId);
-            // Remove from the map.
-            this._mapRecvLocalIdInfo.delete(localId);
-            this._remoteSdp.planBStopReceiving({ mid, offerRtpParameters: rtpParameters });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            const answer = yield this._pc.createAnswer();
-            logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
+    async receive({ trackId, kind, rtpParameters }) {
+        this._assertRecvDirection();
+        logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
+        const localId = trackId;
+        const mid = kind;
+        const streamId = rtpParameters.rtcp.cname;
+        this._remoteSdp.receive({
+            mid,
+            kind,
+            offerRtpParameters: rtpParameters,
+            streamId,
+            trackId
         });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        let answer = await this._pc.createAnswer();
+        const localSdpObject = sdpTransform.parse(answer.sdp);
+        const answerMediaObject = localSdpObject.media
+            .find((m) => String(m.mid) === mid);
+        // May need to modify codec parameters in the answer based on codec
+        // parameters in the offer.
+        sdpCommonUtils.applyCodecParameters({
+            offerRtpParameters: rtpParameters,
+            answerMediaObject
+        });
+        answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
+        logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+        const stream = this._pc.getRemoteStreams()
+            .find((s) => s.id === streamId);
+        const track = stream.getTrackById(localId);
+        if (!track)
+            throw new Error('remote track not found');
+        // Insert into the map.
+        this._mapRecvLocalIdInfo.set(localId, { mid, rtpParameters });
+        return { localId, track };
+    }
+    async stopReceiving(localId) {
+        this._assertRecvDirection();
+        logger.debug('stopReceiving() [localId:%s]', localId);
+        const { mid, rtpParameters } = this._mapRecvLocalIdInfo.get(localId);
+        // Remove from the map.
+        this._mapRecvLocalIdInfo.delete(localId);
+        this._remoteSdp.planBStopReceiving({ mid, offerRtpParameters: rtpParameters });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        const answer = await this._pc.createAnswer();
+        logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    getReceiverStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
-        });
+    async getReceiverStats(localId) {
+        throw new errors_1.UnsupportedError('not implemented');
     }
-    receiveDataChannel({ sctpStreamParameters, label, protocol }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
-            const options = {
-                negotiated: true,
-                id: streamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmitTime: maxPacketLifeTime,
-                maxRetransmits,
-                protocol
-            };
-            logger.debug('receiveDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // If this is the first DataChannel we need to create the SDP offer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                this._remoteSdp.receiveSctpAssociation({ oldDataChannelSpec: true });
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                if (!this._transportReady) {
-                    const localSdpObject = sdpTransform.parse(answer.sdp);
-                    yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-                }
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-                this._hasDataChannelMediaSection = true;
+    async receiveDataChannel({ sctpStreamParameters, label, protocol }) {
+        this._assertRecvDirection();
+        const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
+        const options = {
+            negotiated: true,
+            id: streamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmitTime: maxPacketLifeTime,
+            maxRetransmits,
+            protocol
+        };
+        logger.debug('receiveDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // If this is the first DataChannel we need to create the SDP offer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            this._remoteSdp.receiveSctpAssociation({ oldDataChannelSpec: true });
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            if (!this._transportReady) {
+                const localSdpObject = sdpTransform.parse(answer.sdp);
+                await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
             }
-            return { dataChannel };
-        });
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        return { dataChannel };
     }
-    _setupTransport({ localDtlsRole, localSdpObject }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!localSdpObject)
-                localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            // Get our local DTLS parameters.
-            const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
-            // Set our DTLS role.
-            dtlsParameters.role = localDtlsRole;
-            // Update the remote DTLS role in the SDP.
-            this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
-            // Need to tell the remote transport about our parameters.
-            yield this.safeEmitAsPromise('@connect', { dtlsParameters });
-            this._transportReady = true;
-        });
+    async _setupTransport({ localDtlsRole, localSdpObject }) {
+        if (!localSdpObject)
+            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        // Get our local DTLS parameters.
+        const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
+        // Set our DTLS role.
+        dtlsParameters.role = localDtlsRole;
+        // Update the remote DTLS role in the SDP.
+        this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
+        // Need to tell the remote transport about our parameters.
+        await this.safeEmitAsPromise('@connect', { dtlsParameters });
+        this._transportReady = true;
     }
     _assertSendDirection() {
         if (this._direction !== 'send') {

--- a/lib/handlers/Chrome67.js
+++ b/lib/handlers/Chrome67.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -64,45 +55,41 @@ class Chrome67 extends HandlerInterface_1.HandlerInterface {
             catch (error) { }
         }
     }
-    getNativeRtpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeRtpCapabilities()');
-            const pc = new RTCPeerConnection({
-                iceServers: [],
-                iceTransportPolicy: 'all',
-                bundlePolicy: 'max-bundle',
-                rtcpMuxPolicy: 'require',
-                sdpSemantics: 'plan-b'
+    async getNativeRtpCapabilities() {
+        logger.debug('getNativeRtpCapabilities()');
+        const pc = new RTCPeerConnection({
+            iceServers: [],
+            iceTransportPolicy: 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'plan-b'
+        });
+        try {
+            const offer = await pc.createOffer({
+                offerToReceiveAudio: true,
+                offerToReceiveVideo: true
             });
             try {
-                const offer = yield pc.createOffer({
-                    offerToReceiveAudio: true,
-                    offerToReceiveVideo: true
-                });
-                try {
-                    pc.close();
-                }
-                catch (error) { }
-                const sdpObject = sdpTransform.parse(offer.sdp);
-                const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
-                return nativeRtpCapabilities;
+                pc.close();
             }
-            catch (error) {
-                try {
-                    pc.close();
-                }
-                catch (error2) { }
-                throw error;
+            catch (error) { }
+            const sdpObject = sdpTransform.parse(offer.sdp);
+            const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+            return nativeRtpCapabilities;
+        }
+        catch (error) {
+            try {
+                pc.close();
             }
-        });
+            catch (error2) { }
+            throw error;
+        }
     }
-    getNativeSctpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeSctpCapabilities()');
-            return {
-                numStreams: SCTP_NUM_STREAMS
-            };
-        });
+    async getNativeSctpCapabilities() {
+        logger.debug('getNativeSctpCapabilities()');
+        return {
+            numStreams: SCTP_NUM_STREAMS
+        };
     }
     run({ direction, iceParameters, iceCandidates, dtlsParameters, sctpParameters, iceServers, iceTransportPolicy, additionalSettings, proprietaryConstraints, extendedRtpCapabilities }) {
         logger.debug('run()');
@@ -124,7 +111,14 @@ class Chrome67 extends HandlerInterface_1.HandlerInterface {
                 audio: ortc.getSendingRemoteRtpParameters('audio', extendedRtpCapabilities),
                 video: ortc.getSendingRemoteRtpParameters('video', extendedRtpCapabilities)
             };
-        this._pc = new RTCPeerConnection(Object.assign({ iceServers: iceServers || [], iceTransportPolicy: iceTransportPolicy || 'all', bundlePolicy: 'max-bundle', rtcpMuxPolicy: 'require', sdpSemantics: 'plan-b' }, additionalSettings), proprietaryConstraints);
+        this._pc = new RTCPeerConnection({
+            iceServers: iceServers || [],
+            iceTransportPolicy: iceTransportPolicy || 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'plan-b',
+            ...additionalSettings
+        }, proprietaryConstraints);
         // Handle RTCPeerConnection connection status.
         this._pc.addEventListener('iceconnectionstatechange', () => {
             switch (this._pc.iceConnectionState) {
@@ -147,374 +141,344 @@ class Chrome67 extends HandlerInterface_1.HandlerInterface {
             }
         });
     }
-    updateIceServers(iceServers) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('updateIceServers()');
-            const configuration = this._pc.getConfiguration();
-            configuration.iceServers = iceServers;
-            this._pc.setConfiguration(configuration);
-        });
+    async updateIceServers(iceServers) {
+        logger.debug('updateIceServers()');
+        const configuration = this._pc.getConfiguration();
+        configuration.iceServers = iceServers;
+        this._pc.setConfiguration(configuration);
     }
-    restartIce(iceParameters) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            // Provide the remote SDP handler with new remote ICE parameters.
-            this._remoteSdp.updateIceParameters(iceParameters);
-            if (!this._transportReady)
-                return;
-            if (this._direction === 'send') {
-                const offer = yield this._pc.createOffer({ iceRestart: true });
-                logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-            }
-            else {
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-            }
-        });
+    async restartIce(iceParameters) {
+        logger.debug('restartIce()');
+        // Provide the remote SDP handler with new remote ICE parameters.
+        this._remoteSdp.updateIceParameters(iceParameters);
+        if (!this._transportReady)
+            return;
+        if (this._direction === 'send') {
+            const offer = await this._pc.createOffer({ iceRestart: true });
+            logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+        }
+        else {
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+        }
     }
-    getTransportStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this._pc.getStats();
-        });
+    async getTransportStats() {
+        return this._pc.getStats();
     }
-    send({ track, encodings, codecOptions }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
-            this._sendStream.addTrack(track);
-            this._pc.addTrack(track, this._sendStream);
-            let offer = yield this._pc.createOffer();
-            let localSdpObject = sdpTransform.parse(offer.sdp);
-            let offerMediaObject;
-            const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-            if (track.kind === 'video' && encodings && encodings.length > 1) {
-                logger.debug('send() | enabling simulcast');
-                localSdpObject = sdpTransform.parse(offer.sdp);
-                offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'video');
-                sdpPlanBUtils.addLegacySimulcast({
-                    offerMediaObject,
-                    track,
-                    numStreams: encodings.length
-                });
-                offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
-            }
-            logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+    async send({ track, encodings, codecOptions }) {
+        this._assertSendDirection();
+        logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+        this._sendStream.addTrack(track);
+        this._pc.addTrack(track, this._sendStream);
+        let offer = await this._pc.createOffer();
+        let localSdpObject = sdpTransform.parse(offer.sdp);
+        let offerMediaObject;
+        const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+        if (track.kind === 'video' && encodings && encodings.length > 1) {
+            logger.debug('send() | enabling simulcast');
+            localSdpObject = sdpTransform.parse(offer.sdp);
             offerMediaObject = localSdpObject.media
-                .find((m) => m.type === track.kind);
-            // Set RTCP CNAME.
-            sendingRtpParameters.rtcp.cname =
-                sdpCommonUtils.getCname({ offerMediaObject });
-            // Set RTP encodings.
-            sendingRtpParameters.encodings =
-                sdpPlanBUtils.getRtpEncodings({ offerMediaObject, track });
-            // Complete encodings with given values.
-            if (encodings) {
-                for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
-                    if (encodings[idx])
-                        Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
-                }
-            }
-            // If VP8 and there is effective simulcast, add scalabilityMode to each
-            // encoding.
-            if (sendingRtpParameters.encodings.length > 1 &&
-                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8') {
-                for (const encoding of sendingRtpParameters.encodings) {
-                    encoding.scalabilityMode = 'S1T3';
-                }
-            }
-            this._remoteSdp.send({
+                .find((m) => m.type === 'video');
+            sdpPlanBUtils.addLegacySimulcast({
                 offerMediaObject,
-                offerRtpParameters: sendingRtpParameters,
-                answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
-                codecOptions
+                track,
+                numStreams: encodings.length
             });
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-            const localId = String(this._nextSendLocalId);
-            this._nextSendLocalId++;
-            // Insert into the map.
-            this._mapSendLocalIdTrack.set(localId, track);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            return {
-                localId: localId,
-                rtpParameters: sendingRtpParameters,
-                rtpSender
-            };
+            offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
+        }
+        logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        offerMediaObject = localSdpObject.media
+            .find((m) => m.type === track.kind);
+        // Set RTCP CNAME.
+        sendingRtpParameters.rtcp.cname =
+            sdpCommonUtils.getCname({ offerMediaObject });
+        // Set RTP encodings.
+        sendingRtpParameters.encodings =
+            sdpPlanBUtils.getRtpEncodings({ offerMediaObject, track });
+        // Complete encodings with given values.
+        if (encodings) {
+            for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
+                if (encodings[idx])
+                    Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
+            }
+        }
+        // If VP8 and there is effective simulcast, add scalabilityMode to each
+        // encoding.
+        if (sendingRtpParameters.encodings.length > 1 &&
+            sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8') {
+            for (const encoding of sendingRtpParameters.encodings) {
+                encoding.scalabilityMode = 'S1T3';
+            }
+        }
+        this._remoteSdp.send({
+            offerMediaObject,
+            offerRtpParameters: sendingRtpParameters,
+            answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
+            codecOptions
         });
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+        const localId = String(this._nextSendLocalId);
+        this._nextSendLocalId++;
+        // Insert into the map.
+        this._mapSendLocalIdTrack.set(localId, track);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        return {
+            localId: localId,
+            rtpParameters: sendingRtpParameters,
+            rtpSender
+        };
     }
-    stopSending(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('stopSending() [localId:%s]', localId);
-            const track = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            this._pc.removeTrack(rtpSender);
-            this._sendStream.removeTrack(track);
-            this._mapSendLocalIdTrack.delete(localId);
-            const offer = yield this._pc.createOffer();
-            logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
-            try {
-                yield this._pc.setLocalDescription(offer);
-            }
-            catch (error) {
-                // NOTE: If there are no sending tracks, setLocalDescription() will fail with
-                // "Failed to create channels". If so, ignore it.
-                if (this._sendStream.getTracks().length === 0) {
-                    logger.warn('stopSending() | ignoring expected error due no sending tracks: %s', error.toString());
-                    return;
-                }
-                throw error;
-            }
-            if (this._pc.signalingState === 'stable')
+    async stopSending(localId) {
+        this._assertSendDirection();
+        logger.debug('stopSending() [localId:%s]', localId);
+        const track = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        this._pc.removeTrack(rtpSender);
+        this._sendStream.removeTrack(track);
+        this._mapSendLocalIdTrack.delete(localId);
+        const offer = await this._pc.createOffer();
+        logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
+        try {
+            await this._pc.setLocalDescription(offer);
+        }
+        catch (error) {
+            // NOTE: If there are no sending tracks, setLocalDescription() will fail with
+            // "Failed to create channels". If so, ignore it.
+            if (this._sendStream.getTracks().length === 0) {
+                logger.warn('stopSending() | ignoring expected error due no sending tracks: %s', error.toString());
                 return;
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-        });
-    }
-    replaceTrack(localId, track) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
-            const oldTrack = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === oldTrack);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            yield rtpSender.replaceTrack(track);
-            // Remove the old track from the local stream.
-            this._sendStream.removeTrack(oldTrack);
-            // Add the new track to the local stream.
-            this._sendStream.addTrack(track);
-            // Replace entry in the map.
-            this._mapSendLocalIdTrack.set(localId, track);
-        });
-    }
-    setMaxSpatialLayer(localId, spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
-            const track = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            const parameters = rtpSender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                if (idx <= spatialLayer)
-                    encoding.active = true;
-                else
-                    encoding.active = false;
-            });
-            yield rtpSender.setParameters(parameters);
-        });
-    }
-    setRtpEncodingParameters(localId, params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
-            const track = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            const parameters = rtpSender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                parameters.encodings[idx] = Object.assign(Object.assign({}, encoding), params);
-            });
-            yield rtpSender.setParameters(parameters);
-        });
-    }
-    getSenderStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const track = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            return rtpSender.getStats();
-        });
-    }
-    sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const options = {
-                negotiated: true,
-                id: this._nextSendSctpStreamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmitTime: maxPacketLifeTime,
-                maxRetransmits,
-                protocol,
-                priority
-            };
-            logger.debug('sendDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // Increase next id.
-            this._nextSendSctpStreamId =
-                ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
-            // If this is the first DataChannel we need to create the SDP answer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                const offer = yield this._pc.createOffer();
-                const localSdpObject = sdpTransform.parse(offer.sdp);
-                const offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'application');
-                if (!this._transportReady)
-                    yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-                logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                this._remoteSdp.sendSctpAssociation({ offerMediaObject });
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-                this._hasDataChannelMediaSection = true;
             }
-            const sctpStreamParameters = {
-                streamId: options.id,
-                ordered: options.ordered,
-                maxPacketLifeTime: options.maxPacketLifeTime,
-                maxRetransmits: options.maxRetransmits
-            };
-            return { dataChannel, sctpStreamParameters };
-        });
+            throw error;
+        }
+        if (this._pc.signalingState === 'stable')
+            return;
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
     }
-    receive({ trackId, kind, rtpParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
-            const localId = trackId;
-            const mid = kind;
-            this._remoteSdp.receive({
-                mid,
-                kind,
-                offerRtpParameters: rtpParameters,
-                streamId: rtpParameters.rtcp.cname,
-                trackId
-            });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            let answer = yield this._pc.createAnswer();
-            const localSdpObject = sdpTransform.parse(answer.sdp);
-            const answerMediaObject = localSdpObject.media
-                .find((m) => String(m.mid) === mid);
-            // May need to modify codec parameters in the answer based on codec
-            // parameters in the offer.
-            sdpCommonUtils.applyCodecParameters({
-                offerRtpParameters: rtpParameters,
-                answerMediaObject
-            });
-            answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+    async replaceTrack(localId, track) {
+        this._assertSendDirection();
+        logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
+        const oldTrack = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === oldTrack);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        await rtpSender.replaceTrack(track);
+        // Remove the old track from the local stream.
+        this._sendStream.removeTrack(oldTrack);
+        // Add the new track to the local stream.
+        this._sendStream.addTrack(track);
+        // Replace entry in the map.
+        this._mapSendLocalIdTrack.set(localId, track);
+    }
+    async setMaxSpatialLayer(localId, spatialLayer) {
+        this._assertSendDirection();
+        logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
+        const track = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        const parameters = rtpSender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            if (idx <= spatialLayer)
+                encoding.active = true;
+            else
+                encoding.active = false;
+        });
+        await rtpSender.setParameters(parameters);
+    }
+    async setRtpEncodingParameters(localId, params) {
+        this._assertSendDirection();
+        logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
+        const track = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        const parameters = rtpSender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            parameters.encodings[idx] = { ...encoding, ...params };
+        });
+        await rtpSender.setParameters(parameters);
+    }
+    async getSenderStats(localId) {
+        this._assertSendDirection();
+        const track = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        return rtpSender.getStats();
+    }
+    async sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
+        this._assertSendDirection();
+        const options = {
+            negotiated: true,
+            id: this._nextSendSctpStreamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmitTime: maxPacketLifeTime,
+            maxRetransmits,
+            protocol,
+            priority
+        };
+        logger.debug('sendDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // Increase next id.
+        this._nextSendSctpStreamId =
+            ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+        // If this is the first DataChannel we need to create the SDP answer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            const offer = await this._pc.createOffer();
+            const localSdpObject = sdpTransform.parse(offer.sdp);
+            const offerMediaObject = localSdpObject.media
+                .find((m) => m.type === 'application');
             if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-            logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-            const rtpReceiver = this._pc.getReceivers()
-                .find((r) => r.track && r.track.id === localId);
-            if (!rtpReceiver)
-                throw new Error('new RTCRtpReceiver not');
-            // Insert into the map.
-            this._mapRecvLocalIdInfo.set(localId, { mid, rtpParameters, rtpReceiver });
-            return {
-                localId,
-                track: rtpReceiver.track,
-                rtpReceiver
-            };
-        });
+                await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+            logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            this._remoteSdp.sendSctpAssociation({ offerMediaObject });
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        const sctpStreamParameters = {
+            streamId: options.id,
+            ordered: options.ordered,
+            maxPacketLifeTime: options.maxPacketLifeTime,
+            maxRetransmits: options.maxRetransmits
+        };
+        return { dataChannel, sctpStreamParameters };
     }
-    stopReceiving(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('stopReceiving() [localId:%s]', localId);
-            const { mid, rtpParameters } = this._mapRecvLocalIdInfo.get(localId);
-            // Remove from the map.
-            this._mapRecvLocalIdInfo.delete(localId);
-            this._remoteSdp.planBStopReceiving({ mid, offerRtpParameters: rtpParameters });
+    async receive({ trackId, kind, rtpParameters }) {
+        this._assertRecvDirection();
+        logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
+        const localId = trackId;
+        const mid = kind;
+        this._remoteSdp.receive({
+            mid,
+            kind,
+            offerRtpParameters: rtpParameters,
+            streamId: rtpParameters.rtcp.cname,
+            trackId
+        });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        let answer = await this._pc.createAnswer();
+        const localSdpObject = sdpTransform.parse(answer.sdp);
+        const answerMediaObject = localSdpObject.media
+            .find((m) => String(m.mid) === mid);
+        // May need to modify codec parameters in the answer based on codec
+        // parameters in the offer.
+        sdpCommonUtils.applyCodecParameters({
+            offerRtpParameters: rtpParameters,
+            answerMediaObject
+        });
+        answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
+        logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+        const rtpReceiver = this._pc.getReceivers()
+            .find((r) => r.track && r.track.id === localId);
+        if (!rtpReceiver)
+            throw new Error('new RTCRtpReceiver not');
+        // Insert into the map.
+        this._mapRecvLocalIdInfo.set(localId, { mid, rtpParameters, rtpReceiver });
+        return {
+            localId,
+            track: rtpReceiver.track,
+            rtpReceiver
+        };
+    }
+    async stopReceiving(localId) {
+        this._assertRecvDirection();
+        logger.debug('stopReceiving() [localId:%s]', localId);
+        const { mid, rtpParameters } = this._mapRecvLocalIdInfo.get(localId);
+        // Remove from the map.
+        this._mapRecvLocalIdInfo.delete(localId);
+        this._remoteSdp.planBStopReceiving({ mid, offerRtpParameters: rtpParameters });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        const answer = await this._pc.createAnswer();
+        logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+    }
+    async getReceiverStats(localId) {
+        this._assertRecvDirection();
+        const { rtpReceiver } = this._mapRecvLocalIdInfo.get(localId);
+        if (!rtpReceiver)
+            throw new Error('associated RTCRtpReceiver not found');
+        return rtpReceiver.getStats();
+    }
+    async receiveDataChannel({ sctpStreamParameters, label, protocol }) {
+        this._assertRecvDirection();
+        const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
+        const options = {
+            negotiated: true,
+            id: streamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmitTime: maxPacketLifeTime,
+            maxRetransmits,
+            protocol
+        };
+        logger.debug('receiveDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // If this is the first DataChannel we need to create the SDP offer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            this._remoteSdp.receiveSctpAssociation({ oldDataChannelSpec: true });
             const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            const answer = yield this._pc.createAnswer();
-            logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-        });
-    }
-    getReceiverStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { rtpReceiver } = this._mapRecvLocalIdInfo.get(localId);
-            if (!rtpReceiver)
-                throw new Error('associated RTCRtpReceiver not found');
-            return rtpReceiver.getStats();
-        });
-    }
-    receiveDataChannel({ sctpStreamParameters, label, protocol }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
-            const options = {
-                negotiated: true,
-                id: streamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmitTime: maxPacketLifeTime,
-                maxRetransmits,
-                protocol
-            };
-            logger.debug('receiveDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // If this is the first DataChannel we need to create the SDP offer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                this._remoteSdp.receiveSctpAssociation({ oldDataChannelSpec: true });
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                if (!this._transportReady) {
-                    const localSdpObject = sdpTransform.parse(answer.sdp);
-                    yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-                }
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-                this._hasDataChannelMediaSection = true;
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            if (!this._transportReady) {
+                const localSdpObject = sdpTransform.parse(answer.sdp);
+                await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
             }
-            return { dataChannel };
-        });
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        return { dataChannel };
     }
-    _setupTransport({ localDtlsRole, localSdpObject }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!localSdpObject)
-                localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            // Get our local DTLS parameters.
-            const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
-            // Set our DTLS role.
-            dtlsParameters.role = localDtlsRole;
-            // Update the remote DTLS role in the SDP.
-            this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
-            // Need to tell the remote transport about our parameters.
-            yield this.safeEmitAsPromise('@connect', { dtlsParameters });
-            this._transportReady = true;
-        });
+    async _setupTransport({ localDtlsRole, localSdpObject }) {
+        if (!localSdpObject)
+            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        // Get our local DTLS parameters.
+        const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
+        // Set our DTLS role.
+        dtlsParameters.role = localDtlsRole;
+        // Update the remote DTLS role in the SDP.
+        this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
+        // Need to tell the remote transport about our parameters.
+        await this.safeEmitAsPromise('@connect', { dtlsParameters });
+        this._transportReady = true;
     }
     _assertSendDirection() {
         if (this._direction !== 'send') {

--- a/lib/handlers/Chrome70.js
+++ b/lib/handlers/Chrome70.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -79,7 +70,14 @@ class Chrome70 extends HandlerInterface_1.HandlerInterface {
                 audio: ortc.getSendingRemoteRtpParameters('audio', extendedRtpCapabilities),
                 video: ortc.getSendingRemoteRtpParameters('video', extendedRtpCapabilities)
             };
-        this._pc = new RTCPeerConnection(Object.assign({ iceServers: iceServers || [], iceTransportPolicy: iceTransportPolicy || 'all', bundlePolicy: 'max-bundle', rtcpMuxPolicy: 'require', sdpSemantics: 'unified-plan' }, additionalSettings), proprietaryConstraints);
+        this._pc = new RTCPeerConnection({
+            iceServers: iceServers || [],
+            iceTransportPolicy: iceTransportPolicy || 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'unified-plan',
+            ...additionalSettings
+        }, proprietaryConstraints);
         // Handle RTCPeerConnection connection status.
         this._pc.addEventListener('iceconnectionstatechange', () => {
             switch (this._pc.iceConnectionState) {
@@ -102,403 +100,369 @@ class Chrome70 extends HandlerInterface_1.HandlerInterface {
             }
         });
     }
-    getNativeRtpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeRtpCapabilities()');
-            const pc = new RTCPeerConnection({
-                iceServers: [],
-                iceTransportPolicy: 'all',
-                bundlePolicy: 'max-bundle',
-                rtcpMuxPolicy: 'require',
-                sdpSemantics: 'unified-plan'
-            });
+    async getNativeRtpCapabilities() {
+        logger.debug('getNativeRtpCapabilities()');
+        const pc = new RTCPeerConnection({
+            iceServers: [],
+            iceTransportPolicy: 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'unified-plan'
+        });
+        try {
+            pc.addTransceiver('audio');
+            pc.addTransceiver('video');
+            const offer = await pc.createOffer();
             try {
-                pc.addTransceiver('audio');
-                pc.addTransceiver('video');
-                const offer = yield pc.createOffer();
-                try {
-                    pc.close();
-                }
-                catch (error) { }
-                const sdpObject = sdpTransform.parse(offer.sdp);
-                const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
-                return nativeRtpCapabilities;
+                pc.close();
             }
-            catch (error) {
-                try {
-                    pc.close();
-                }
-                catch (error2) { }
-                throw error;
+            catch (error) { }
+            const sdpObject = sdpTransform.parse(offer.sdp);
+            const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+            return nativeRtpCapabilities;
+        }
+        catch (error) {
+            try {
+                pc.close();
             }
-        });
+            catch (error2) { }
+            throw error;
+        }
     }
-    getNativeSctpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeSctpCapabilities()');
-            return {
-                numStreams: SCTP_NUM_STREAMS
-            };
-        });
+    async getNativeSctpCapabilities() {
+        logger.debug('getNativeSctpCapabilities()');
+        return {
+            numStreams: SCTP_NUM_STREAMS
+        };
     }
-    updateIceServers(iceServers) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('updateIceServers()');
-            const configuration = this._pc.getConfiguration();
-            configuration.iceServers = iceServers;
-            this._pc.setConfiguration(configuration);
-        });
+    async updateIceServers(iceServers) {
+        logger.debug('updateIceServers()');
+        const configuration = this._pc.getConfiguration();
+        configuration.iceServers = iceServers;
+        this._pc.setConfiguration(configuration);
     }
-    restartIce(iceParameters) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            // Provide the remote SDP handler with new remote ICE parameters.
-            this._remoteSdp.updateIceParameters(iceParameters);
-            if (!this._transportReady)
-                return;
-            if (this._direction === 'send') {
-                const offer = yield this._pc.createOffer({ iceRestart: true });
-                logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-            }
-            else {
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-            }
-        });
+    async restartIce(iceParameters) {
+        logger.debug('restartIce()');
+        // Provide the remote SDP handler with new remote ICE parameters.
+        this._remoteSdp.updateIceParameters(iceParameters);
+        if (!this._transportReady)
+            return;
+        if (this._direction === 'send') {
+            const offer = await this._pc.createOffer({ iceRestart: true });
+            logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+        }
+        else {
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+        }
     }
-    getTransportStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this._pc.getStats();
-        });
+    async getTransportStats() {
+        return this._pc.getStats();
     }
-    send({ track, encodings, codecOptions }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
-            const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
-            const transceiver = this._pc.addTransceiver(track, { direction: 'sendonly', streams: [this._sendStream] });
-            let offer = yield this._pc.createOffer();
-            let localSdpObject = sdpTransform.parse(offer.sdp);
-            let offerMediaObject;
-            const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-            if (encodings && encodings.length > 1) {
-                logger.debug('send() | enabling legacy simulcast');
-                localSdpObject = sdpTransform.parse(offer.sdp);
-                offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
-                sdpUnifiedPlanUtils.addLegacySimulcast({
-                    offerMediaObject,
-                    numStreams: encodings.length
-                });
-                offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
-            }
-            // Special case for VP9 with SVC.
-            let hackVp9Svc = false;
-            const layers = scalabilityModes_1.parse((encodings || [{}])[0].scalabilityMode);
-            if (encodings &&
-                encodings.length === 1 &&
-                layers.spatialLayers > 1 &&
-                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp9') {
-                logger.debug('send() | enabling legacy simulcast for VP9 SVC');
-                hackVp9Svc = true;
-                localSdpObject = sdpTransform.parse(offer.sdp);
-                offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
-                sdpUnifiedPlanUtils.addLegacySimulcast({
-                    offerMediaObject,
-                    numStreams: layers.spatialLayers
-                });
-                offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
-            }
-            logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            // We can now get the transceiver.mid.
-            const localId = transceiver.mid;
-            // Set MID.
-            sendingRtpParameters.mid = localId;
-            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+    async send({ track, encodings, codecOptions }) {
+        this._assertSendDirection();
+        logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+        const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
+        const transceiver = this._pc.addTransceiver(track, { direction: 'sendonly', streams: [this._sendStream] });
+        let offer = await this._pc.createOffer();
+        let localSdpObject = sdpTransform.parse(offer.sdp);
+        let offerMediaObject;
+        const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+        if (encodings && encodings.length > 1) {
+            logger.debug('send() | enabling legacy simulcast');
+            localSdpObject = sdpTransform.parse(offer.sdp);
             offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
-            // Set RTCP CNAME.
-            sendingRtpParameters.rtcp.cname =
-                sdpCommonUtils.getCname({ offerMediaObject });
-            // Set RTP encodings.
-            sendingRtpParameters.encodings =
-                sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
-            // Complete encodings with given values.
-            if (encodings) {
-                for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
-                    if (encodings[idx])
-                        Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
-                }
-            }
-            // Hack for VP9 SVC.
-            if (hackVp9Svc) {
-                sendingRtpParameters.encodings = [sendingRtpParameters.encodings[0]];
-            }
-            // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
-            // each encoding.
-            if (sendingRtpParameters.encodings.length > 1 &&
-                (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
-                    sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
-                for (const encoding of sendingRtpParameters.encodings) {
-                    encoding.scalabilityMode = 'S1T3';
-                }
-            }
-            this._remoteSdp.send({
+            sdpUnifiedPlanUtils.addLegacySimulcast({
                 offerMediaObject,
-                reuseMid: mediaSectionIdx.reuseMid,
-                offerRtpParameters: sendingRtpParameters,
-                answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
-                codecOptions
+                numStreams: encodings.length
             });
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-            // Store in the map.
-            this._mapMidTransceiver.set(localId, transceiver);
-            return {
-                localId,
-                rtpParameters: sendingRtpParameters,
-                rtpSender: transceiver.sender
-            };
-        });
-    }
-    stopSending(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('stopSending() [localId:%s]', localId);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            transceiver.sender.replaceTrack(null);
-            this._pc.removeTrack(transceiver.sender);
-            this._remoteSdp.closeMediaSection(transceiver.mid);
-            const offer = yield this._pc.createOffer();
-            logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-        });
-    }
-    replaceTrack(localId, track) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            yield transceiver.sender.replaceTrack(track);
-        });
-    }
-    setMaxSpatialLayer(localId, spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            const parameters = transceiver.sender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                if (idx <= spatialLayer)
-                    encoding.active = true;
-                else
-                    encoding.active = false;
+            offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
+        }
+        // Special case for VP9 with SVC.
+        let hackVp9Svc = false;
+        const layers = scalabilityModes_1.parse((encodings || [{}])[0].scalabilityMode);
+        if (encodings &&
+            encodings.length === 1 &&
+            layers.spatialLayers > 1 &&
+            sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp9') {
+            logger.debug('send() | enabling legacy simulcast for VP9 SVC');
+            hackVp9Svc = true;
+            localSdpObject = sdpTransform.parse(offer.sdp);
+            offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
+            sdpUnifiedPlanUtils.addLegacySimulcast({
+                offerMediaObject,
+                numStreams: layers.spatialLayers
             });
-            yield transceiver.sender.setParameters(parameters);
-        });
-    }
-    setRtpEncodingParameters(localId, params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            const parameters = transceiver.sender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                parameters.encodings[idx] = Object.assign(Object.assign({}, encoding), params);
-            });
-            yield transceiver.sender.setParameters(parameters);
-        });
-    }
-    getSenderStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            return transceiver.sender.getStats();
-        });
-    }
-    sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const options = {
-                negotiated: true,
-                id: this._nextSendSctpStreamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmitTime: maxPacketLifeTime,
-                maxRetransmits,
-                protocol,
-                priority
-            };
-            logger.debug('sendDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // Increase next id.
-            this._nextSendSctpStreamId =
-                ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
-            // If this is the first DataChannel we need to create the SDP answer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                const offer = yield this._pc.createOffer();
-                const localSdpObject = sdpTransform.parse(offer.sdp);
-                const offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'application');
-                if (!this._transportReady)
-                    yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-                logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                this._remoteSdp.sendSctpAssociation({ offerMediaObject });
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-                this._hasDataChannelMediaSection = true;
+            offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
+        }
+        logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        // We can now get the transceiver.mid.
+        const localId = transceiver.mid;
+        // Set MID.
+        sendingRtpParameters.mid = localId;
+        localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
+        // Set RTCP CNAME.
+        sendingRtpParameters.rtcp.cname =
+            sdpCommonUtils.getCname({ offerMediaObject });
+        // Set RTP encodings.
+        sendingRtpParameters.encodings =
+            sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+        // Complete encodings with given values.
+        if (encodings) {
+            for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
+                if (encodings[idx])
+                    Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
             }
-            const sctpStreamParameters = {
-                streamId: options.id,
-                ordered: options.ordered,
-                maxPacketLifeTime: options.maxPacketLifeTime,
-                maxRetransmits: options.maxRetransmits
-            };
-            return { dataChannel, sctpStreamParameters };
+        }
+        // Hack for VP9 SVC.
+        if (hackVp9Svc) {
+            sendingRtpParameters.encodings = [sendingRtpParameters.encodings[0]];
+        }
+        // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
+        // each encoding.
+        if (sendingRtpParameters.encodings.length > 1 &&
+            (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
+                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
+            for (const encoding of sendingRtpParameters.encodings) {
+                encoding.scalabilityMode = 'S1T3';
+            }
+        }
+        this._remoteSdp.send({
+            offerMediaObject,
+            reuseMid: mediaSectionIdx.reuseMid,
+            offerRtpParameters: sendingRtpParameters,
+            answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
+            codecOptions
         });
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+        // Store in the map.
+        this._mapMidTransceiver.set(localId, transceiver);
+        return {
+            localId,
+            rtpParameters: sendingRtpParameters,
+            rtpSender: transceiver.sender
+        };
     }
-    receive({ trackId, kind, rtpParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
-            const localId = String(this._mapMidTransceiver.size);
-            this._remoteSdp.receive({
-                mid: localId,
-                kind,
-                offerRtpParameters: rtpParameters,
-                streamId: rtpParameters.rtcp.cname,
-                trackId
-            });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            let answer = yield this._pc.createAnswer();
-            const localSdpObject = sdpTransform.parse(answer.sdp);
-            const answerMediaObject = localSdpObject.media
-                .find((m) => String(m.mid) === localId);
-            // May need to modify codec parameters in the answer based on codec
-            // parameters in the offer.
-            sdpCommonUtils.applyCodecParameters({
-                offerRtpParameters: rtpParameters,
-                answerMediaObject
-            });
-            answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+    async stopSending(localId) {
+        this._assertSendDirection();
+        logger.debug('stopSending() [localId:%s]', localId);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        transceiver.sender.replaceTrack(null);
+        this._pc.removeTrack(transceiver.sender);
+        this._remoteSdp.closeMediaSection(transceiver.mid);
+        const offer = await this._pc.createOffer();
+        logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+    }
+    async replaceTrack(localId, track) {
+        this._assertSendDirection();
+        logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        await transceiver.sender.replaceTrack(track);
+    }
+    async setMaxSpatialLayer(localId, spatialLayer) {
+        this._assertSendDirection();
+        logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        const parameters = transceiver.sender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            if (idx <= spatialLayer)
+                encoding.active = true;
+            else
+                encoding.active = false;
+        });
+        await transceiver.sender.setParameters(parameters);
+    }
+    async setRtpEncodingParameters(localId, params) {
+        this._assertSendDirection();
+        logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        const parameters = transceiver.sender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            parameters.encodings[idx] = { ...encoding, ...params };
+        });
+        await transceiver.sender.setParameters(parameters);
+    }
+    async getSenderStats(localId) {
+        this._assertSendDirection();
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        return transceiver.sender.getStats();
+    }
+    async sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
+        this._assertSendDirection();
+        const options = {
+            negotiated: true,
+            id: this._nextSendSctpStreamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmitTime: maxPacketLifeTime,
+            maxRetransmits,
+            protocol,
+            priority
+        };
+        logger.debug('sendDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // Increase next id.
+        this._nextSendSctpStreamId =
+            ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+        // If this is the first DataChannel we need to create the SDP answer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            const offer = await this._pc.createOffer();
+            const localSdpObject = sdpTransform.parse(offer.sdp);
+            const offerMediaObject = localSdpObject.media
+                .find((m) => m.type === 'application');
             if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-            logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-            const transceiver = this._pc.getTransceivers()
-                .find((t) => t.mid === localId);
-            if (!transceiver)
-                throw new Error('new RTCRtpTransceiver not found');
-            // Store in the map.
-            this._mapMidTransceiver.set(localId, transceiver);
-            return {
-                localId,
-                track: transceiver.receiver.track,
-                rtpReceiver: transceiver.receiver
-            };
-        });
+                await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+            logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            this._remoteSdp.sendSctpAssociation({ offerMediaObject });
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        const sctpStreamParameters = {
+            streamId: options.id,
+            ordered: options.ordered,
+            maxPacketLifeTime: options.maxPacketLifeTime,
+            maxRetransmits: options.maxRetransmits
+        };
+        return { dataChannel, sctpStreamParameters };
     }
-    stopReceiving(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('stopReceiving() [localId:%s]', localId);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            this._remoteSdp.closeMediaSection(transceiver.mid);
+    async receive({ trackId, kind, rtpParameters }) {
+        this._assertRecvDirection();
+        logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
+        const localId = String(this._mapMidTransceiver.size);
+        this._remoteSdp.receive({
+            mid: localId,
+            kind,
+            offerRtpParameters: rtpParameters,
+            streamId: rtpParameters.rtcp.cname,
+            trackId
+        });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        let answer = await this._pc.createAnswer();
+        const localSdpObject = sdpTransform.parse(answer.sdp);
+        const answerMediaObject = localSdpObject.media
+            .find((m) => String(m.mid) === localId);
+        // May need to modify codec parameters in the answer based on codec
+        // parameters in the offer.
+        sdpCommonUtils.applyCodecParameters({
+            offerRtpParameters: rtpParameters,
+            answerMediaObject
+        });
+        answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
+        logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+        const transceiver = this._pc.getTransceivers()
+            .find((t) => t.mid === localId);
+        if (!transceiver)
+            throw new Error('new RTCRtpTransceiver not found');
+        // Store in the map.
+        this._mapMidTransceiver.set(localId, transceiver);
+        return {
+            localId,
+            track: transceiver.receiver.track,
+            rtpReceiver: transceiver.receiver
+        };
+    }
+    async stopReceiving(localId) {
+        this._assertRecvDirection();
+        logger.debug('stopReceiving() [localId:%s]', localId);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        this._remoteSdp.closeMediaSection(transceiver.mid);
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        const answer = await this._pc.createAnswer();
+        logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+    }
+    async getReceiverStats(localId) {
+        this._assertRecvDirection();
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        return transceiver.receiver.getStats();
+    }
+    async receiveDataChannel({ sctpStreamParameters, label, protocol }) {
+        this._assertRecvDirection();
+        const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
+        const options = {
+            negotiated: true,
+            id: streamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmitTime: maxPacketLifeTime,
+            maxRetransmits,
+            protocol
+        };
+        logger.debug('receiveDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // If this is the first DataChannel we need to create the SDP offer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            this._remoteSdp.receiveSctpAssociation();
             const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            const answer = yield this._pc.createAnswer();
-            logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-        });
-    }
-    getReceiverStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            return transceiver.receiver.getStats();
-        });
-    }
-    receiveDataChannel({ sctpStreamParameters, label, protocol }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
-            const options = {
-                negotiated: true,
-                id: streamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmitTime: maxPacketLifeTime,
-                maxRetransmits,
-                protocol
-            };
-            logger.debug('receiveDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // If this is the first DataChannel we need to create the SDP offer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                this._remoteSdp.receiveSctpAssociation();
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                if (!this._transportReady) {
-                    const localSdpObject = sdpTransform.parse(answer.sdp);
-                    yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-                }
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-                this._hasDataChannelMediaSection = true;
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            if (!this._transportReady) {
+                const localSdpObject = sdpTransform.parse(answer.sdp);
+                await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
             }
-            return { dataChannel };
-        });
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        return { dataChannel };
     }
-    _setupTransport({ localDtlsRole, localSdpObject }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!localSdpObject)
-                localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            // Get our local DTLS parameters.
-            const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
-            // Set our DTLS role.
-            dtlsParameters.role = localDtlsRole;
-            // Update the remote DTLS role in the SDP.
-            this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
-            // Need to tell the remote transport about our parameters.
-            yield this.safeEmitAsPromise('@connect', { dtlsParameters });
-            this._transportReady = true;
-        });
+    async _setupTransport({ localDtlsRole, localSdpObject }) {
+        if (!localSdpObject)
+            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        // Get our local DTLS parameters.
+        const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
+        // Set our DTLS role.
+        dtlsParameters.role = localDtlsRole;
+        // Update the remote DTLS role in the SDP.
+        this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
+        // Need to tell the remote transport about our parameters.
+        await this.safeEmitAsPromise('@connect', { dtlsParameters });
+        this._transportReady = true;
     }
     _assertSendDirection() {
         if (this._direction !== 'send') {

--- a/lib/handlers/Chrome74.js
+++ b/lib/handlers/Chrome74.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -60,44 +51,40 @@ class Chrome74 extends HandlerInterface_1.HandlerInterface {
             catch (error) { }
         }
     }
-    getNativeRtpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeRtpCapabilities()');
-            const pc = new RTCPeerConnection({
-                iceServers: [],
-                iceTransportPolicy: 'all',
-                bundlePolicy: 'max-bundle',
-                rtcpMuxPolicy: 'require',
-                sdpSemantics: 'unified-plan'
-            });
+    async getNativeRtpCapabilities() {
+        logger.debug('getNativeRtpCapabilities()');
+        const pc = new RTCPeerConnection({
+            iceServers: [],
+            iceTransportPolicy: 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'unified-plan'
+        });
+        try {
+            pc.addTransceiver('audio');
+            pc.addTransceiver('video');
+            const offer = await pc.createOffer();
             try {
-                pc.addTransceiver('audio');
-                pc.addTransceiver('video');
-                const offer = yield pc.createOffer();
-                try {
-                    pc.close();
-                }
-                catch (error) { }
-                const sdpObject = sdpTransform.parse(offer.sdp);
-                const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
-                return nativeRtpCapabilities;
+                pc.close();
             }
-            catch (error) {
-                try {
-                    pc.close();
-                }
-                catch (error2) { }
-                throw error;
+            catch (error) { }
+            const sdpObject = sdpTransform.parse(offer.sdp);
+            const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+            return nativeRtpCapabilities;
+        }
+        catch (error) {
+            try {
+                pc.close();
             }
-        });
+            catch (error2) { }
+            throw error;
+        }
     }
-    getNativeSctpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeSctpCapabilities()');
-            return {
-                numStreams: SCTP_NUM_STREAMS
-            };
-        });
+    async getNativeSctpCapabilities() {
+        logger.debug('getNativeSctpCapabilities()');
+        return {
+            numStreams: SCTP_NUM_STREAMS
+        };
     }
     run({ direction, iceParameters, iceCandidates, dtlsParameters, sctpParameters, iceServers, iceTransportPolicy, additionalSettings, proprietaryConstraints, extendedRtpCapabilities }) {
         logger.debug('run()');
@@ -118,7 +105,14 @@ class Chrome74 extends HandlerInterface_1.HandlerInterface {
                 audio: ortc.getSendingRemoteRtpParameters('audio', extendedRtpCapabilities),
                 video: ortc.getSendingRemoteRtpParameters('video', extendedRtpCapabilities)
             };
-        this._pc = new RTCPeerConnection(Object.assign({ iceServers: iceServers || [], iceTransportPolicy: iceTransportPolicy || 'all', bundlePolicy: 'max-bundle', rtcpMuxPolicy: 'require', sdpSemantics: 'unified-plan' }, additionalSettings), proprietaryConstraints);
+        this._pc = new RTCPeerConnection({
+            iceServers: iceServers || [],
+            iceTransportPolicy: iceTransportPolicy || 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'unified-plan',
+            ...additionalSettings
+        }, proprietaryConstraints);
         // Handle RTCPeerConnection connection status.
         this._pc.addEventListener('iceconnectionstatechange', () => {
             switch (this._pc.iceConnectionState) {
@@ -141,367 +135,337 @@ class Chrome74 extends HandlerInterface_1.HandlerInterface {
             }
         });
     }
-    updateIceServers(iceServers) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('updateIceServers()');
-            const configuration = this._pc.getConfiguration();
-            configuration.iceServers = iceServers;
-            this._pc.setConfiguration(configuration);
-        });
+    async updateIceServers(iceServers) {
+        logger.debug('updateIceServers()');
+        const configuration = this._pc.getConfiguration();
+        configuration.iceServers = iceServers;
+        this._pc.setConfiguration(configuration);
     }
-    restartIce(iceParameters) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            // Provide the remote SDP handler with new remote ICE parameters.
-            this._remoteSdp.updateIceParameters(iceParameters);
-            if (!this._transportReady)
-                return;
-            if (this._direction === 'send') {
-                const offer = yield this._pc.createOffer({ iceRestart: true });
-                logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-            }
-            else {
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-            }
-        });
+    async restartIce(iceParameters) {
+        logger.debug('restartIce()');
+        // Provide the remote SDP handler with new remote ICE parameters.
+        this._remoteSdp.updateIceParameters(iceParameters);
+        if (!this._transportReady)
+            return;
+        if (this._direction === 'send') {
+            const offer = await this._pc.createOffer({ iceRestart: true });
+            logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+        }
+        else {
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+        }
     }
-    getTransportStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this._pc.getStats();
-        });
+    async getTransportStats() {
+        return this._pc.getStats();
     }
-    send({ track, encodings, codecOptions }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
-            if (encodings && encodings.length > 1) {
-                encodings.forEach((encoding, idx) => {
-                    encoding.rid = `r${idx}`;
-                });
-            }
-            const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
-            const transceiver = this._pc.addTransceiver(track, {
-                direction: 'sendonly',
-                streams: [this._sendStream],
-                sendEncodings: encodings
+    async send({ track, encodings, codecOptions }) {
+        this._assertSendDirection();
+        logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+        if (encodings && encodings.length > 1) {
+            encodings.forEach((encoding, idx) => {
+                encoding.rid = `r${idx}`;
             });
-            let offer = yield this._pc.createOffer();
-            let localSdpObject = sdpTransform.parse(offer.sdp);
-            let offerMediaObject;
-            const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-            // Special case for VP9 with SVC.
-            let hackVp9Svc = false;
-            const layers = scalabilityModes_1.parse((encodings || [{}])[0].scalabilityMode);
-            if (encodings &&
-                encodings.length === 1 &&
-                layers.spatialLayers > 1 &&
-                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp9') {
-                logger.debug('send() | enabling legacy simulcast for VP9 SVC');
-                hackVp9Svc = true;
-                localSdpObject = sdpTransform.parse(offer.sdp);
-                offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
-                sdpUnifiedPlanUtils.addLegacySimulcast({
-                    offerMediaObject,
-                    numStreams: layers.spatialLayers
-                });
-                offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
-            }
-            logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            // We can now get the transceiver.mid.
-            const localId = transceiver.mid;
-            // Set MID.
-            sendingRtpParameters.mid = localId;
-            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        }
+        const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
+        const transceiver = this._pc.addTransceiver(track, {
+            direction: 'sendonly',
+            streams: [this._sendStream],
+            sendEncodings: encodings
+        });
+        let offer = await this._pc.createOffer();
+        let localSdpObject = sdpTransform.parse(offer.sdp);
+        let offerMediaObject;
+        const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+        // Special case for VP9 with SVC.
+        let hackVp9Svc = false;
+        const layers = scalabilityModes_1.parse((encodings || [{}])[0].scalabilityMode);
+        if (encodings &&
+            encodings.length === 1 &&
+            layers.spatialLayers > 1 &&
+            sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp9') {
+            logger.debug('send() | enabling legacy simulcast for VP9 SVC');
+            hackVp9Svc = true;
+            localSdpObject = sdpTransform.parse(offer.sdp);
             offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
-            // Set RTCP CNAME.
-            sendingRtpParameters.rtcp.cname =
-                sdpCommonUtils.getCname({ offerMediaObject });
-            // Set RTP encodings by parsing the SDP offer if no encodings are given.
-            if (!encodings) {
-                sendingRtpParameters.encodings =
-                    sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
-            }
-            // Set RTP encodings by parsing the SDP offer and complete them with given
-            // one if just a single encoding has been given.
-            else if (encodings.length === 1) {
-                let newEncodings = sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
-                Object.assign(newEncodings[0], encodings[0]);
-                // Hack for VP9 SVC.
-                if (hackVp9Svc)
-                    newEncodings = [newEncodings[0]];
-                sendingRtpParameters.encodings = newEncodings;
-            }
-            // Otherwise if more than 1 encoding are given use them verbatim.
-            else {
-                sendingRtpParameters.encodings = encodings;
-            }
-            // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
-            // each encoding.
-            if (sendingRtpParameters.encodings.length > 1 &&
-                (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
-                    sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
-                for (const encoding of sendingRtpParameters.encodings) {
-                    encoding.scalabilityMode = 'S1T3';
-                }
-            }
-            this._remoteSdp.send({
+            sdpUnifiedPlanUtils.addLegacySimulcast({
                 offerMediaObject,
-                reuseMid: mediaSectionIdx.reuseMid,
-                offerRtpParameters: sendingRtpParameters,
-                answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
-                codecOptions,
-                extmapAllowMixed: true
+                numStreams: layers.spatialLayers
             });
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-            // Store in the map.
-            this._mapMidTransceiver.set(localId, transceiver);
-            return {
-                localId,
-                rtpParameters: sendingRtpParameters,
-                rtpSender: transceiver.sender
-            };
-        });
-    }
-    stopSending(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('stopSending() [localId:%s]', localId);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            transceiver.sender.replaceTrack(null);
-            this._pc.removeTrack(transceiver.sender);
-            this._remoteSdp.closeMediaSection(transceiver.mid);
-            const offer = yield this._pc.createOffer();
-            logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-        });
-    }
-    replaceTrack(localId, track) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            yield transceiver.sender.replaceTrack(track);
-        });
-    }
-    setMaxSpatialLayer(localId, spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            const parameters = transceiver.sender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                if (idx <= spatialLayer)
-                    encoding.active = true;
-                else
-                    encoding.active = false;
-            });
-            yield transceiver.sender.setParameters(parameters);
-        });
-    }
-    setRtpEncodingParameters(localId, params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            const parameters = transceiver.sender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                parameters.encodings[idx] = Object.assign(Object.assign({}, encoding), params);
-            });
-            yield transceiver.sender.setParameters(parameters);
-        });
-    }
-    getSenderStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            return transceiver.sender.getStats();
-        });
-    }
-    sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const options = {
-                negotiated: true,
-                id: this._nextSendSctpStreamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmits,
-                protocol,
-                priority
-            };
-            logger.debug('sendDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // Increase next id.
-            this._nextSendSctpStreamId =
-                ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
-            // If this is the first DataChannel we need to create the SDP answer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                const offer = yield this._pc.createOffer();
-                const localSdpObject = sdpTransform.parse(offer.sdp);
-                const offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'application');
-                if (!this._transportReady)
-                    yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-                logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                this._remoteSdp.sendSctpAssociation({ offerMediaObject });
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-                this._hasDataChannelMediaSection = true;
+            offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
+        }
+        logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        // We can now get the transceiver.mid.
+        const localId = transceiver.mid;
+        // Set MID.
+        sendingRtpParameters.mid = localId;
+        localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
+        // Set RTCP CNAME.
+        sendingRtpParameters.rtcp.cname =
+            sdpCommonUtils.getCname({ offerMediaObject });
+        // Set RTP encodings by parsing the SDP offer if no encodings are given.
+        if (!encodings) {
+            sendingRtpParameters.encodings =
+                sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+        }
+        // Set RTP encodings by parsing the SDP offer and complete them with given
+        // one if just a single encoding has been given.
+        else if (encodings.length === 1) {
+            let newEncodings = sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+            Object.assign(newEncodings[0], encodings[0]);
+            // Hack for VP9 SVC.
+            if (hackVp9Svc)
+                newEncodings = [newEncodings[0]];
+            sendingRtpParameters.encodings = newEncodings;
+        }
+        // Otherwise if more than 1 encoding are given use them verbatim.
+        else {
+            sendingRtpParameters.encodings = encodings;
+        }
+        // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
+        // each encoding.
+        if (sendingRtpParameters.encodings.length > 1 &&
+            (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
+                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
+            for (const encoding of sendingRtpParameters.encodings) {
+                encoding.scalabilityMode = 'S1T3';
             }
-            const sctpStreamParameters = {
-                streamId: options.id,
-                ordered: options.ordered,
-                maxPacketLifeTime: options.maxPacketLifeTime,
-                maxRetransmits: options.maxRetransmits
-            };
-            return { dataChannel, sctpStreamParameters };
+        }
+        this._remoteSdp.send({
+            offerMediaObject,
+            reuseMid: mediaSectionIdx.reuseMid,
+            offerRtpParameters: sendingRtpParameters,
+            answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
+            codecOptions,
+            extmapAllowMixed: true
         });
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+        // Store in the map.
+        this._mapMidTransceiver.set(localId, transceiver);
+        return {
+            localId,
+            rtpParameters: sendingRtpParameters,
+            rtpSender: transceiver.sender
+        };
     }
-    receive({ trackId, kind, rtpParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
-            const localId = String(this._mapMidTransceiver.size);
-            this._remoteSdp.receive({
-                mid: localId,
-                kind,
-                offerRtpParameters: rtpParameters,
-                streamId: rtpParameters.rtcp.cname,
-                trackId
-            });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            let answer = yield this._pc.createAnswer();
-            const localSdpObject = sdpTransform.parse(answer.sdp);
-            const answerMediaObject = localSdpObject.media
-                .find((m) => String(m.mid) === localId);
-            // May need to modify codec parameters in the answer based on codec
-            // parameters in the offer.
-            sdpCommonUtils.applyCodecParameters({
-                offerRtpParameters: rtpParameters,
-                answerMediaObject
-            });
-            answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+    async stopSending(localId) {
+        this._assertSendDirection();
+        logger.debug('stopSending() [localId:%s]', localId);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        transceiver.sender.replaceTrack(null);
+        this._pc.removeTrack(transceiver.sender);
+        this._remoteSdp.closeMediaSection(transceiver.mid);
+        const offer = await this._pc.createOffer();
+        logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+    }
+    async replaceTrack(localId, track) {
+        this._assertSendDirection();
+        logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        await transceiver.sender.replaceTrack(track);
+    }
+    async setMaxSpatialLayer(localId, spatialLayer) {
+        this._assertSendDirection();
+        logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        const parameters = transceiver.sender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            if (idx <= spatialLayer)
+                encoding.active = true;
+            else
+                encoding.active = false;
+        });
+        await transceiver.sender.setParameters(parameters);
+    }
+    async setRtpEncodingParameters(localId, params) {
+        this._assertSendDirection();
+        logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        const parameters = transceiver.sender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            parameters.encodings[idx] = { ...encoding, ...params };
+        });
+        await transceiver.sender.setParameters(parameters);
+    }
+    async getSenderStats(localId) {
+        this._assertSendDirection();
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        return transceiver.sender.getStats();
+    }
+    async sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
+        this._assertSendDirection();
+        const options = {
+            negotiated: true,
+            id: this._nextSendSctpStreamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmits,
+            protocol,
+            priority
+        };
+        logger.debug('sendDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // Increase next id.
+        this._nextSendSctpStreamId =
+            ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+        // If this is the first DataChannel we need to create the SDP answer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            const offer = await this._pc.createOffer();
+            const localSdpObject = sdpTransform.parse(offer.sdp);
+            const offerMediaObject = localSdpObject.media
+                .find((m) => m.type === 'application');
             if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-            logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-            const transceiver = this._pc.getTransceivers()
-                .find((t) => t.mid === localId);
-            if (!transceiver)
-                throw new Error('new RTCRtpTransceiver not found');
-            // Store in the map.
-            this._mapMidTransceiver.set(localId, transceiver);
-            return {
-                localId,
-                track: transceiver.receiver.track,
-                rtpReceiver: transceiver.receiver
-            };
-        });
+                await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+            logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            this._remoteSdp.sendSctpAssociation({ offerMediaObject });
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        const sctpStreamParameters = {
+            streamId: options.id,
+            ordered: options.ordered,
+            maxPacketLifeTime: options.maxPacketLifeTime,
+            maxRetransmits: options.maxRetransmits
+        };
+        return { dataChannel, sctpStreamParameters };
     }
-    stopReceiving(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('stopReceiving() [localId:%s]', localId);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            this._remoteSdp.closeMediaSection(transceiver.mid);
+    async receive({ trackId, kind, rtpParameters }) {
+        this._assertRecvDirection();
+        logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
+        const localId = String(this._mapMidTransceiver.size);
+        this._remoteSdp.receive({
+            mid: localId,
+            kind,
+            offerRtpParameters: rtpParameters,
+            streamId: rtpParameters.rtcp.cname,
+            trackId
+        });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        let answer = await this._pc.createAnswer();
+        const localSdpObject = sdpTransform.parse(answer.sdp);
+        const answerMediaObject = localSdpObject.media
+            .find((m) => String(m.mid) === localId);
+        // May need to modify codec parameters in the answer based on codec
+        // parameters in the offer.
+        sdpCommonUtils.applyCodecParameters({
+            offerRtpParameters: rtpParameters,
+            answerMediaObject
+        });
+        answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
+        logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+        const transceiver = this._pc.getTransceivers()
+            .find((t) => t.mid === localId);
+        if (!transceiver)
+            throw new Error('new RTCRtpTransceiver not found');
+        // Store in the map.
+        this._mapMidTransceiver.set(localId, transceiver);
+        return {
+            localId,
+            track: transceiver.receiver.track,
+            rtpReceiver: transceiver.receiver
+        };
+    }
+    async stopReceiving(localId) {
+        this._assertRecvDirection();
+        logger.debug('stopReceiving() [localId:%s]', localId);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        this._remoteSdp.closeMediaSection(transceiver.mid);
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        const answer = await this._pc.createAnswer();
+        logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+    }
+    async getReceiverStats(localId) {
+        this._assertRecvDirection();
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        return transceiver.receiver.getStats();
+    }
+    async receiveDataChannel({ sctpStreamParameters, label, protocol }) {
+        this._assertRecvDirection();
+        const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
+        const options = {
+            negotiated: true,
+            id: streamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmits,
+            protocol
+        };
+        logger.debug('receiveDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // If this is the first DataChannel we need to create the SDP offer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            this._remoteSdp.receiveSctpAssociation();
             const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            const answer = yield this._pc.createAnswer();
-            logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-        });
-    }
-    getReceiverStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            return transceiver.receiver.getStats();
-        });
-    }
-    receiveDataChannel({ sctpStreamParameters, label, protocol }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
-            const options = {
-                negotiated: true,
-                id: streamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmits,
-                protocol
-            };
-            logger.debug('receiveDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // If this is the first DataChannel we need to create the SDP offer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                this._remoteSdp.receiveSctpAssociation();
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                if (!this._transportReady) {
-                    const localSdpObject = sdpTransform.parse(answer.sdp);
-                    yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-                }
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-                this._hasDataChannelMediaSection = true;
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            if (!this._transportReady) {
+                const localSdpObject = sdpTransform.parse(answer.sdp);
+                await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
             }
-            return { dataChannel };
-        });
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        return { dataChannel };
     }
-    _setupTransport({ localDtlsRole, localSdpObject }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!localSdpObject)
-                localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            // Get our local DTLS parameters.
-            const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
-            // Set our DTLS role.
-            dtlsParameters.role = localDtlsRole;
-            // Update the remote DTLS role in the SDP.
-            this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
-            // Need to tell the remote transport about our parameters.
-            yield this.safeEmitAsPromise('@connect', { dtlsParameters });
-            this._transportReady = true;
-        });
+    async _setupTransport({ localDtlsRole, localSdpObject }) {
+        if (!localSdpObject)
+            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        // Get our local DTLS parameters.
+        const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
+        // Set our DTLS role.
+        dtlsParameters.role = localDtlsRole;
+        // Update the remote DTLS role in the SDP.
+        this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
+        // Need to tell the remote transport about our parameters.
+        await this.safeEmitAsPromise('@connect', { dtlsParameters });
+        this._transportReady = true;
     }
     _assertSendDirection() {
         if (this._direction !== 'send') {

--- a/lib/handlers/Edge11.js
+++ b/lib/handlers/Edge11.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -77,19 +68,15 @@ class Edge11 extends HandlerInterface_1.HandlerInterface {
             catch (error) { }
         }
     }
-    getNativeRtpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeRtpCapabilities()');
-            return edgeUtils.getCapabilities();
-        });
+    async getNativeRtpCapabilities() {
+        logger.debug('getNativeRtpCapabilities()');
+        return edgeUtils.getCapabilities();
     }
-    getNativeSctpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeSctpCapabilities()');
-            return {
-                numStreams: { OS: 0, MIS: 0 }
-            };
-        });
+    async getNativeSctpCapabilities() {
+        logger.debug('getNativeSctpCapabilities()');
+        return {
+            numStreams: { OS: 0, MIS: 0 }
+        };
     }
     run({ direction, // eslint-disable-line @typescript-eslint/no-unused-vars
     iceParameters, iceCandidates, dtlsParameters, sctpParameters, // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -111,200 +98,172 @@ class Edge11 extends HandlerInterface_1.HandlerInterface {
         this._setDtlsTransport();
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    updateIceServers(iceServers) {
-        return __awaiter(this, void 0, void 0, function* () {
-            // NOTE: Edge 11 does not implement iceGatherer.gater().
-            throw new errors_1.UnsupportedError('not supported');
-        });
+    async updateIceServers(iceServers) {
+        // NOTE: Edge 11 does not implement iceGatherer.gater().
+        throw new errors_1.UnsupportedError('not supported');
     }
-    restartIce(iceParameters) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            this._remoteIceParameters = iceParameters;
-            if (!this._transportReady)
-                return;
-            logger.debug('restartIce() | calling iceTransport.start()');
-            this._iceTransport.start(this._iceGatherer, iceParameters, 'controlling');
-            for (const candidate of this._remoteIceCandidates) {
-                this._iceTransport.addRemoteCandidate(candidate);
-            }
-            this._iceTransport.addRemoteCandidate({});
-        });
+    async restartIce(iceParameters) {
+        logger.debug('restartIce()');
+        this._remoteIceParameters = iceParameters;
+        if (!this._transportReady)
+            return;
+        logger.debug('restartIce() | calling iceTransport.start()');
+        this._iceTransport.start(this._iceGatherer, iceParameters, 'controlling');
+        for (const candidate of this._remoteIceCandidates) {
+            this._iceTransport.addRemoteCandidate(candidate);
+        }
+        this._iceTransport.addRemoteCandidate({});
     }
-    getTransportStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this._iceTransport.getStats();
-        });
+    async getTransportStats() {
+        return this._iceTransport.getStats();
     }
-    send(
+    async send(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     { track, encodings, codecOptions }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'server' });
-            logger.debug('send() | calling new RTCRtpSender()');
-            const rtpSender = new RTCRtpSender(track, this._dtlsTransport);
-            const rtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
-            const useRtx = rtpParameters.codecs
-                .some((codec) => /.+\/rtx$/i.test(codec.mimeType));
-            if (!encodings)
-                encodings = [{}];
-            for (const encoding of encodings) {
-                encoding.ssrc = utils.generateRandomNumber();
-                if (useRtx)
-                    encoding.rtx = { ssrc: utils.generateRandomNumber() };
-            }
-            rtpParameters.encodings = encodings;
-            // Fill RTCRtpParameters.rtcp.
-            rtpParameters.rtcp =
-                {
-                    cname: this._cname,
-                    reducedSize: true,
-                    mux: true
-                };
-            // NOTE: Convert our standard RTCRtpParameters into those that Edge
-            // expects.
-            const edgeRtpParameters = edgeUtils.mangleRtpParameters(rtpParameters);
-            logger.debug('send() | calling rtpSender.send() [params:%o]', edgeRtpParameters);
-            yield rtpSender.send(edgeRtpParameters);
-            const localId = String(this._nextSendLocalId);
-            this._nextSendLocalId++;
-            // Store it.
-            this._rtpSenders.set(localId, rtpSender);
-            return { localId, rtpParameters, rtpSender };
-        });
-    }
-    stopSending(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('stopSending() [localId:%s]', localId);
-            const rtpSender = this._rtpSenders.get(localId);
-            if (!rtpSender)
-                throw new Error('RTCRtpSender not found');
-            this._rtpSenders.delete(localId);
-            try {
-                logger.debug('stopSending() | calling rtpSender.stop()');
-                rtpSender.stop();
-            }
-            catch (error) {
-                logger.warn('stopSending() | rtpSender.stop() failed:%o', error);
-                throw error;
-            }
-        });
-    }
-    replaceTrack(localId, track) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
-            const rtpSender = this._rtpSenders.get(localId);
-            if (!rtpSender)
-                throw new Error('RTCRtpSender not found');
-            const oldTrack = rtpSender.track;
-            rtpSender.setTrack(track);
-            // Replace key.
-            this._rtpSenders.delete(oldTrack.id);
-            this._rtpSenders.set(track.id, rtpSender);
-        });
-    }
-    setMaxSpatialLayer(localId, spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
-            const rtpSender = this._rtpSenders.get(localId);
-            if (!rtpSender)
-                throw new Error('RTCRtpSender not found');
-            const parameters = rtpSender.getParameters();
-            parameters.encodings
-                .forEach((encoding, idx) => {
-                if (idx <= spatialLayer)
-                    encoding.active = true;
-                else
-                    encoding.active = false;
-            });
-            yield rtpSender.setParameters(parameters);
-        });
-    }
-    setRtpEncodingParameters(localId, params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
-            const rtpSender = this._rtpSenders.get(localId);
-            if (!rtpSender)
-                throw new Error('RTCRtpSender not found');
-            const parameters = rtpSender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                parameters.encodings[idx] = Object.assign(Object.assign({}, encoding), params);
-            });
-            yield rtpSender.setParameters(parameters);
-        });
-    }
-    getSenderStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const rtpSender = this._rtpSenders.get(localId);
-            if (!rtpSender)
-                throw new Error('RTCRtpSender not found');
-            return rtpSender.getStats();
-        });
-    }
-    sendDataChannel(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    options) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
-        });
-    }
-    receive({ trackId, kind, rtpParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'server' });
-            logger.debug('receive() | calling new RTCRtpReceiver()');
-            const rtpReceiver = new RTCRtpReceiver(this._dtlsTransport, kind);
-            rtpReceiver.addEventListener('error', (event) => {
-                logger.error('rtpReceiver "error" event [event:%o]', event);
-            });
-            // NOTE: Convert our standard RTCRtpParameters into those that Edge
-            // expects.
-            const edgeRtpParameters = edgeUtils.mangleRtpParameters(rtpParameters);
-            logger.debug('receive() | calling rtpReceiver.receive() [params:%o]', edgeRtpParameters);
-            yield rtpReceiver.receive(edgeRtpParameters);
-            const localId = trackId;
-            // Store it.
-            this._rtpReceivers.set(localId, rtpReceiver);
-            return {
-                localId,
-                track: rtpReceiver.track,
-                rtpReceiver
+        logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'server' });
+        logger.debug('send() | calling new RTCRtpSender()');
+        const rtpSender = new RTCRtpSender(track, this._dtlsTransport);
+        const rtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
+        const useRtx = rtpParameters.codecs
+            .some((codec) => /.+\/rtx$/i.test(codec.mimeType));
+        if (!encodings)
+            encodings = [{}];
+        for (const encoding of encodings) {
+            encoding.ssrc = utils.generateRandomNumber();
+            if (useRtx)
+                encoding.rtx = { ssrc: utils.generateRandomNumber() };
+        }
+        rtpParameters.encodings = encodings;
+        // Fill RTCRtpParameters.rtcp.
+        rtpParameters.rtcp =
+            {
+                cname: this._cname,
+                reducedSize: true,
+                mux: true
             };
-        });
+        // NOTE: Convert our standard RTCRtpParameters into those that Edge
+        // expects.
+        const edgeRtpParameters = edgeUtils.mangleRtpParameters(rtpParameters);
+        logger.debug('send() | calling rtpSender.send() [params:%o]', edgeRtpParameters);
+        await rtpSender.send(edgeRtpParameters);
+        const localId = String(this._nextSendLocalId);
+        this._nextSendLocalId++;
+        // Store it.
+        this._rtpSenders.set(localId, rtpSender);
+        return { localId, rtpParameters, rtpSender };
     }
-    stopReceiving(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('stopReceiving() [localId:%s]', localId);
-            const rtpReceiver = this._rtpReceivers.get(localId);
-            if (!rtpReceiver)
-                throw new Error('RTCRtpReceiver not found');
-            this._rtpReceivers.delete(localId);
-            try {
-                logger.debug('stopReceiving() | calling rtpReceiver.stop()');
-                rtpReceiver.stop();
-            }
-            catch (error) {
-                logger.warn('stopReceiving() | rtpReceiver.stop() failed:%o', error);
-            }
-        });
+    async stopSending(localId) {
+        logger.debug('stopSending() [localId:%s]', localId);
+        const rtpSender = this._rtpSenders.get(localId);
+        if (!rtpSender)
+            throw new Error('RTCRtpSender not found');
+        this._rtpSenders.delete(localId);
+        try {
+            logger.debug('stopSending() | calling rtpSender.stop()');
+            rtpSender.stop();
+        }
+        catch (error) {
+            logger.warn('stopSending() | rtpSender.stop() failed:%o', error);
+            throw error;
+        }
     }
-    getReceiverStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const rtpReceiver = this._rtpReceivers.get(localId);
-            if (!rtpReceiver)
-                throw new Error('RTCRtpReceiver not found');
-            return rtpReceiver.getStats();
-        });
+    async replaceTrack(localId, track) {
+        logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
+        const rtpSender = this._rtpSenders.get(localId);
+        if (!rtpSender)
+            throw new Error('RTCRtpSender not found');
+        const oldTrack = rtpSender.track;
+        rtpSender.setTrack(track);
+        // Replace key.
+        this._rtpSenders.delete(oldTrack.id);
+        this._rtpSenders.set(track.id, rtpSender);
     }
-    receiveDataChannel(
+    async setMaxSpatialLayer(localId, spatialLayer) {
+        logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
+        const rtpSender = this._rtpSenders.get(localId);
+        if (!rtpSender)
+            throw new Error('RTCRtpSender not found');
+        const parameters = rtpSender.getParameters();
+        parameters.encodings
+            .forEach((encoding, idx) => {
+            if (idx <= spatialLayer)
+                encoding.active = true;
+            else
+                encoding.active = false;
+        });
+        await rtpSender.setParameters(parameters);
+    }
+    async setRtpEncodingParameters(localId, params) {
+        logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
+        const rtpSender = this._rtpSenders.get(localId);
+        if (!rtpSender)
+            throw new Error('RTCRtpSender not found');
+        const parameters = rtpSender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            parameters.encodings[idx] = { ...encoding, ...params };
+        });
+        await rtpSender.setParameters(parameters);
+    }
+    async getSenderStats(localId) {
+        const rtpSender = this._rtpSenders.get(localId);
+        if (!rtpSender)
+            throw new Error('RTCRtpSender not found');
+        return rtpSender.getStats();
+    }
+    async sendDataChannel(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
+        throw new errors_1.UnsupportedError('not implemented');
+    }
+    async receive({ trackId, kind, rtpParameters }) {
+        logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'server' });
+        logger.debug('receive() | calling new RTCRtpReceiver()');
+        const rtpReceiver = new RTCRtpReceiver(this._dtlsTransport, kind);
+        rtpReceiver.addEventListener('error', (event) => {
+            logger.error('rtpReceiver "error" event [event:%o]', event);
         });
+        // NOTE: Convert our standard RTCRtpParameters into those that Edge
+        // expects.
+        const edgeRtpParameters = edgeUtils.mangleRtpParameters(rtpParameters);
+        logger.debug('receive() | calling rtpReceiver.receive() [params:%o]', edgeRtpParameters);
+        await rtpReceiver.receive(edgeRtpParameters);
+        const localId = trackId;
+        // Store it.
+        this._rtpReceivers.set(localId, rtpReceiver);
+        return {
+            localId,
+            track: rtpReceiver.track,
+            rtpReceiver
+        };
+    }
+    async stopReceiving(localId) {
+        logger.debug('stopReceiving() [localId:%s]', localId);
+        const rtpReceiver = this._rtpReceivers.get(localId);
+        if (!rtpReceiver)
+            throw new Error('RTCRtpReceiver not found');
+        this._rtpReceivers.delete(localId);
+        try {
+            logger.debug('stopReceiving() | calling rtpReceiver.stop()');
+            rtpReceiver.stop();
+        }
+        catch (error) {
+            logger.warn('stopReceiving() | rtpReceiver.stop() failed:%o', error);
+        }
+    }
+    async getReceiverStats(localId) {
+        const rtpReceiver = this._rtpReceivers.get(localId);
+        if (!rtpReceiver)
+            throw new Error('RTCRtpReceiver not found');
+        return rtpReceiver.getStats();
+    }
+    async receiveDataChannel(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    options) {
+        throw new errors_1.UnsupportedError('not implemented');
     }
     _setIceGatherer({ iceServers, iceTransportPolicy }) {
         const iceGatherer = new RTCIceGatherer({
@@ -389,36 +348,34 @@ class Edge11 extends HandlerInterface_1.HandlerInterface {
         });
         this._dtlsTransport = dtlsTransport;
     }
-    _setupTransport({ localDtlsRole }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('_setupTransport()');
-            // Get our local DTLS parameters.
-            const dtlsParameters = this._dtlsTransport.getLocalParameters();
-            dtlsParameters.role = localDtlsRole;
-            // Need to tell the remote transport about our parameters.
-            yield this.safeEmitAsPromise('@connect', { dtlsParameters });
-            // Start the RTCIceTransport.
-            this._iceTransport.start(this._iceGatherer, this._remoteIceParameters, 'controlling');
-            // Add remote ICE candidates.
-            for (const candidate of this._remoteIceCandidates) {
-                this._iceTransport.addRemoteCandidate(candidate);
-            }
-            // Also signal a 'complete' candidate as per spec.
-            // NOTE: It should be {complete: true} but Edge prefers {}.
-            // NOTE: If we don't signal end of candidates, the Edge RTCIceTransport
-            // won't enter the 'completed' state.
-            this._iceTransport.addRemoteCandidate({});
-            // NOTE: Edge does not like SHA less than 256.
-            this._remoteDtlsParameters.fingerprints = this._remoteDtlsParameters.fingerprints
-                .filter((fingerprint) => {
-                return (fingerprint.algorithm === 'sha-256' ||
-                    fingerprint.algorithm === 'sha-384' ||
-                    fingerprint.algorithm === 'sha-512');
-            });
-            // Start the RTCDtlsTransport.
-            this._dtlsTransport.start(this._remoteDtlsParameters);
-            this._transportReady = true;
+    async _setupTransport({ localDtlsRole }) {
+        logger.debug('_setupTransport()');
+        // Get our local DTLS parameters.
+        const dtlsParameters = this._dtlsTransport.getLocalParameters();
+        dtlsParameters.role = localDtlsRole;
+        // Need to tell the remote transport about our parameters.
+        await this.safeEmitAsPromise('@connect', { dtlsParameters });
+        // Start the RTCIceTransport.
+        this._iceTransport.start(this._iceGatherer, this._remoteIceParameters, 'controlling');
+        // Add remote ICE candidates.
+        for (const candidate of this._remoteIceCandidates) {
+            this._iceTransport.addRemoteCandidate(candidate);
+        }
+        // Also signal a 'complete' candidate as per spec.
+        // NOTE: It should be {complete: true} but Edge prefers {}.
+        // NOTE: If we don't signal end of candidates, the Edge RTCIceTransport
+        // won't enter the 'completed' state.
+        this._iceTransport.addRemoteCandidate({});
+        // NOTE: Edge does not like SHA less than 256.
+        this._remoteDtlsParameters.fingerprints = this._remoteDtlsParameters.fingerprints
+            .filter((fingerprint) => {
+            return (fingerprint.algorithm === 'sha-256' ||
+                fingerprint.algorithm === 'sha-384' ||
+                fingerprint.algorithm === 'sha-512');
         });
+        // Start the RTCDtlsTransport.
+        this._dtlsTransport.start(this._remoteDtlsParameters);
+        this._transportReady = true;
     }
 }
 exports.Edge11 = Edge11;

--- a/lib/handlers/Firefox60.js
+++ b/lib/handlers/Firefox60.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -60,72 +51,68 @@ class Firefox60 extends HandlerInterface_1.HandlerInterface {
             catch (error) { }
         }
     }
-    getNativeRtpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeRtpCapabilities()');
-            const pc = new RTCPeerConnection({
-                iceServers: [],
-                iceTransportPolicy: 'all',
-                bundlePolicy: 'max-bundle',
-                rtcpMuxPolicy: 'require'
-            });
-            // NOTE: We need to add a real video track to get the RID extension mapping.
-            const canvas = document.createElement('canvas');
-            // NOTE: Otherwise Firefox fails in next line.
-            canvas.getContext('2d');
-            const fakeStream = canvas.captureStream();
-            const fakeVideoTrack = fakeStream.getVideoTracks()[0];
+    async getNativeRtpCapabilities() {
+        logger.debug('getNativeRtpCapabilities()');
+        const pc = new RTCPeerConnection({
+            iceServers: [],
+            iceTransportPolicy: 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require'
+        });
+        // NOTE: We need to add a real video track to get the RID extension mapping.
+        const canvas = document.createElement('canvas');
+        // NOTE: Otherwise Firefox fails in next line.
+        canvas.getContext('2d');
+        const fakeStream = canvas.captureStream();
+        const fakeVideoTrack = fakeStream.getVideoTracks()[0];
+        try {
+            pc.addTransceiver('audio', { direction: 'sendrecv' });
+            const videoTransceiver = pc.addTransceiver(fakeVideoTrack, { direction: 'sendrecv' });
+            const parameters = videoTransceiver.sender.getParameters();
+            const encodings = [
+                { rid: 'r0', maxBitrate: 100000 },
+                { rid: 'r1', maxBitrate: 500000 }
+            ];
+            parameters.encodings = encodings;
+            await videoTransceiver.sender.setParameters(parameters);
+            const offer = await pc.createOffer();
             try {
-                pc.addTransceiver('audio', { direction: 'sendrecv' });
-                const videoTransceiver = pc.addTransceiver(fakeVideoTrack, { direction: 'sendrecv' });
-                const parameters = videoTransceiver.sender.getParameters();
-                const encodings = [
-                    { rid: 'r0', maxBitrate: 100000 },
-                    { rid: 'r1', maxBitrate: 500000 }
-                ];
-                parameters.encodings = encodings;
-                yield videoTransceiver.sender.setParameters(parameters);
-                const offer = yield pc.createOffer();
-                try {
-                    canvas.remove();
-                }
-                catch (error) { }
-                try {
-                    fakeVideoTrack.stop();
-                }
-                catch (error) { }
-                try {
-                    pc.close();
-                }
-                catch (error) { }
-                const sdpObject = sdpTransform.parse(offer.sdp);
-                const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
-                return nativeRtpCapabilities;
+                canvas.remove();
             }
-            catch (error) {
-                try {
-                    canvas.remove();
-                }
-                catch (error2) { }
-                try {
-                    fakeVideoTrack.stop();
-                }
-                catch (error2) { }
-                try {
-                    pc.close();
-                }
-                catch (error2) { }
-                throw error;
+            catch (error) { }
+            try {
+                fakeVideoTrack.stop();
             }
-        });
+            catch (error) { }
+            try {
+                pc.close();
+            }
+            catch (error) { }
+            const sdpObject = sdpTransform.parse(offer.sdp);
+            const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+            return nativeRtpCapabilities;
+        }
+        catch (error) {
+            try {
+                canvas.remove();
+            }
+            catch (error2) { }
+            try {
+                fakeVideoTrack.stop();
+            }
+            catch (error2) { }
+            try {
+                pc.close();
+            }
+            catch (error2) { }
+            throw error;
+        }
     }
-    getNativeSctpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeSctpCapabilities()');
-            return {
-                numStreams: SCTP_NUM_STREAMS
-            };
-        });
+    async getNativeSctpCapabilities() {
+        logger.debug('getNativeSctpCapabilities()');
+        return {
+            numStreams: SCTP_NUM_STREAMS
+        };
     }
     run({ direction, iceParameters, iceCandidates, dtlsParameters, sctpParameters, iceServers, iceTransportPolicy, additionalSettings, proprietaryConstraints, extendedRtpCapabilities }) {
         logger.debug('run()');
@@ -146,7 +133,13 @@ class Firefox60 extends HandlerInterface_1.HandlerInterface {
                 audio: ortc.getSendingRemoteRtpParameters('audio', extendedRtpCapabilities),
                 video: ortc.getSendingRemoteRtpParameters('video', extendedRtpCapabilities)
             };
-        this._pc = new RTCPeerConnection(Object.assign({ iceServers: iceServers || [], iceTransportPolicy: iceTransportPolicy || 'all', bundlePolicy: 'max-bundle', rtcpMuxPolicy: 'require' }, additionalSettings), proprietaryConstraints);
+        this._pc = new RTCPeerConnection({
+            iceServers: iceServers || [],
+            iceTransportPolicy: iceTransportPolicy || 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            ...additionalSettings
+        }, proprietaryConstraints);
         // Handle RTCPeerConnection connection status.
         this._pc.addEventListener('iceconnectionstatechange', () => {
             switch (this._pc.iceConnectionState) {
@@ -170,361 +163,331 @@ class Firefox60 extends HandlerInterface_1.HandlerInterface {
         });
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    updateIceServers(iceServers) {
-        return __awaiter(this, void 0, void 0, function* () {
-            // NOTE: Firefox does not implement pc.setConfiguration().
-            throw new errors_1.UnsupportedError('not supported');
-        });
+    async updateIceServers(iceServers) {
+        // NOTE: Firefox does not implement pc.setConfiguration().
+        throw new errors_1.UnsupportedError('not supported');
     }
-    restartIce(iceParameters) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            // Provide the remote SDP handler with new remote ICE parameters.
-            this._remoteSdp.updateIceParameters(iceParameters);
+    async restartIce(iceParameters) {
+        logger.debug('restartIce()');
+        // Provide the remote SDP handler with new remote ICE parameters.
+        this._remoteSdp.updateIceParameters(iceParameters);
+        if (!this._transportReady)
+            return;
+        if (this._direction === 'send') {
+            const offer = await this._pc.createOffer({ iceRestart: true });
+            logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+        }
+        else {
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+        }
+    }
+    async getTransportStats() {
+        return this._pc.getStats();
+    }
+    async send({ track, encodings, codecOptions }) {
+        this._assertSendDirection();
+        logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+        let reverseEncodings;
+        if (encodings && encodings.length > 1) {
+            encodings.forEach((encoding, idx) => {
+                encoding.rid = `r${idx}`;
+            });
+            // Clone the encodings and reverse them because Firefox likes them
+            // from high to low.
+            reverseEncodings = utils.clone(encodings).reverse();
+        }
+        // NOTE: Firefox fails sometimes to properly anticipate the closed media
+        // section that it should use, so don't reuse closed media sections.
+        //   https://github.com/versatica/mediasoup-client/issues/104
+        //
+        // const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
+        const transceiver = this._pc.addTransceiver(track, { direction: 'sendonly', streams: [this._sendStream] });
+        // NOTE: This is not spec compliants. Encodings should be given in addTransceiver
+        // second argument, but Firefox does not support it.
+        if (reverseEncodings) {
+            const parameters = transceiver.sender.getParameters();
+            parameters.encodings = reverseEncodings;
+            await transceiver.sender.setParameters(parameters);
+        }
+        const offer = await this._pc.createOffer();
+        let localSdpObject = sdpTransform.parse(offer.sdp);
+        const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
+        // In Firefox use DTLS role client even if we are the "offerer" since
+        // Firefox does not respect ICE-Lite.
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
+        logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        // We can now get the transceiver.mid.
+        const localId = transceiver.mid;
+        // Set MID.
+        sendingRtpParameters.mid = localId;
+        localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        const offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
+        // Set RTCP CNAME.
+        sendingRtpParameters.rtcp.cname =
+            sdpCommonUtils.getCname({ offerMediaObject });
+        // Set RTP encodings by parsing the SDP offer if no encodings are given.
+        if (!encodings) {
+            sendingRtpParameters.encodings =
+                sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+        }
+        // Set RTP encodings by parsing the SDP offer and complete them with given
+        // one if just a single encoding has been given.
+        else if (encodings.length === 1) {
+            const newEncodings = sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+            Object.assign(newEncodings[0], encodings[0]);
+            sendingRtpParameters.encodings = newEncodings;
+        }
+        // Otherwise if more than 1 encoding are given use them verbatim.
+        else {
+            sendingRtpParameters.encodings = encodings;
+        }
+        // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
+        // each encoding.
+        if (sendingRtpParameters.encodings.length > 1 &&
+            (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
+                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
+            for (const encoding of sendingRtpParameters.encodings) {
+                encoding.scalabilityMode = 'S1T3';
+            }
+        }
+        this._remoteSdp.send({
+            offerMediaObject,
+            offerRtpParameters: sendingRtpParameters,
+            answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
+            codecOptions,
+            extmapAllowMixed: true
+        });
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+        // Store in the map.
+        this._mapMidTransceiver.set(localId, transceiver);
+        return {
+            localId,
+            rtpParameters: sendingRtpParameters,
+            rtpSender: transceiver.sender
+        };
+    }
+    async stopSending(localId) {
+        logger.debug('stopSending() [localId:%s]', localId);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated transceiver not found');
+        transceiver.sender.replaceTrack(null);
+        this._pc.removeTrack(transceiver.sender);
+        // NOTE: Cannot use closeMediaSection() due to the the note above in send()
+        // method.
+        // this._remoteSdp.closeMediaSection(transceiver.mid);
+        this._remoteSdp.disableMediaSection(transceiver.mid);
+        const offer = await this._pc.createOffer();
+        logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+    }
+    async replaceTrack(localId, track) {
+        this._assertSendDirection();
+        logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        await transceiver.sender.replaceTrack(track);
+    }
+    async setMaxSpatialLayer(localId, spatialLayer) {
+        this._assertSendDirection();
+        logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated transceiver not found');
+        const parameters = transceiver.sender.getParameters();
+        // NOTE: We require encodings given from low to high, however Firefox
+        // requires them in reverse order, so do magic here.
+        spatialLayer = parameters.encodings.length - 1 - spatialLayer;
+        parameters.encodings.forEach((encoding, idx) => {
+            if (idx >= spatialLayer)
+                encoding.active = true;
+            else
+                encoding.active = false;
+        });
+        await transceiver.sender.setParameters(parameters);
+    }
+    async setRtpEncodingParameters(localId, params) {
+        this._assertSendDirection();
+        logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        const parameters = transceiver.sender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            parameters.encodings[idx] = { ...encoding, ...params };
+        });
+        await transceiver.sender.setParameters(parameters);
+    }
+    async getSenderStats(localId) {
+        this._assertSendDirection();
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        return transceiver.sender.getStats();
+    }
+    async sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
+        this._assertSendDirection();
+        const options = {
+            negotiated: true,
+            id: this._nextSendSctpStreamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmits,
+            protocol,
+            priority
+        };
+        logger.debug('sendDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // Increase next id.
+        this._nextSendSctpStreamId =
+            ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+        // If this is the first DataChannel we need to create the SDP answer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            const offer = await this._pc.createOffer();
+            const localSdpObject = sdpTransform.parse(offer.sdp);
+            const offerMediaObject = localSdpObject.media
+                .find((m) => m.type === 'application');
             if (!this._transportReady)
-                return;
-            if (this._direction === 'send') {
-                const offer = yield this._pc.createOffer({ iceRestart: true });
-                logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-            }
-            else {
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-            }
-        });
+                await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+            logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            this._remoteSdp.sendSctpAssociation({ offerMediaObject });
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        const sctpStreamParameters = {
+            streamId: options.id,
+            ordered: options.ordered,
+            maxPacketLifeTime: options.maxPacketLifeTime,
+            maxRetransmits: options.maxRetransmits
+        };
+        return { dataChannel, sctpStreamParameters };
     }
-    getTransportStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this._pc.getStats();
+    async receive({ trackId, kind, rtpParameters }) {
+        this._assertRecvDirection();
+        logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
+        const localId = String(this._mapMidTransceiver.size);
+        this._remoteSdp.receive({
+            mid: localId,
+            kind,
+            offerRtpParameters: rtpParameters,
+            streamId: rtpParameters.rtcp.cname,
+            trackId
         });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        let answer = await this._pc.createAnswer();
+        const localSdpObject = sdpTransform.parse(answer.sdp);
+        const answerMediaObject = localSdpObject.media
+            .find((m) => String(m.mid) === localId);
+        // May need to modify codec parameters in the answer based on codec
+        // parameters in the offer.
+        sdpCommonUtils.applyCodecParameters({
+            offerRtpParameters: rtpParameters,
+            answerMediaObject
+        });
+        answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
+        logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+        const transceiver = this._pc.getTransceivers()
+            .find((t) => t.mid === localId);
+        if (!transceiver)
+            throw new Error('new RTCRtpTransceiver not found');
+        // Store in the map.
+        this._mapMidTransceiver.set(localId, transceiver);
+        return {
+            localId,
+            track: transceiver.receiver.track,
+            rtpReceiver: transceiver.receiver
+        };
     }
-    send({ track, encodings, codecOptions }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
-            let reverseEncodings;
-            if (encodings && encodings.length > 1) {
-                encodings.forEach((encoding, idx) => {
-                    encoding.rid = `r${idx}`;
-                });
-                // Clone the encodings and reverse them because Firefox likes them
-                // from high to low.
-                reverseEncodings = utils.clone(encodings).reverse();
+    async stopReceiving(localId) {
+        this._assertRecvDirection();
+        logger.debug('stopReceiving() [localId:%s]', localId);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        this._remoteSdp.closeMediaSection(transceiver.mid);
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        const answer = await this._pc.createAnswer();
+        logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+    }
+    async getReceiverStats(localId) {
+        this._assertRecvDirection();
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        return transceiver.receiver.getStats();
+    }
+    async receiveDataChannel({ sctpStreamParameters, label, protocol }) {
+        this._assertRecvDirection();
+        const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
+        const options = {
+            negotiated: true,
+            id: streamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmits,
+            protocol
+        };
+        logger.debug('receiveDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // If this is the first DataChannel we need to create the SDP offer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            this._remoteSdp.receiveSctpAssociation();
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            if (!this._transportReady) {
+                const localSdpObject = sdpTransform.parse(answer.sdp);
+                await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
             }
-            // NOTE: Firefox fails sometimes to properly anticipate the closed media
-            // section that it should use, so don't reuse closed media sections.
-            //   https://github.com/versatica/mediasoup-client/issues/104
-            //
-            // const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
-            const transceiver = this._pc.addTransceiver(track, { direction: 'sendonly', streams: [this._sendStream] });
-            // NOTE: This is not spec compliants. Encodings should be given in addTransceiver
-            // second argument, but Firefox does not support it.
-            if (reverseEncodings) {
-                const parameters = transceiver.sender.getParameters();
-                parameters.encodings = reverseEncodings;
-                yield transceiver.sender.setParameters(parameters);
-            }
-            const offer = yield this._pc.createOffer();
-            let localSdpObject = sdpTransform.parse(offer.sdp);
-            const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
-            // In Firefox use DTLS role client even if we are the "offerer" since
-            // Firefox does not respect ICE-Lite.
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-            logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            // We can now get the transceiver.mid.
-            const localId = transceiver.mid;
-            // Set MID.
-            sendingRtpParameters.mid = localId;
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        return { dataChannel };
+    }
+    async _setupTransport({ localDtlsRole, localSdpObject }) {
+        if (!localSdpObject)
             localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            const offerMediaObject = localSdpObject.media[localSdpObject.media.length - 1];
-            // Set RTCP CNAME.
-            sendingRtpParameters.rtcp.cname =
-                sdpCommonUtils.getCname({ offerMediaObject });
-            // Set RTP encodings by parsing the SDP offer if no encodings are given.
-            if (!encodings) {
-                sendingRtpParameters.encodings =
-                    sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
-            }
-            // Set RTP encodings by parsing the SDP offer and complete them with given
-            // one if just a single encoding has been given.
-            else if (encodings.length === 1) {
-                const newEncodings = sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
-                Object.assign(newEncodings[0], encodings[0]);
-                sendingRtpParameters.encodings = newEncodings;
-            }
-            // Otherwise if more than 1 encoding are given use them verbatim.
-            else {
-                sendingRtpParameters.encodings = encodings;
-            }
-            // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
-            // each encoding.
-            if (sendingRtpParameters.encodings.length > 1 &&
-                (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
-                    sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
-                for (const encoding of sendingRtpParameters.encodings) {
-                    encoding.scalabilityMode = 'S1T3';
-                }
-            }
-            this._remoteSdp.send({
-                offerMediaObject,
-                offerRtpParameters: sendingRtpParameters,
-                answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
-                codecOptions,
-                extmapAllowMixed: true
-            });
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-            // Store in the map.
-            this._mapMidTransceiver.set(localId, transceiver);
-            return {
-                localId,
-                rtpParameters: sendingRtpParameters,
-                rtpSender: transceiver.sender
-            };
-        });
-    }
-    stopSending(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('stopSending() [localId:%s]', localId);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated transceiver not found');
-            transceiver.sender.replaceTrack(null);
-            this._pc.removeTrack(transceiver.sender);
-            // NOTE: Cannot use closeMediaSection() due to the the note above in send()
-            // method.
-            // this._remoteSdp.closeMediaSection(transceiver.mid);
-            this._remoteSdp.disableMediaSection(transceiver.mid);
-            const offer = yield this._pc.createOffer();
-            logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-        });
-    }
-    replaceTrack(localId, track) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            yield transceiver.sender.replaceTrack(track);
-        });
-    }
-    setMaxSpatialLayer(localId, spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated transceiver not found');
-            const parameters = transceiver.sender.getParameters();
-            // NOTE: We require encodings given from low to high, however Firefox
-            // requires them in reverse order, so do magic here.
-            spatialLayer = parameters.encodings.length - 1 - spatialLayer;
-            parameters.encodings.forEach((encoding, idx) => {
-                if (idx >= spatialLayer)
-                    encoding.active = true;
-                else
-                    encoding.active = false;
-            });
-            yield transceiver.sender.setParameters(parameters);
-        });
-    }
-    setRtpEncodingParameters(localId, params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            const parameters = transceiver.sender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                parameters.encodings[idx] = Object.assign(Object.assign({}, encoding), params);
-            });
-            yield transceiver.sender.setParameters(parameters);
-        });
-    }
-    getSenderStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            return transceiver.sender.getStats();
-        });
-    }
-    sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const options = {
-                negotiated: true,
-                id: this._nextSendSctpStreamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmits,
-                protocol,
-                priority
-            };
-            logger.debug('sendDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // Increase next id.
-            this._nextSendSctpStreamId =
-                ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
-            // If this is the first DataChannel we need to create the SDP answer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                const offer = yield this._pc.createOffer();
-                const localSdpObject = sdpTransform.parse(offer.sdp);
-                const offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'application');
-                if (!this._transportReady)
-                    yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-                logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                this._remoteSdp.sendSctpAssociation({ offerMediaObject });
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-                this._hasDataChannelMediaSection = true;
-            }
-            const sctpStreamParameters = {
-                streamId: options.id,
-                ordered: options.ordered,
-                maxPacketLifeTime: options.maxPacketLifeTime,
-                maxRetransmits: options.maxRetransmits
-            };
-            return { dataChannel, sctpStreamParameters };
-        });
-    }
-    receive({ trackId, kind, rtpParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
-            const localId = String(this._mapMidTransceiver.size);
-            this._remoteSdp.receive({
-                mid: localId,
-                kind,
-                offerRtpParameters: rtpParameters,
-                streamId: rtpParameters.rtcp.cname,
-                trackId
-            });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            let answer = yield this._pc.createAnswer();
-            const localSdpObject = sdpTransform.parse(answer.sdp);
-            const answerMediaObject = localSdpObject.media
-                .find((m) => String(m.mid) === localId);
-            // May need to modify codec parameters in the answer based on codec
-            // parameters in the offer.
-            sdpCommonUtils.applyCodecParameters({
-                offerRtpParameters: rtpParameters,
-                answerMediaObject
-            });
-            answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-            logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-            const transceiver = this._pc.getTransceivers()
-                .find((t) => t.mid === localId);
-            if (!transceiver)
-                throw new Error('new RTCRtpTransceiver not found');
-            // Store in the map.
-            this._mapMidTransceiver.set(localId, transceiver);
-            return {
-                localId,
-                track: transceiver.receiver.track,
-                rtpReceiver: transceiver.receiver
-            };
-        });
-    }
-    stopReceiving(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('stopReceiving() [localId:%s]', localId);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            this._remoteSdp.closeMediaSection(transceiver.mid);
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            const answer = yield this._pc.createAnswer();
-            logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-        });
-    }
-    getReceiverStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            return transceiver.receiver.getStats();
-        });
-    }
-    receiveDataChannel({ sctpStreamParameters, label, protocol }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
-            const options = {
-                negotiated: true,
-                id: streamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmits,
-                protocol
-            };
-            logger.debug('receiveDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // If this is the first DataChannel we need to create the SDP offer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                this._remoteSdp.receiveSctpAssociation();
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                if (!this._transportReady) {
-                    const localSdpObject = sdpTransform.parse(answer.sdp);
-                    yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-                }
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-                this._hasDataChannelMediaSection = true;
-            }
-            return { dataChannel };
-        });
-    }
-    _setupTransport({ localDtlsRole, localSdpObject }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!localSdpObject)
-                localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            // Get our local DTLS parameters.
-            const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
-            // Set our DTLS role.
-            dtlsParameters.role = localDtlsRole;
-            // Update the remote DTLS role in the SDP.
-            this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
-            // Need to tell the remote transport about our parameters.
-            yield this.safeEmitAsPromise('@connect', { dtlsParameters });
-            this._transportReady = true;
-        });
+        // Get our local DTLS parameters.
+        const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
+        // Set our DTLS role.
+        dtlsParameters.role = localDtlsRole;
+        // Update the remote DTLS role in the SDP.
+        this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
+        // Need to tell the remote transport about our parameters.
+        await this.safeEmitAsPromise('@connect', { dtlsParameters });
+        this._transportReady = true;
     }
     _assertSendDirection() {
         if (this._direction !== 'send') {

--- a/lib/handlers/ReactNative.js
+++ b/lib/handlers/ReactNative.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -65,45 +56,41 @@ class ReactNative extends HandlerInterface_1.HandlerInterface {
             catch (error) { }
         }
     }
-    getNativeRtpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeRtpCapabilities()');
-            const pc = new RTCPeerConnection({
-                iceServers: [],
-                iceTransportPolicy: 'all',
-                bundlePolicy: 'max-bundle',
-                rtcpMuxPolicy: 'require',
-                sdpSemantics: 'plan-b'
+    async getNativeRtpCapabilities() {
+        logger.debug('getNativeRtpCapabilities()');
+        const pc = new RTCPeerConnection({
+            iceServers: [],
+            iceTransportPolicy: 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'plan-b'
+        });
+        try {
+            const offer = await pc.createOffer({
+                offerToReceiveAudio: true,
+                offerToReceiveVideo: true
             });
             try {
-                const offer = yield pc.createOffer({
-                    offerToReceiveAudio: true,
-                    offerToReceiveVideo: true
-                });
-                try {
-                    pc.close();
-                }
-                catch (error) { }
-                const sdpObject = sdpTransform.parse(offer.sdp);
-                const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
-                return nativeRtpCapabilities;
+                pc.close();
             }
-            catch (error) {
-                try {
-                    pc.close();
-                }
-                catch (error2) { }
-                throw error;
+            catch (error) { }
+            const sdpObject = sdpTransform.parse(offer.sdp);
+            const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+            return nativeRtpCapabilities;
+        }
+        catch (error) {
+            try {
+                pc.close();
             }
-        });
+            catch (error2) { }
+            throw error;
+        }
     }
-    getNativeSctpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeSctpCapabilities()');
-            return {
-                numStreams: SCTP_NUM_STREAMS
-            };
-        });
+    async getNativeSctpCapabilities() {
+        logger.debug('getNativeSctpCapabilities()');
+        return {
+            numStreams: SCTP_NUM_STREAMS
+        };
     }
     run({ direction, iceParameters, iceCandidates, dtlsParameters, sctpParameters, iceServers, iceTransportPolicy, additionalSettings, proprietaryConstraints, extendedRtpCapabilities }) {
         logger.debug('run()');
@@ -125,7 +112,14 @@ class ReactNative extends HandlerInterface_1.HandlerInterface {
                 audio: ortc.getSendingRemoteRtpParameters('audio', extendedRtpCapabilities),
                 video: ortc.getSendingRemoteRtpParameters('video', extendedRtpCapabilities)
             };
-        this._pc = new RTCPeerConnection(Object.assign({ iceServers: iceServers || [], iceTransportPolicy: iceTransportPolicy || 'all', bundlePolicy: 'max-bundle', rtcpMuxPolicy: 'require', sdpSemantics: 'plan-b' }, additionalSettings), proprietaryConstraints);
+        this._pc = new RTCPeerConnection({
+            iceServers: iceServers || [],
+            iceTransportPolicy: iceTransportPolicy || 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'plan-b',
+            ...additionalSettings
+        }, proprietaryConstraints);
         // Handle RTCPeerConnection connection status.
         this._pc.addEventListener('iceconnectionstatechange', () => {
             switch (this._pc.iceConnectionState) {
@@ -148,331 +142,301 @@ class ReactNative extends HandlerInterface_1.HandlerInterface {
             }
         });
     }
-    updateIceServers(iceServers) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('updateIceServers()');
-            const configuration = this._pc.getConfiguration();
-            configuration.iceServers = iceServers;
-            this._pc.setConfiguration(configuration);
-        });
+    async updateIceServers(iceServers) {
+        logger.debug('updateIceServers()');
+        const configuration = this._pc.getConfiguration();
+        configuration.iceServers = iceServers;
+        this._pc.setConfiguration(configuration);
     }
-    restartIce(iceParameters) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            // Provide the remote SDP handler with new remote ICE parameters.
-            this._remoteSdp.updateIceParameters(iceParameters);
-            if (!this._transportReady)
-                return;
-            if (this._direction === 'send') {
-                const offer = yield this._pc.createOffer({ iceRestart: true });
-                logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-            }
-            else {
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-            }
-        });
+    async restartIce(iceParameters) {
+        logger.debug('restartIce()');
+        // Provide the remote SDP handler with new remote ICE parameters.
+        this._remoteSdp.updateIceParameters(iceParameters);
+        if (!this._transportReady)
+            return;
+        if (this._direction === 'send') {
+            const offer = await this._pc.createOffer({ iceRestart: true });
+            logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+        }
+        else {
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+        }
     }
-    getTransportStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this._pc.getStats();
-        });
+    async getTransportStats() {
+        return this._pc.getStats();
     }
-    send({ track, encodings, codecOptions }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
-            this._sendStream.addTrack(track);
-            this._pc.addStream(this._sendStream);
-            let offer = yield this._pc.createOffer();
-            let localSdpObject = sdpTransform.parse(offer.sdp);
-            let offerMediaObject;
-            const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-            if (track.kind === 'video' && encodings && encodings.length > 1) {
-                logger.debug('send() | enabling simulcast');
-                localSdpObject = sdpTransform.parse(offer.sdp);
-                offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'video');
-                sdpPlanBUtils.addLegacySimulcast({
-                    offerMediaObject,
-                    track,
-                    numStreams: encodings.length
-                });
-                offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
-            }
-            logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+    async send({ track, encodings, codecOptions }) {
+        this._assertSendDirection();
+        logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+        this._sendStream.addTrack(track);
+        this._pc.addStream(this._sendStream);
+        let offer = await this._pc.createOffer();
+        let localSdpObject = sdpTransform.parse(offer.sdp);
+        let offerMediaObject;
+        const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+        if (track.kind === 'video' && encodings && encodings.length > 1) {
+            logger.debug('send() | enabling simulcast');
+            localSdpObject = sdpTransform.parse(offer.sdp);
             offerMediaObject = localSdpObject.media
-                .find((m) => m.type === track.kind);
-            // Set RTCP CNAME.
-            sendingRtpParameters.rtcp.cname =
-                sdpCommonUtils.getCname({ offerMediaObject });
-            // Set RTP encodings.
-            sendingRtpParameters.encodings =
-                sdpPlanBUtils.getRtpEncodings({ offerMediaObject, track });
-            // Complete encodings with given values.
-            if (encodings) {
-                for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
-                    if (encodings[idx])
-                        Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
-                }
-            }
-            // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
-            // each encoding.
-            if (sendingRtpParameters.encodings.length > 1 &&
-                (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
-                    sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
-                for (const encoding of sendingRtpParameters.encodings) {
-                    encoding.scalabilityMode = 'S1T3';
-                }
-            }
-            this._remoteSdp.send({
+                .find((m) => m.type === 'video');
+            sdpPlanBUtils.addLegacySimulcast({
                 offerMediaObject,
-                offerRtpParameters: sendingRtpParameters,
-                answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
-                codecOptions
+                track,
+                numStreams: encodings.length
             });
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-            const localId = String(this._nextSendLocalId);
-            this._nextSendLocalId++;
-            // Insert into the map.
-            this._mapSendLocalIdTrack.set(localId, track);
-            return {
-                localId: localId,
-                rtpParameters: sendingRtpParameters
-            };
+            offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
+        }
+        logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        offerMediaObject = localSdpObject.media
+            .find((m) => m.type === track.kind);
+        // Set RTCP CNAME.
+        sendingRtpParameters.rtcp.cname =
+            sdpCommonUtils.getCname({ offerMediaObject });
+        // Set RTP encodings.
+        sendingRtpParameters.encodings =
+            sdpPlanBUtils.getRtpEncodings({ offerMediaObject, track });
+        // Complete encodings with given values.
+        if (encodings) {
+            for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
+                if (encodings[idx])
+                    Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
+            }
+        }
+        // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
+        // each encoding.
+        if (sendingRtpParameters.encodings.length > 1 &&
+            (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
+                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
+            for (const encoding of sendingRtpParameters.encodings) {
+                encoding.scalabilityMode = 'S1T3';
+            }
+        }
+        this._remoteSdp.send({
+            offerMediaObject,
+            offerRtpParameters: sendingRtpParameters,
+            answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
+            codecOptions
         });
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+        const localId = String(this._nextSendLocalId);
+        this._nextSendLocalId++;
+        // Insert into the map.
+        this._mapSendLocalIdTrack.set(localId, track);
+        return {
+            localId: localId,
+            rtpParameters: sendingRtpParameters
+        };
     }
-    stopSending(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('stopSending() [localId:%s]', localId);
-            const track = this._mapSendLocalIdTrack.get(localId);
-            if (!track)
-                throw new Error('track not found');
-            this._mapSendLocalIdTrack.delete(localId);
-            this._sendStream.removeTrack(track);
-            this._pc.addStream(this._sendStream);
-            const offer = yield this._pc.createOffer();
-            logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
-            try {
-                yield this._pc.setLocalDescription(offer);
-            }
-            catch (error) {
-                // NOTE: If there are no sending tracks, setLocalDescription() will fail with
-                // "Failed to create channels". If so, ignore it.
-                if (this._sendStream.getTracks().length === 0) {
-                    logger.warn('stopSending() | ignoring expected error due no sending tracks: %s', error.toString());
-                    return;
-                }
-                throw error;
-            }
-            if (this._pc.signalingState === 'stable')
+    async stopSending(localId) {
+        this._assertSendDirection();
+        logger.debug('stopSending() [localId:%s]', localId);
+        const track = this._mapSendLocalIdTrack.get(localId);
+        if (!track)
+            throw new Error('track not found');
+        this._mapSendLocalIdTrack.delete(localId);
+        this._sendStream.removeTrack(track);
+        this._pc.addStream(this._sendStream);
+        const offer = await this._pc.createOffer();
+        logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
+        try {
+            await this._pc.setLocalDescription(offer);
+        }
+        catch (error) {
+            // NOTE: If there are no sending tracks, setLocalDescription() will fail with
+            // "Failed to create channels". If so, ignore it.
+            if (this._sendStream.getTracks().length === 0) {
+                logger.warn('stopSending() | ignoring expected error due no sending tracks: %s', error.toString());
                 return;
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-        });
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    replaceTrack(localId, track) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
-        });
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    setMaxSpatialLayer(localId, spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
-        });
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    setRtpEncodingParameters(localId, params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
-        });
-    }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    getSenderStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
-        });
-    }
-    sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const options = {
-                negotiated: true,
-                id: this._nextSendSctpStreamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmitTime: maxPacketLifeTime,
-                maxRetransmits,
-                protocol,
-                priority
-            };
-            logger.debug('sendDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // Increase next id.
-            this._nextSendSctpStreamId =
-                ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
-            // If this is the first DataChannel we need to create the SDP answer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                const offer = yield this._pc.createOffer();
-                const localSdpObject = sdpTransform.parse(offer.sdp);
-                const offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'application');
-                if (!this._transportReady)
-                    yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-                logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                this._remoteSdp.sendSctpAssociation({ offerMediaObject });
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-                this._hasDataChannelMediaSection = true;
             }
-            const sctpStreamParameters = {
-                streamId: options.id,
-                ordered: options.ordered,
-                maxPacketLifeTime: options.maxPacketLifeTime,
-                maxRetransmits: options.maxRetransmits
-            };
-            return { dataChannel, sctpStreamParameters };
-        });
+            throw error;
+        }
+        if (this._pc.signalingState === 'stable')
+            return;
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
     }
-    receive({ trackId, kind, rtpParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
-            const localId = trackId;
-            const mid = kind;
-            let streamId = rtpParameters.rtcp.cname;
-            // NOTE: In React-Native we cannot reuse the same remote MediaStream for new
-            // remote tracks. This is because react-native-webrtc does not react on new
-            // tracks generated within already existing streams, so force the streamId
-            // to be different.
-            logger.debug('receive() | forcing a random remote streamId to avoid well known bug in react-native-webrtc');
-            streamId += `-hack-${utils.generateRandomNumber()}`;
-            this._remoteSdp.receive({
-                mid,
-                kind,
-                offerRtpParameters: rtpParameters,
-                streamId,
-                trackId
-            });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            let answer = yield this._pc.createAnswer();
-            const localSdpObject = sdpTransform.parse(answer.sdp);
-            const answerMediaObject = localSdpObject.media
-                .find((m) => String(m.mid) === mid);
-            // May need to modify codec parameters in the answer based on codec
-            // parameters in the offer.
-            sdpCommonUtils.applyCodecParameters({
-                offerRtpParameters: rtpParameters,
-                answerMediaObject
-            });
-            answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async replaceTrack(localId, track) {
+        throw new errors_1.UnsupportedError('not implemented');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async setMaxSpatialLayer(localId, spatialLayer) {
+        throw new errors_1.UnsupportedError('not implemented');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async setRtpEncodingParameters(localId, params) {
+        throw new errors_1.UnsupportedError('not implemented');
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async getSenderStats(localId) {
+        throw new errors_1.UnsupportedError('not implemented');
+    }
+    async sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
+        this._assertSendDirection();
+        const options = {
+            negotiated: true,
+            id: this._nextSendSctpStreamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmitTime: maxPacketLifeTime,
+            maxRetransmits,
+            protocol,
+            priority
+        };
+        logger.debug('sendDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // Increase next id.
+        this._nextSendSctpStreamId =
+            ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+        // If this is the first DataChannel we need to create the SDP answer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            const offer = await this._pc.createOffer();
+            const localSdpObject = sdpTransform.parse(offer.sdp);
+            const offerMediaObject = localSdpObject.media
+                .find((m) => m.type === 'application');
             if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-            logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-            const stream = this._pc.getRemoteStreams()
-                .find((s) => s.id === streamId);
-            const track = stream.getTrackById(localId);
-            if (!track)
-                throw new Error('remote track not found');
-            // Insert into the map.
-            this._mapRecvLocalIdInfo.set(localId, { mid, rtpParameters });
-            return { localId, track };
-        });
+                await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+            logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            this._remoteSdp.sendSctpAssociation({ offerMediaObject });
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        const sctpStreamParameters = {
+            streamId: options.id,
+            ordered: options.ordered,
+            maxPacketLifeTime: options.maxPacketLifeTime,
+            maxRetransmits: options.maxRetransmits
+        };
+        return { dataChannel, sctpStreamParameters };
     }
-    stopReceiving(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('stopReceiving() [localId:%s]', localId);
-            const { mid, rtpParameters } = this._mapRecvLocalIdInfo.get(localId);
-            // Remove from the map.
-            this._mapRecvLocalIdInfo.delete(localId);
-            this._remoteSdp.planBStopReceiving({ mid, offerRtpParameters: rtpParameters });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            const answer = yield this._pc.createAnswer();
-            logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
+    async receive({ trackId, kind, rtpParameters }) {
+        this._assertRecvDirection();
+        logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
+        const localId = trackId;
+        const mid = kind;
+        let streamId = rtpParameters.rtcp.cname;
+        // NOTE: In React-Native we cannot reuse the same remote MediaStream for new
+        // remote tracks. This is because react-native-webrtc does not react on new
+        // tracks generated within already existing streams, so force the streamId
+        // to be different.
+        logger.debug('receive() | forcing a random remote streamId to avoid well known bug in react-native-webrtc');
+        streamId += `-hack-${utils.generateRandomNumber()}`;
+        this._remoteSdp.receive({
+            mid,
+            kind,
+            offerRtpParameters: rtpParameters,
+            streamId,
+            trackId
         });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        let answer = await this._pc.createAnswer();
+        const localSdpObject = sdpTransform.parse(answer.sdp);
+        const answerMediaObject = localSdpObject.media
+            .find((m) => String(m.mid) === mid);
+        // May need to modify codec parameters in the answer based on codec
+        // parameters in the offer.
+        sdpCommonUtils.applyCodecParameters({
+            offerRtpParameters: rtpParameters,
+            answerMediaObject
+        });
+        answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
+        logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+        const stream = this._pc.getRemoteStreams()
+            .find((s) => s.id === streamId);
+        const track = stream.getTrackById(localId);
+        if (!track)
+            throw new Error('remote track not found');
+        // Insert into the map.
+        this._mapRecvLocalIdInfo.set(localId, { mid, rtpParameters });
+        return { localId, track };
+    }
+    async stopReceiving(localId) {
+        this._assertRecvDirection();
+        logger.debug('stopReceiving() [localId:%s]', localId);
+        const { mid, rtpParameters } = this._mapRecvLocalIdInfo.get(localId);
+        // Remove from the map.
+        this._mapRecvLocalIdInfo.delete(localId);
+        this._remoteSdp.planBStopReceiving({ mid, offerRtpParameters: rtpParameters });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        const answer = await this._pc.createAnswer();
+        logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    getReceiverStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            throw new errors_1.UnsupportedError('not implemented');
-        });
+    async getReceiverStats(localId) {
+        throw new errors_1.UnsupportedError('not implemented');
     }
-    receiveDataChannel({ sctpStreamParameters, label, protocol }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
-            const options = {
-                negotiated: true,
-                id: streamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmitTime: maxPacketLifeTime,
-                maxRetransmits,
-                protocol
-            };
-            logger.debug('receiveDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // If this is the first DataChannel we need to create the SDP offer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                this._remoteSdp.receiveSctpAssociation({ oldDataChannelSpec: true });
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                if (!this._transportReady) {
-                    const localSdpObject = sdpTransform.parse(answer.sdp);
-                    yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-                }
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-                this._hasDataChannelMediaSection = true;
+    async receiveDataChannel({ sctpStreamParameters, label, protocol }) {
+        this._assertRecvDirection();
+        const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
+        const options = {
+            negotiated: true,
+            id: streamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmitTime: maxPacketLifeTime,
+            maxRetransmits,
+            protocol
+        };
+        logger.debug('receiveDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // If this is the first DataChannel we need to create the SDP offer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            this._remoteSdp.receiveSctpAssociation({ oldDataChannelSpec: true });
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            if (!this._transportReady) {
+                const localSdpObject = sdpTransform.parse(answer.sdp);
+                await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
             }
-            return { dataChannel };
-        });
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        return { dataChannel };
     }
-    _setupTransport({ localDtlsRole, localSdpObject }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!localSdpObject)
-                localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            // Get our local DTLS parameters.
-            const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
-            // Set our DTLS role.
-            dtlsParameters.role = localDtlsRole;
-            // Update the remote DTLS role in the SDP.
-            this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
-            // Need to tell the remote transport about our parameters.
-            yield this.safeEmitAsPromise('@connect', { dtlsParameters });
-            this._transportReady = true;
-        });
+    async _setupTransport({ localDtlsRole, localSdpObject }) {
+        if (!localSdpObject)
+            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        // Get our local DTLS parameters.
+        const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
+        // Set our DTLS role.
+        dtlsParameters.role = localDtlsRole;
+        // Update the remote DTLS role in the SDP.
+        this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
+        // Need to tell the remote transport about our parameters.
+        await this.safeEmitAsPromise('@connect', { dtlsParameters });
+        this._transportReady = true;
     }
     _assertSendDirection() {
         if (this._direction !== 'send') {

--- a/lib/handlers/Safari11.js
+++ b/lib/handlers/Safari11.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -64,45 +55,41 @@ class Safari11 extends HandlerInterface_1.HandlerInterface {
             catch (error) { }
         }
     }
-    getNativeRtpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeRtpCapabilities()');
-            const pc = new RTCPeerConnection({
-                iceServers: [],
-                iceTransportPolicy: 'all',
-                bundlePolicy: 'max-bundle',
-                rtcpMuxPolicy: 'require',
-                sdpSemantics: 'plan-b'
+    async getNativeRtpCapabilities() {
+        logger.debug('getNativeRtpCapabilities()');
+        const pc = new RTCPeerConnection({
+            iceServers: [],
+            iceTransportPolicy: 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            sdpSemantics: 'plan-b'
+        });
+        try {
+            const offer = await pc.createOffer({
+                offerToReceiveAudio: true,
+                offerToReceiveVideo: true
             });
             try {
-                const offer = yield pc.createOffer({
-                    offerToReceiveAudio: true,
-                    offerToReceiveVideo: true
-                });
-                try {
-                    pc.close();
-                }
-                catch (error) { }
-                const sdpObject = sdpTransform.parse(offer.sdp);
-                const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
-                return nativeRtpCapabilities;
+                pc.close();
             }
-            catch (error) {
-                try {
-                    pc.close();
-                }
-                catch (error2) { }
-                throw error;
+            catch (error) { }
+            const sdpObject = sdpTransform.parse(offer.sdp);
+            const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+            return nativeRtpCapabilities;
+        }
+        catch (error) {
+            try {
+                pc.close();
             }
-        });
+            catch (error2) { }
+            throw error;
+        }
     }
-    getNativeSctpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeSctpCapabilities()');
-            return {
-                numStreams: SCTP_NUM_STREAMS
-            };
-        });
+    async getNativeSctpCapabilities() {
+        logger.debug('getNativeSctpCapabilities()');
+        return {
+            numStreams: SCTP_NUM_STREAMS
+        };
     }
     run({ direction, iceParameters, iceCandidates, dtlsParameters, sctpParameters, iceServers, iceTransportPolicy, additionalSettings, proprietaryConstraints, extendedRtpCapabilities }) {
         logger.debug('run()');
@@ -124,7 +111,13 @@ class Safari11 extends HandlerInterface_1.HandlerInterface {
                 audio: ortc.getSendingRemoteRtpParameters('audio', extendedRtpCapabilities),
                 video: ortc.getSendingRemoteRtpParameters('video', extendedRtpCapabilities)
             };
-        this._pc = new RTCPeerConnection(Object.assign({ iceServers: iceServers || [], iceTransportPolicy: iceTransportPolicy || 'all', bundlePolicy: 'max-bundle', rtcpMuxPolicy: 'require' }, additionalSettings), proprietaryConstraints);
+        this._pc = new RTCPeerConnection({
+            iceServers: iceServers || [],
+            iceTransportPolicy: iceTransportPolicy || 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            ...additionalSettings
+        }, proprietaryConstraints);
         // Handle RTCPeerConnection connection status.
         this._pc.addEventListener('iceconnectionstatechange', () => {
             switch (this._pc.iceConnectionState) {
@@ -147,370 +140,340 @@ class Safari11 extends HandlerInterface_1.HandlerInterface {
             }
         });
     }
-    updateIceServers(iceServers) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('updateIceServers()');
-            const configuration = this._pc.getConfiguration();
-            configuration.iceServers = iceServers;
-            this._pc.setConfiguration(configuration);
-        });
+    async updateIceServers(iceServers) {
+        logger.debug('updateIceServers()');
+        const configuration = this._pc.getConfiguration();
+        configuration.iceServers = iceServers;
+        this._pc.setConfiguration(configuration);
     }
-    restartIce(iceParameters) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            // Provide the remote SDP handler with new remote ICE parameters.
-            this._remoteSdp.updateIceParameters(iceParameters);
-            if (!this._transportReady)
-                return;
-            if (this._direction === 'send') {
-                const offer = yield this._pc.createOffer({ iceRestart: true });
-                logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-            }
-            else {
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-            }
-        });
+    async restartIce(iceParameters) {
+        logger.debug('restartIce()');
+        // Provide the remote SDP handler with new remote ICE parameters.
+        this._remoteSdp.updateIceParameters(iceParameters);
+        if (!this._transportReady)
+            return;
+        if (this._direction === 'send') {
+            const offer = await this._pc.createOffer({ iceRestart: true });
+            logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+        }
+        else {
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+        }
     }
-    getTransportStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this._pc.getStats();
-        });
+    async getTransportStats() {
+        return this._pc.getStats();
     }
-    send({ track, encodings, codecOptions }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
-            this._sendStream.addTrack(track);
-            this._pc.addTrack(track, this._sendStream);
-            let offer = yield this._pc.createOffer();
-            let localSdpObject = sdpTransform.parse(offer.sdp);
-            let offerMediaObject;
-            const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-            if (track.kind === 'video' && encodings && encodings.length > 1) {
-                logger.debug('send() | enabling simulcast');
-                localSdpObject = sdpTransform.parse(offer.sdp);
-                offerMediaObject = localSdpObject.media.find((m) => m.type === 'video');
-                sdpPlanBUtils.addLegacySimulcast({
-                    offerMediaObject,
-                    track,
-                    numStreams: encodings.length
-                });
-                offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
-            }
-            logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            offerMediaObject = localSdpObject.media
-                .find((m) => m.type === track.kind);
-            // Set RTCP CNAME.
-            sendingRtpParameters.rtcp.cname =
-                sdpCommonUtils.getCname({ offerMediaObject });
-            // Set RTP encodings.
-            sendingRtpParameters.encodings =
-                sdpPlanBUtils.getRtpEncodings({ offerMediaObject, track });
-            // Complete encodings with given values.
-            if (encodings) {
-                for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
-                    if (encodings[idx])
-                        Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
-                }
-            }
-            // If VP8 and there is effective simulcast, add scalabilityMode to each
-            // encoding.
-            if (sendingRtpParameters.encodings.length > 1 &&
-                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8') {
-                for (const encoding of sendingRtpParameters.encodings) {
-                    encoding.scalabilityMode = 'S1T3';
-                }
-            }
-            this._remoteSdp.send({
+    async send({ track, encodings, codecOptions }) {
+        this._assertSendDirection();
+        logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+        this._sendStream.addTrack(track);
+        this._pc.addTrack(track, this._sendStream);
+        let offer = await this._pc.createOffer();
+        let localSdpObject = sdpTransform.parse(offer.sdp);
+        let offerMediaObject;
+        const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+        if (track.kind === 'video' && encodings && encodings.length > 1) {
+            logger.debug('send() | enabling simulcast');
+            localSdpObject = sdpTransform.parse(offer.sdp);
+            offerMediaObject = localSdpObject.media.find((m) => m.type === 'video');
+            sdpPlanBUtils.addLegacySimulcast({
                 offerMediaObject,
-                offerRtpParameters: sendingRtpParameters,
-                answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
-                codecOptions
+                track,
+                numStreams: encodings.length
             });
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-            const localId = String(this._nextSendLocalId);
-            this._nextSendLocalId++;
-            // Insert into the map.
-            this._mapSendLocalIdTrack.set(localId, track);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            return {
-                localId: localId,
-                rtpParameters: sendingRtpParameters,
-                rtpSender
-            };
+            offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
+        }
+        logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        offerMediaObject = localSdpObject.media
+            .find((m) => m.type === track.kind);
+        // Set RTCP CNAME.
+        sendingRtpParameters.rtcp.cname =
+            sdpCommonUtils.getCname({ offerMediaObject });
+        // Set RTP encodings.
+        sendingRtpParameters.encodings =
+            sdpPlanBUtils.getRtpEncodings({ offerMediaObject, track });
+        // Complete encodings with given values.
+        if (encodings) {
+            for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
+                if (encodings[idx])
+                    Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
+            }
+        }
+        // If VP8 and there is effective simulcast, add scalabilityMode to each
+        // encoding.
+        if (sendingRtpParameters.encodings.length > 1 &&
+            sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8') {
+            for (const encoding of sendingRtpParameters.encodings) {
+                encoding.scalabilityMode = 'S1T3';
+            }
+        }
+        this._remoteSdp.send({
+            offerMediaObject,
+            offerRtpParameters: sendingRtpParameters,
+            answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
+            codecOptions
         });
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+        const localId = String(this._nextSendLocalId);
+        this._nextSendLocalId++;
+        // Insert into the map.
+        this._mapSendLocalIdTrack.set(localId, track);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        return {
+            localId: localId,
+            rtpParameters: sendingRtpParameters,
+            rtpSender
+        };
     }
-    stopSending(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const track = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            this._pc.removeTrack(rtpSender);
-            this._sendStream.removeTrack(track);
-            this._mapSendLocalIdTrack.delete(localId);
-            const offer = yield this._pc.createOffer();
-            logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
-            try {
-                yield this._pc.setLocalDescription(offer);
-            }
-            catch (error) {
-                // NOTE: If there are no sending tracks, setLocalDescription() will fail with
-                // "Failed to create channels". If so, ignore it.
-                if (this._sendStream.getTracks().length === 0) {
-                    logger.warn('stopSending() | ignoring expected error due no sending tracks: %s', error.toString());
-                    return;
-                }
-                throw error;
-            }
-            if (this._pc.signalingState === 'stable')
+    async stopSending(localId) {
+        this._assertSendDirection();
+        const track = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        this._pc.removeTrack(rtpSender);
+        this._sendStream.removeTrack(track);
+        this._mapSendLocalIdTrack.delete(localId);
+        const offer = await this._pc.createOffer();
+        logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
+        try {
+            await this._pc.setLocalDescription(offer);
+        }
+        catch (error) {
+            // NOTE: If there are no sending tracks, setLocalDescription() will fail with
+            // "Failed to create channels". If so, ignore it.
+            if (this._sendStream.getTracks().length === 0) {
+                logger.warn('stopSending() | ignoring expected error due no sending tracks: %s', error.toString());
                 return;
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-        });
-    }
-    replaceTrack(localId, track) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
-            const oldTrack = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === oldTrack);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            yield rtpSender.replaceTrack(track);
-            // Remove the old track from the local stream.
-            this._sendStream.removeTrack(oldTrack);
-            // Add the new track to the local stream.
-            this._sendStream.addTrack(track);
-            // Replace entry in the map.
-            this._mapSendLocalIdTrack.set(localId, track);
-        });
-    }
-    setMaxSpatialLayer(localId, spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
-            const track = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            const parameters = rtpSender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                if (idx <= spatialLayer)
-                    encoding.active = true;
-                else
-                    encoding.active = false;
-            });
-            yield rtpSender.setParameters(parameters);
-        });
-    }
-    setRtpEncodingParameters(localId, params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
-            const track = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            const parameters = rtpSender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                parameters.encodings[idx] = Object.assign(Object.assign({}, encoding), params);
-            });
-            yield rtpSender.setParameters(parameters);
-        });
-    }
-    getSenderStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const track = this._mapSendLocalIdTrack.get(localId);
-            const rtpSender = this._pc.getSenders()
-                .find((s) => s.track === track);
-            if (!rtpSender)
-                throw new Error('associated RTCRtpSender not found');
-            return rtpSender.getStats();
-        });
-    }
-    sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const options = {
-                negotiated: true,
-                id: this._nextSendSctpStreamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmits,
-                protocol,
-                priority
-            };
-            logger.debug('sendDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // Increase next id.
-            this._nextSendSctpStreamId =
-                ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
-            // If this is the first DataChannel we need to create the SDP answer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                const offer = yield this._pc.createOffer();
-                const localSdpObject = sdpTransform.parse(offer.sdp);
-                const offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'application');
-                if (!this._transportReady)
-                    yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-                logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                this._remoteSdp.sendSctpAssociation({ offerMediaObject });
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-                this._hasDataChannelMediaSection = true;
             }
-            const sctpStreamParameters = {
-                streamId: options.id,
-                ordered: options.ordered,
-                maxPacketLifeTime: options.maxPacketLifeTime,
-                maxRetransmits: options.maxRetransmits
-            };
-            return { dataChannel, sctpStreamParameters };
-        });
+            throw error;
+        }
+        if (this._pc.signalingState === 'stable')
+            return;
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
     }
-    receive({ trackId, kind, rtpParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
-            const localId = trackId;
-            const mid = kind;
-            this._remoteSdp.receive({
-                mid,
-                kind,
-                offerRtpParameters: rtpParameters,
-                streamId: rtpParameters.rtcp.cname,
-                trackId
-            });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            let answer = yield this._pc.createAnswer();
-            const localSdpObject = sdpTransform.parse(answer.sdp);
-            const answerMediaObject = localSdpObject.media
-                .find((m) => String(m.mid) === mid);
-            // May need to modify codec parameters in the answer based on codec
-            // parameters in the offer.
-            sdpCommonUtils.applyCodecParameters({
-                offerRtpParameters: rtpParameters,
-                answerMediaObject
-            });
-            answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+    async replaceTrack(localId, track) {
+        this._assertSendDirection();
+        logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
+        const oldTrack = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === oldTrack);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        await rtpSender.replaceTrack(track);
+        // Remove the old track from the local stream.
+        this._sendStream.removeTrack(oldTrack);
+        // Add the new track to the local stream.
+        this._sendStream.addTrack(track);
+        // Replace entry in the map.
+        this._mapSendLocalIdTrack.set(localId, track);
+    }
+    async setMaxSpatialLayer(localId, spatialLayer) {
+        this._assertSendDirection();
+        logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
+        const track = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        const parameters = rtpSender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            if (idx <= spatialLayer)
+                encoding.active = true;
+            else
+                encoding.active = false;
+        });
+        await rtpSender.setParameters(parameters);
+    }
+    async setRtpEncodingParameters(localId, params) {
+        this._assertSendDirection();
+        logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
+        const track = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        const parameters = rtpSender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            parameters.encodings[idx] = { ...encoding, ...params };
+        });
+        await rtpSender.setParameters(parameters);
+    }
+    async getSenderStats(localId) {
+        this._assertSendDirection();
+        const track = this._mapSendLocalIdTrack.get(localId);
+        const rtpSender = this._pc.getSenders()
+            .find((s) => s.track === track);
+        if (!rtpSender)
+            throw new Error('associated RTCRtpSender not found');
+        return rtpSender.getStats();
+    }
+    async sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
+        this._assertSendDirection();
+        const options = {
+            negotiated: true,
+            id: this._nextSendSctpStreamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmits,
+            protocol,
+            priority
+        };
+        logger.debug('sendDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // Increase next id.
+        this._nextSendSctpStreamId =
+            ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+        // If this is the first DataChannel we need to create the SDP answer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            const offer = await this._pc.createOffer();
+            const localSdpObject = sdpTransform.parse(offer.sdp);
+            const offerMediaObject = localSdpObject.media
+                .find((m) => m.type === 'application');
             if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-            logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-            const rtpReceiver = this._pc.getReceivers()
-                .find((r) => r.track && r.track.id === localId);
-            if (!rtpReceiver)
-                throw new Error('new RTCRtpReceiver not');
-            // Insert into the map.
-            this._mapRecvLocalIdInfo.set(localId, { mid, rtpParameters, rtpReceiver });
-            return {
-                localId,
-                track: rtpReceiver.track,
-                rtpReceiver
-            };
-        });
+                await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+            logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            this._remoteSdp.sendSctpAssociation({ offerMediaObject });
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        const sctpStreamParameters = {
+            streamId: options.id,
+            ordered: options.ordered,
+            maxPacketLifeTime: options.maxPacketLifeTime,
+            maxRetransmits: options.maxRetransmits
+        };
+        return { dataChannel, sctpStreamParameters };
     }
-    stopReceiving(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('stopReceiving() [localId:%s]', localId);
-            const { mid, rtpParameters } = this._mapRecvLocalIdInfo.get(localId);
-            // Remove from the map.
-            this._mapRecvLocalIdInfo.delete(localId);
-            this._remoteSdp.planBStopReceiving({ mid, offerRtpParameters: rtpParameters });
+    async receive({ trackId, kind, rtpParameters }) {
+        this._assertRecvDirection();
+        logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
+        const localId = trackId;
+        const mid = kind;
+        this._remoteSdp.receive({
+            mid,
+            kind,
+            offerRtpParameters: rtpParameters,
+            streamId: rtpParameters.rtcp.cname,
+            trackId
+        });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        let answer = await this._pc.createAnswer();
+        const localSdpObject = sdpTransform.parse(answer.sdp);
+        const answerMediaObject = localSdpObject.media
+            .find((m) => String(m.mid) === mid);
+        // May need to modify codec parameters in the answer based on codec
+        // parameters in the offer.
+        sdpCommonUtils.applyCodecParameters({
+            offerRtpParameters: rtpParameters,
+            answerMediaObject
+        });
+        answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
+        logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+        const rtpReceiver = this._pc.getReceivers()
+            .find((r) => r.track && r.track.id === localId);
+        if (!rtpReceiver)
+            throw new Error('new RTCRtpReceiver not');
+        // Insert into the map.
+        this._mapRecvLocalIdInfo.set(localId, { mid, rtpParameters, rtpReceiver });
+        return {
+            localId,
+            track: rtpReceiver.track,
+            rtpReceiver
+        };
+    }
+    async stopReceiving(localId) {
+        this._assertRecvDirection();
+        logger.debug('stopReceiving() [localId:%s]', localId);
+        const { mid, rtpParameters } = this._mapRecvLocalIdInfo.get(localId);
+        // Remove from the map.
+        this._mapRecvLocalIdInfo.delete(localId);
+        this._remoteSdp.planBStopReceiving({ mid, offerRtpParameters: rtpParameters });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        const answer = await this._pc.createAnswer();
+        logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+    }
+    async getReceiverStats(localId) {
+        this._assertRecvDirection();
+        const { rtpReceiver } = this._mapRecvLocalIdInfo.get(localId);
+        if (!rtpReceiver)
+            throw new Error('associated RTCRtpReceiver not found');
+        return rtpReceiver.getStats();
+    }
+    async receiveDataChannel({ sctpStreamParameters, label, protocol }) {
+        this._assertRecvDirection();
+        const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
+        const options = {
+            negotiated: true,
+            id: streamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmits,
+            protocol
+        };
+        logger.debug('receiveDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // If this is the first DataChannel we need to create the SDP offer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            this._remoteSdp.receiveSctpAssociation({ oldDataChannelSpec: true });
             const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            const answer = yield this._pc.createAnswer();
-            logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-        });
-    }
-    getReceiverStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { rtpReceiver } = this._mapRecvLocalIdInfo.get(localId);
-            if (!rtpReceiver)
-                throw new Error('associated RTCRtpReceiver not found');
-            return rtpReceiver.getStats();
-        });
-    }
-    receiveDataChannel({ sctpStreamParameters, label, protocol }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
-            const options = {
-                negotiated: true,
-                id: streamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmits,
-                protocol
-            };
-            logger.debug('receiveDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // If this is the first DataChannel we need to create the SDP offer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                this._remoteSdp.receiveSctpAssociation({ oldDataChannelSpec: true });
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                if (!this._transportReady) {
-                    const localSdpObject = sdpTransform.parse(answer.sdp);
-                    yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-                }
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-                this._hasDataChannelMediaSection = true;
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            if (!this._transportReady) {
+                const localSdpObject = sdpTransform.parse(answer.sdp);
+                await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
             }
-            return { dataChannel };
-        });
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        return { dataChannel };
     }
-    _setupTransport({ localDtlsRole, localSdpObject }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!localSdpObject)
-                localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            // Get our local DTLS parameters.
-            const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
-            // Set our DTLS role.
-            dtlsParameters.role = localDtlsRole;
-            // Update the remote DTLS role in the SDP.
-            this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
-            // Need to tell the remote transport about our parameters.
-            yield this.safeEmitAsPromise('@connect', { dtlsParameters });
-            this._transportReady = true;
-        });
+    async _setupTransport({ localDtlsRole, localSdpObject }) {
+        if (!localSdpObject)
+            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        // Get our local DTLS parameters.
+        const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
+        // Set our DTLS role.
+        dtlsParameters.role = localDtlsRole;
+        // Update the remote DTLS role in the SDP.
+        this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
+        // Need to tell the remote transport about our parameters.
+        await this.safeEmitAsPromise('@connect', { dtlsParameters });
+        this._transportReady = true;
     }
     _assertSendDirection() {
         if (this._direction !== 'send') {

--- a/lib/handlers/Safari12.js
+++ b/lib/handlers/Safari12.js
@@ -1,13 +1,4 @@
 "use strict";
-var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
-    return new (P || (P = Promise))(function (resolve, reject) {
-        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
-        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
-        step((generator = generator.apply(thisArg, _arguments || [])).next());
-    });
-};
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
@@ -59,43 +50,39 @@ class Safari12 extends HandlerInterface_1.HandlerInterface {
             catch (error) { }
         }
     }
-    getNativeRtpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeRtpCapabilities()');
-            const pc = new RTCPeerConnection({
-                iceServers: [],
-                iceTransportPolicy: 'all',
-                bundlePolicy: 'max-bundle',
-                rtcpMuxPolicy: 'require'
-            });
+    async getNativeRtpCapabilities() {
+        logger.debug('getNativeRtpCapabilities()');
+        const pc = new RTCPeerConnection({
+            iceServers: [],
+            iceTransportPolicy: 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require'
+        });
+        try {
+            pc.addTransceiver('audio');
+            pc.addTransceiver('video');
+            const offer = await pc.createOffer();
             try {
-                pc.addTransceiver('audio');
-                pc.addTransceiver('video');
-                const offer = yield pc.createOffer();
-                try {
-                    pc.close();
-                }
-                catch (error) { }
-                const sdpObject = sdpTransform.parse(offer.sdp);
-                const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
-                return nativeRtpCapabilities;
+                pc.close();
             }
-            catch (error) {
-                try {
-                    pc.close();
-                }
-                catch (error2) { }
-                throw error;
+            catch (error) { }
+            const sdpObject = sdpTransform.parse(offer.sdp);
+            const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+            return nativeRtpCapabilities;
+        }
+        catch (error) {
+            try {
+                pc.close();
             }
-        });
+            catch (error2) { }
+            throw error;
+        }
     }
-    getNativeSctpCapabilities() {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('getNativeSctpCapabilities()');
-            return {
-                numStreams: SCTP_NUM_STREAMS
-            };
-        });
+    async getNativeSctpCapabilities() {
+        logger.debug('getNativeSctpCapabilities()');
+        return {
+            numStreams: SCTP_NUM_STREAMS
+        };
     }
     run({ direction, iceParameters, iceCandidates, dtlsParameters, sctpParameters, iceServers, iceTransportPolicy, additionalSettings, proprietaryConstraints, extendedRtpCapabilities }) {
         logger.debug('run()');
@@ -116,7 +103,13 @@ class Safari12 extends HandlerInterface_1.HandlerInterface {
                 audio: ortc.getSendingRemoteRtpParameters('audio', extendedRtpCapabilities),
                 video: ortc.getSendingRemoteRtpParameters('video', extendedRtpCapabilities)
             };
-        this._pc = new RTCPeerConnection(Object.assign({ iceServers: iceServers || [], iceTransportPolicy: iceTransportPolicy || 'all', bundlePolicy: 'max-bundle', rtcpMuxPolicy: 'require' }, additionalSettings), proprietaryConstraints);
+        this._pc = new RTCPeerConnection({
+            iceServers: iceServers || [],
+            iceTransportPolicy: iceTransportPolicy || 'all',
+            bundlePolicy: 'max-bundle',
+            rtcpMuxPolicy: 'require',
+            ...additionalSettings
+        }, proprietaryConstraints);
         // Handle RTCPeerConnection connection status.
         this._pc.addEventListener('iceconnectionstatechange', () => {
             switch (this._pc.iceConnectionState) {
@@ -139,341 +132,311 @@ class Safari12 extends HandlerInterface_1.HandlerInterface {
             }
         });
     }
-    updateIceServers(iceServers) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('updateIceServers()');
-            const configuration = this._pc.getConfiguration();
-            configuration.iceServers = iceServers;
-            this._pc.setConfiguration(configuration);
-        });
+    async updateIceServers(iceServers) {
+        logger.debug('updateIceServers()');
+        const configuration = this._pc.getConfiguration();
+        configuration.iceServers = iceServers;
+        this._pc.setConfiguration(configuration);
     }
-    restartIce(iceParameters) {
-        return __awaiter(this, void 0, void 0, function* () {
-            logger.debug('restartIce()');
-            // Provide the remote SDP handler with new remote ICE parameters.
-            this._remoteSdp.updateIceParameters(iceParameters);
-            if (!this._transportReady)
-                return;
-            if (this._direction === 'send') {
-                const offer = yield this._pc.createOffer({ iceRestart: true });
-                logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-            }
-            else {
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-            }
-        });
+    async restartIce(iceParameters) {
+        logger.debug('restartIce()');
+        // Provide the remote SDP handler with new remote ICE parameters.
+        this._remoteSdp.updateIceParameters(iceParameters);
+        if (!this._transportReady)
+            return;
+        if (this._direction === 'send') {
+            const offer = await this._pc.createOffer({ iceRestart: true });
+            logger.debug('restartIce() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+        }
+        else {
+            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('restartIce() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            logger.debug('restartIce() | calling pc.setLocalDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+        }
     }
-    getTransportStats() {
-        return __awaiter(this, void 0, void 0, function* () {
-            return this._pc.getStats();
-        });
+    async getTransportStats() {
+        return this._pc.getStats();
     }
-    send({ track, encodings, codecOptions }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
-            const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
-            const transceiver = this._pc.addTransceiver(track, { direction: 'sendonly', streams: [this._sendStream] });
-            let offer = yield this._pc.createOffer();
-            let localSdpObject = sdpTransform.parse(offer.sdp);
-            let offerMediaObject;
-            const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
-            if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-            if (encodings && encodings.length > 1) {
-                logger.debug('send() | enabling legacy simulcast');
-                localSdpObject = sdpTransform.parse(offer.sdp);
-                offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
-                sdpUnifiedPlanUtils.addLegacySimulcast({
-                    offerMediaObject,
-                    numStreams: encodings.length
-                });
-                offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
-            }
-            logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            // We can now get the transceiver.mid.
-            const localId = transceiver.mid;
-            // Set MID.
-            sendingRtpParameters.mid = localId;
-            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+    async send({ track, encodings, codecOptions }) {
+        this._assertSendDirection();
+        logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+        const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
+        const transceiver = this._pc.addTransceiver(track, { direction: 'sendonly', streams: [this._sendStream] });
+        let offer = await this._pc.createOffer();
+        let localSdpObject = sdpTransform.parse(offer.sdp);
+        let offerMediaObject;
+        const sendingRtpParameters = utils.clone(this._sendingRtpParametersByKind[track.kind]);
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+        if (encodings && encodings.length > 1) {
+            logger.debug('send() | enabling legacy simulcast');
+            localSdpObject = sdpTransform.parse(offer.sdp);
             offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
-            // Set RTCP CNAME.
-            sendingRtpParameters.rtcp.cname =
-                sdpCommonUtils.getCname({ offerMediaObject });
-            // Set RTP encodings.
-            sendingRtpParameters.encodings =
-                sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
-            // Complete encodings with given values.
-            if (encodings) {
-                for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
-                    if (encodings[idx])
-                        Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
-                }
-            }
-            // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
-            // each encoding.
-            if (sendingRtpParameters.encodings.length > 1 &&
-                (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
-                    sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
-                for (const encoding of sendingRtpParameters.encodings) {
-                    encoding.scalabilityMode = 'S1T3';
-                }
-            }
-            this._remoteSdp.send({
+            sdpUnifiedPlanUtils.addLegacySimulcast({
                 offerMediaObject,
-                reuseMid: mediaSectionIdx.reuseMid,
-                offerRtpParameters: sendingRtpParameters,
-                answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
-                codecOptions
+                numStreams: encodings.length
             });
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-            // Store in the map.
-            this._mapMidTransceiver.set(localId, transceiver);
-            return {
-                localId,
-                rtpParameters: sendingRtpParameters,
-                rtpSender: transceiver.sender
-            };
-        });
-    }
-    stopSending(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('stopSending() [localId:%s]', localId);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            transceiver.sender.replaceTrack(null);
-            this._pc.removeTrack(transceiver.sender);
-            this._remoteSdp.closeMediaSection(transceiver.mid);
-            const offer = yield this._pc.createOffer();
-            logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
-            yield this._pc.setLocalDescription(offer);
-            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
-            yield this._pc.setRemoteDescription(answer);
-        });
-    }
-    replaceTrack(localId, track) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            yield transceiver.sender.replaceTrack(track);
-        });
-    }
-    setMaxSpatialLayer(localId, spatialLayer) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            const parameters = transceiver.sender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                if (idx <= spatialLayer)
-                    encoding.active = true;
-                else
-                    encoding.active = false;
-            });
-            yield transceiver.sender.setParameters(parameters);
-        });
-    }
-    setRtpEncodingParameters(localId, params) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            const parameters = transceiver.sender.getParameters();
-            parameters.encodings.forEach((encoding, idx) => {
-                parameters.encodings[idx] = Object.assign(Object.assign({}, encoding), params);
-            });
-            yield transceiver.sender.setParameters(parameters);
-        });
-    }
-    getSenderStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            return transceiver.sender.getStats();
-        });
-    }
-    sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertSendDirection();
-            const options = {
-                negotiated: true,
-                id: this._nextSendSctpStreamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmits,
-                protocol,
-                priority
-            };
-            logger.debug('sendDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // Increase next id.
-            this._nextSendSctpStreamId =
-                ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
-            // If this is the first DataChannel we need to create the SDP answer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                const offer = yield this._pc.createOffer();
-                const localSdpObject = sdpTransform.parse(offer.sdp);
-                const offerMediaObject = localSdpObject.media
-                    .find((m) => m.type === 'application');
-                if (!this._transportReady)
-                    yield this._setupTransport({ localDtlsRole: 'server', localSdpObject });
-                logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
-                yield this._pc.setLocalDescription(offer);
-                this._remoteSdp.sendSctpAssociation({ offerMediaObject });
-                const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setRemoteDescription(answer);
-                this._hasDataChannelMediaSection = true;
+            offer = { type: 'offer', sdp: sdpTransform.write(localSdpObject) };
+        }
+        logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        // We can now get the transceiver.mid.
+        const localId = transceiver.mid;
+        // Set MID.
+        sendingRtpParameters.mid = localId;
+        localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        offerMediaObject = localSdpObject.media[mediaSectionIdx.idx];
+        // Set RTCP CNAME.
+        sendingRtpParameters.rtcp.cname =
+            sdpCommonUtils.getCname({ offerMediaObject });
+        // Set RTP encodings.
+        sendingRtpParameters.encodings =
+            sdpUnifiedPlanUtils.getRtpEncodings({ offerMediaObject });
+        // Complete encodings with given values.
+        if (encodings) {
+            for (let idx = 0; idx < sendingRtpParameters.encodings.length; ++idx) {
+                if (encodings[idx])
+                    Object.assign(sendingRtpParameters.encodings[idx], encodings[idx]);
             }
-            const sctpStreamParameters = {
-                streamId: options.id,
-                ordered: options.ordered,
-                maxPacketLifeTime: options.maxPacketLifeTime,
-                maxRetransmits: options.maxRetransmits
-            };
-            return { dataChannel, sctpStreamParameters };
+        }
+        // If VP8 or H264 and there is effective simulcast, add scalabilityMode to
+        // each encoding.
+        if (sendingRtpParameters.encodings.length > 1 &&
+            (sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/vp8' ||
+                sendingRtpParameters.codecs[0].mimeType.toLowerCase() === 'video/h264')) {
+            for (const encoding of sendingRtpParameters.encodings) {
+                encoding.scalabilityMode = 'S1T3';
+            }
+        }
+        this._remoteSdp.send({
+            offerMediaObject,
+            reuseMid: mediaSectionIdx.reuseMid,
+            offerRtpParameters: sendingRtpParameters,
+            answerRtpParameters: this._sendingRemoteRtpParametersByKind[track.kind],
+            codecOptions
         });
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('send() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+        // Store in the map.
+        this._mapMidTransceiver.set(localId, transceiver);
+        return {
+            localId,
+            rtpParameters: sendingRtpParameters,
+            rtpSender: transceiver.sender
+        };
     }
-    receive({ trackId, kind, rtpParameters }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
-            const localId = String(this._mapMidTransceiver.size);
-            this._remoteSdp.receive({
-                mid: localId,
-                kind,
-                offerRtpParameters: rtpParameters,
-                streamId: rtpParameters.rtcp.cname,
-                trackId
-            });
-            const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            let answer = yield this._pc.createAnswer();
-            const localSdpObject = sdpTransform.parse(answer.sdp);
-            const answerMediaObject = localSdpObject.media
-                .find((m) => String(m.mid) === localId);
-            // May need to modify codec parameters in the answer based on codec
-            // parameters in the offer.
-            sdpCommonUtils.applyCodecParameters({
-                offerRtpParameters: rtpParameters,
-                answerMediaObject
-            });
-            answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+    async stopSending(localId) {
+        this._assertSendDirection();
+        logger.debug('stopSending() [localId:%s]', localId);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        transceiver.sender.replaceTrack(null);
+        this._pc.removeTrack(transceiver.sender);
+        this._remoteSdp.closeMediaSection(transceiver.mid);
+        const offer = await this._pc.createOffer();
+        logger.debug('stopSending() | calling pc.setLocalDescription() [offer:%o]', offer);
+        await this._pc.setLocalDescription(offer);
+        const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopSending() | calling pc.setRemoteDescription() [answer:%o]', answer);
+        await this._pc.setRemoteDescription(answer);
+    }
+    async replaceTrack(localId, track) {
+        this._assertSendDirection();
+        logger.debug('replaceTrack() [localId:%s, track.id:%s]', localId, track.id);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        await transceiver.sender.replaceTrack(track);
+    }
+    async setMaxSpatialLayer(localId, spatialLayer) {
+        this._assertSendDirection();
+        logger.debug('setMaxSpatialLayer() [localId:%s, spatialLayer:%s]', localId, spatialLayer);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        const parameters = transceiver.sender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            if (idx <= spatialLayer)
+                encoding.active = true;
+            else
+                encoding.active = false;
+        });
+        await transceiver.sender.setParameters(parameters);
+    }
+    async setRtpEncodingParameters(localId, params) {
+        this._assertSendDirection();
+        logger.debug('setRtpEncodingParameters() [localId:%s, params:%o]', localId, params);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        const parameters = transceiver.sender.getParameters();
+        parameters.encodings.forEach((encoding, idx) => {
+            parameters.encodings[idx] = { ...encoding, ...params };
+        });
+        await transceiver.sender.setParameters(parameters);
+    }
+    async getSenderStats(localId) {
+        this._assertSendDirection();
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        return transceiver.sender.getStats();
+    }
+    async sendDataChannel({ ordered, maxPacketLifeTime, maxRetransmits, label, protocol, priority }) {
+        this._assertSendDirection();
+        const options = {
+            negotiated: true,
+            id: this._nextSendSctpStreamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmits,
+            protocol,
+            priority
+        };
+        logger.debug('sendDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // Increase next id.
+        this._nextSendSctpStreamId =
+            ++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+        // If this is the first DataChannel we need to create the SDP answer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            const offer = await this._pc.createOffer();
+            const localSdpObject = sdpTransform.parse(offer.sdp);
+            const offerMediaObject = localSdpObject.media
+                .find((m) => m.type === 'application');
             if (!this._transportReady)
-                yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-            logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-            const transceiver = this._pc.getTransceivers()
-                .find((t) => t.mid === localId);
-            if (!transceiver)
-                throw new Error('new RTCRtpTransceiver not found');
-            // Store in the map.
-            this._mapMidTransceiver.set(localId, transceiver);
-            return {
-                localId,
-                track: transceiver.receiver.track,
-                rtpReceiver: transceiver.receiver
-            };
-        });
+                await this._setupTransport({ localDtlsRole: 'server', localSdpObject });
+            logger.debug('sendDataChannel() | calling pc.setLocalDescription() [offer:%o]', offer);
+            await this._pc.setLocalDescription(offer);
+            this._remoteSdp.sendSctpAssociation({ offerMediaObject });
+            const answer = { type: 'answer', sdp: this._remoteSdp.getSdp() };
+            logger.debug('sendDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setRemoteDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        const sctpStreamParameters = {
+            streamId: options.id,
+            ordered: options.ordered,
+            maxPacketLifeTime: options.maxPacketLifeTime,
+            maxRetransmits: options.maxRetransmits
+        };
+        return { dataChannel, sctpStreamParameters };
     }
-    stopReceiving(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            logger.debug('stopReceiving() [localId:%s]', localId);
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            this._remoteSdp.closeMediaSection(transceiver.mid);
+    async receive({ trackId, kind, rtpParameters }) {
+        this._assertRecvDirection();
+        logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
+        const localId = String(this._mapMidTransceiver.size);
+        this._remoteSdp.receive({
+            mid: localId,
+            kind,
+            offerRtpParameters: rtpParameters,
+            streamId: rtpParameters.rtcp.cname,
+            trackId
+        });
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('receive() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        let answer = await this._pc.createAnswer();
+        const localSdpObject = sdpTransform.parse(answer.sdp);
+        const answerMediaObject = localSdpObject.media
+            .find((m) => String(m.mid) === localId);
+        // May need to modify codec parameters in the answer based on codec
+        // parameters in the offer.
+        sdpCommonUtils.applyCodecParameters({
+            offerRtpParameters: rtpParameters,
+            answerMediaObject
+        });
+        answer = { type: 'answer', sdp: sdpTransform.write(localSdpObject) };
+        if (!this._transportReady)
+            await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
+        logger.debug('receive() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+        const transceiver = this._pc.getTransceivers()
+            .find((t) => t.mid === localId);
+        if (!transceiver)
+            throw new Error('new RTCRtpTransceiver not found');
+        // Store in the map.
+        this._mapMidTransceiver.set(localId, transceiver);
+        return {
+            localId,
+            track: transceiver.receiver.track,
+            rtpReceiver: transceiver.receiver
+        };
+    }
+    async stopReceiving(localId) {
+        this._assertRecvDirection();
+        logger.debug('stopReceiving() [localId:%s]', localId);
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        this._remoteSdp.closeMediaSection(transceiver.mid);
+        const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
+        logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
+        await this._pc.setRemoteDescription(offer);
+        const answer = await this._pc.createAnswer();
+        logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
+        await this._pc.setLocalDescription(answer);
+    }
+    async getReceiverStats(localId) {
+        this._assertRecvDirection();
+        const transceiver = this._mapMidTransceiver.get(localId);
+        if (!transceiver)
+            throw new Error('associated RTCRtpTransceiver not found');
+        return transceiver.receiver.getStats();
+    }
+    async receiveDataChannel({ sctpStreamParameters, label, protocol }) {
+        this._assertRecvDirection();
+        const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
+        const options = {
+            negotiated: true,
+            id: streamId,
+            ordered,
+            maxPacketLifeTime,
+            maxRetransmits,
+            protocol
+        };
+        logger.debug('receiveDataChannel() [options:%o]', options);
+        const dataChannel = this._pc.createDataChannel(label, options);
+        // If this is the first DataChannel we need to create the SDP offer with
+        // m=application section.
+        if (!this._hasDataChannelMediaSection) {
+            this._remoteSdp.receiveSctpAssociation();
             const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-            logger.debug('stopReceiving() | calling pc.setRemoteDescription() [offer:%o]', offer);
-            yield this._pc.setRemoteDescription(offer);
-            const answer = yield this._pc.createAnswer();
-            logger.debug('stopReceiving() | calling pc.setLocalDescription() [answer:%o]', answer);
-            yield this._pc.setLocalDescription(answer);
-        });
-    }
-    getReceiverStats(localId) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const transceiver = this._mapMidTransceiver.get(localId);
-            if (!transceiver)
-                throw new Error('associated RTCRtpTransceiver not found');
-            return transceiver.receiver.getStats();
-        });
-    }
-    receiveDataChannel({ sctpStreamParameters, label, protocol }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            this._assertRecvDirection();
-            const { streamId, ordered, maxPacketLifeTime, maxRetransmits } = sctpStreamParameters;
-            const options = {
-                negotiated: true,
-                id: streamId,
-                ordered,
-                maxPacketLifeTime,
-                maxRetransmits,
-                protocol
-            };
-            logger.debug('receiveDataChannel() [options:%o]', options);
-            const dataChannel = this._pc.createDataChannel(label, options);
-            // If this is the first DataChannel we need to create the SDP offer with
-            // m=application section.
-            if (!this._hasDataChannelMediaSection) {
-                this._remoteSdp.receiveSctpAssociation();
-                const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
-                yield this._pc.setRemoteDescription(offer);
-                const answer = yield this._pc.createAnswer();
-                if (!this._transportReady) {
-                    const localSdpObject = sdpTransform.parse(answer.sdp);
-                    yield this._setupTransport({ localDtlsRole: 'client', localSdpObject });
-                }
-                logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
-                yield this._pc.setLocalDescription(answer);
-                this._hasDataChannelMediaSection = true;
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [offer:%o]', offer);
+            await this._pc.setRemoteDescription(offer);
+            const answer = await this._pc.createAnswer();
+            if (!this._transportReady) {
+                const localSdpObject = sdpTransform.parse(answer.sdp);
+                await this._setupTransport({ localDtlsRole: 'client', localSdpObject });
             }
-            return { dataChannel };
-        });
+            logger.debug('receiveDataChannel() | calling pc.setRemoteDescription() [answer:%o]', answer);
+            await this._pc.setLocalDescription(answer);
+            this._hasDataChannelMediaSection = true;
+        }
+        return { dataChannel };
     }
-    _setupTransport({ localDtlsRole, localSdpObject }) {
-        return __awaiter(this, void 0, void 0, function* () {
-            if (!localSdpObject)
-                localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
-            // Get our local DTLS parameters.
-            const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
-            // Set our DTLS role.
-            dtlsParameters.role = localDtlsRole;
-            // Update the remote DTLS role in the SDP.
-            this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
-            // Need to tell the remote transport about our parameters.
-            yield this.safeEmitAsPromise('@connect', { dtlsParameters });
-            this._transportReady = true;
-        });
+    async _setupTransport({ localDtlsRole, localSdpObject }) {
+        if (!localSdpObject)
+            localSdpObject = sdpTransform.parse(this._pc.localDescription.sdp);
+        // Get our local DTLS parameters.
+        const dtlsParameters = sdpCommonUtils.extractDtlsParameters({ sdpObject: localSdpObject });
+        // Set our DTLS role.
+        dtlsParameters.role = localDtlsRole;
+        // Update the remote DTLS role in the SDP.
+        this._remoteSdp.updateDtlsRole(localDtlsRole === 'client' ? 'server' : 'client');
+        // Need to tell the remote transport about our parameters.
+        await this.safeEmitAsPromise('@connect', { dtlsParameters });
+        this._transportReady = true;
     }
     _assertSendDirection() {
         if (this._direction !== 'send') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 	"compilerOptions":
 	{
 		"lib": [ "es6", "es7", "dom" ],
-		"target": "es6",
+		"target": "es2020",
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"esModuleInterop": true,


### PR DESCRIPTION
Current settings in `tsconfig.target` is `es6`.
This convert this

```js
(async () => {
  await new Promise(r => setTimeout(r, 1000));
}())
```

into this.

```js
var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
    return new (P || (P = Promise))(function (resolve, reject) {
        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
        step((generator = generator.apply(thisArg, _arguments || [])).next());
    });
};
(() => __awaiter(void 0, void 0, void 0, function* () {
    yield new Promise(r => setTimeout(r, 1000));
}))();
```

Since `mediasoup-client` requires developers to use bundler, polyfill also should be responsible to developers, I think.

---

1 more question.
Why are you adding built `/lib/**/*` files under `git` and publish raw `/src/**/*.ts` files(and others including test files) to npm?
