### PR TITLE
Migrate ReactNative pc.addStream to pc.addTrack

### DIFF
--- a/src/handlers/ReactNative.ts
+++ b/src/handlers/ReactNative.ts
@@ -314,7 +314,7 @@ export class ReactNative extends HandlerInterface
 		}
 
 		this._sendStream.addTrack(track);
-		this._pc.addStream(this._sendStream);
+		this._pc.addTrack(track, this._sendStream);
 
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);


### PR DESCRIPTION
RTCPeerConnection.addStream is deprecated (https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream).  Let's migrate to the new addTrack API.

Because it is deprecated, right now pc.addStream is undefined in ReactNative so we cannot use mediasoupSendTransport.produce({ track }).