### PR TITLE
iOS WKWebView support

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -80,6 +80,13 @@ export function detectDevice(): BuiltinHandlerName | undefined
 		const browser = Bowser.getParser(ua);
 		const engine = browser.getEngine();
 
+    const browserInfo = Bowser.parse(window.navigator.userAgent)
+    const [major, minor, patch] = browserInfo?.os?.version?.split(".") || []
+    const isIOSWebKit =
+    browserInfo?.os?.name?.toLocaleLowerCase() === "ios" &&
+      +major >= 14 &&
+      +minor >= 3
+ 
 		// Chrome and Chromium.
 		if (browser.satisfies({ chrome: '>=74', chromium: '>=74' }))
 		{
@@ -104,7 +111,7 @@ export function detectDevice(): BuiltinHandlerName | undefined
 		}
 		// Safari with Unified-Plan support enabled.
 		else if (
-			browser.satisfies({ safari: '>=12.0' }) &&
+			(isIOSWebKit || browser.satisfies({ safari: '>=12.0' })) &&
 			typeof RTCRtpTransceiver !== 'undefined' &&
 			RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection')
 		)


### PR DESCRIPTION
On iOS only look for OS version >= 14.3, which is the one where getUserMedia was released

In custom iOS apps the user agent string is not recognized by Bowser. Instead, check for OS version.

It would be great, if the internal check could be fully overridden if the user is sure it will work.