### PR TITLE
package.json: make 'fake-mediastreamtrack' a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bowser": "^2.11.0",
     "debug": "^4.3.1",
     "events": "^3.3.0",
+    "fake-mediastreamtrack": "^1.1.6",
     "h264-profile-level-id": "^1.0.1",
     "sdp-transform": "^2.14.1",
     "supports-color": "^8.1.1"
@@ -51,7 +52,6 @@
     "@typescript-eslint/parser": "^4.26.1",
     "eslint": "^7.28.0",
     "eslint-plugin-jest": "^24.3.6",
-    "fake-mediastreamtrack": "^1.1.6",
     "jest": "^27.0.4",
     "jest-tobetype": "^1.2.3",
     "open-cli": "^6.0.1",


### PR DESCRIPTION
FakeHandler directly depends on it.

Right now, a FakeHandler usage in a project dependant on
mediasoup-client will fail because 'fake-mediastreamtrack' is
unreachable.