### PR TITLE
Fix typescript build error

### DIFF
--- a/src/DataConsumer.ts
+++ b/src/DataConsumer.ts
@@ -138,7 +138,7 @@ export class DataConsumer extends EnhancedEventEmitter<DataConsumerEvents>
 	 */
 	get binaryType(): BinaryType
 	{
-		return this._dataChannel.binaryType;
+		return this._dataChannel.binaryType as BinaryType;
 	}
 
 	/**


### PR DESCRIPTION
Fix typescript build error as below.

```
src/DataConsumer.ts:141:3 - error TS2322: Type 'string' is not assignable to type 'BinaryType'.

141     return this._dataChannel.binaryType;
```