### PR TITLE
Fix Consumer creation/pause/resume in batch

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -937,11 +937,11 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 
 	_pausePendingConsumers()
 	{
+		this._consumerPauseInProgress = true;
+
 		this._awaitQueue.push(
 			async () =>
 			{
-				this._consumerPauseInProgress = true;
-
 				const pendingPauseConsumers = Array.from(this._pendingPauseConsumers.values());
 
 				// Clear pending pause Consumer map.
@@ -975,11 +975,11 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 
 	_resumePendingConsumers()
 	{
+		this._consumerResumeInProgress = true;
+
 		this._awaitQueue.push(
 			async () =>
 			{
-				this._consumerResumeInProgress = true;
-
 				const pendingResumeConsumers = Array.from(this._pendingResumeConsumers.values());
 
 				// Clear pending resume Consumer map.

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -821,11 +821,11 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 	// This method is guaranteed to never throw.
 	async _createPendingConsumers(): Promise<void>
 	{
+		this._consumerCreationInProgress = true;
+
 		this._awaitQueue.push(
 			async () =>
 			{
-				this._consumerCreationInProgress = true;
-
 				const pendingConsumerTasks = [ ...this._pendingConsumerTasks ];
 
 				// Clear pending Consumer tasks.


### PR DESCRIPTION
Currently `Transport` is using an AwaitQueue to do tasks related to peerConnection stuff. When there is a task in progress (like a consumer creation or ice stuff) and we try to pause/resume other consumers, it will add a new task to the queue for each `consumer.pause()/consumer.resume()` call instead a single one for all them. 

Why?

The `this._consumerResumeInProgress` and `this._consumerPauseInProgress` are only set as true when we start to run that task. (See https://github.com/versatica/mediasoup-client/blob/v3/src/Transport.ts#L981 and https://github.com/versatica/mediasoup-client/blob/v3/src/Transport.ts#L943)

It means that if we didn't start to process any pause/resume yet, it will add new tasks. For example:

- If we call `transport.consume()` and before this promise resolves we call `consumer1.pause()`, `consumer2.pause()`, `consumer3.pause()` it will push three new different tasks in the queue because `this._consumerPauseInProgress` is still false.

- In the first task related to pause consumers, it will call setRemoteDescription and update the state for all tracks. The other two tasks will call setRemoteDescription without changing  anything. And this could consume a lot of time and could delay another relevant tasks in the queue.