### PR TITLE
Fix replacetrack when zeroRtpOnPause is enabled

### DIFF
--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -419,18 +419,15 @@ export class Producer extends EnhancedEventEmitter<ProducerEvents>
 			return;
 		}
 
-		if (!this._zeroRtpOnPause || !this._paused)
+		await new Promise<void>((resolve, reject) =>
 		{
-			await new Promise<void>((resolve, reject) =>
-			{
-				this.safeEmit(
-					'@replacetrack',
-					track,
-					resolve,
-					reject
-				);
-			});
-		}
+			this.safeEmit(
+				'@replacetrack',
+				track,
+				resolve,
+				reject
+			);
+		});
 
 		// Destroy the previous track.
 		this._destroyTrack();


### PR DESCRIPTION
When _zeroRtpOnPause is enabled replacing the track while the producer is paused doesn't work because the RtpSender track is not replaced.    Is there a reason for that behaviour different than when _zeroRtpOnPause is disabled?

When unmuting a video participant we are unpausing the producer and replacing the track with a new one from getUserMedia and we do those operations in no specific order so it can happen that the producer is still paused when replacing the track.

This PR makes the replacetrack call happen always no matter what while before it was happening always apart from that specific case.   Maybe there is a better solution or some side effects of this change so it would be good to know what you think.