### PR TITLE
add WeChat inline browser support on iOS whith version >=14.3

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -107,6 +107,10 @@ export function detectDevice(): BuiltinHandlerName | undefined
 		{
 			return 'Safari12';
 		}
+		// WeChat inline browser on iOS.
+		else if (browser.satisfies({ ios: { OS: '>=14.3', wechat: '>=0' } })) {
+		    return 'Safari12';
+		}
 		// Safari with Unified-Plan support enabled.
 		else if (
 			browser.satisfies({ safari: '>=12.0' }) &&


### PR DESCRIPTION
WeChat is a very popular IM App in China, so there is a lot of WebRTC scene on WeChat inline browser. The iOS with version >=14.3 has already supported WebRTC in WkWebView, this patch add the mediasoup-client support in iOS WeChat >= 14.3.