### PR TITLE
New streamId option in transport.consume() to tell the browser which inbound streams it should synchronize

### DIFF
--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -11,6 +11,7 @@ export type ConsumerOptions =
 	producerId?: string;
 	kind?: 'audio' | 'video';
 	rtpParameters: RtpParameters;
+	streamId?: string;
 	appData?: Record<string, unknown>;
 };
 

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -623,6 +623,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 			producerId,
 			kind,
 			rtpParameters,
+			streamId,
 			appData = {}
 		}: ConsumerOptions
 	): Promise<Consumer>
@@ -659,6 +660,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 				producerId,
 				kind,
 				rtpParameters,
+				streamId,
 				appData
 			}
 		);
@@ -850,13 +852,15 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 
 				for (const task of pendingConsumerTasks)
 				{
-					const { id, kind, rtpParameters } = task.consumerOptions;
+					const { id, kind, rtpParameters, streamId } = task.consumerOptions;
 
-					optionsList.push({
-						trackId : id!,
-						kind    : kind as 'audio' | 'video',
-						rtpParameters
-					});
+					optionsList.push(
+						{
+							trackId : id!,
+							kind    : kind as MediaKind,
+							rtpParameters,
+							streamId
+						});
 				}
 
 				try

--- a/src/handlers/Chrome55.ts
+++ b/src/handlers/Chrome55.ts
@@ -615,19 +615,18 @@ export class Chrome55 extends HandlerInterface
 
 		for (const options of optionsList)
 		{
-			const { trackId, kind, rtpParameters } = options;
+			const { trackId, kind, rtpParameters, streamId } = options;
 
 			logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
 
 			const mid = kind;
-			const streamId = rtpParameters.rtcp!.cname!;
 
 			this._remoteSdp!.receive(
 				{
 					mid,
 					kind,
 					offerRtpParameters : rtpParameters,
-					streamId,
+					streamId           : streamId || rtpParameters.rtcp!.cname!,
 					trackId
 				});
 		}
@@ -681,7 +680,7 @@ export class Chrome55 extends HandlerInterface
 			const { kind, trackId, rtpParameters } = options;
 			const mid = kind;
 			const localId = trackId;
-			const streamId = rtpParameters.rtcp!.cname!;
+			const streamId = options.streamId || rtpParameters.rtcp!.cname!;
 			const stream = this._pc.getRemoteStreams()
 				.find((s: any) => s.id === streamId);
 			const track = stream.getTrackById(localId);

--- a/src/handlers/Chrome67.ts
+++ b/src/handlers/Chrome67.ts
@@ -683,7 +683,6 @@ export class Chrome67 extends HandlerInterface
 	}
 
 	async receive(
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
 		optionsList: HandlerReceiveOptions[]
 	) : Promise<HandlerReceiveResult[]>
 	{
@@ -693,7 +692,7 @@ export class Chrome67 extends HandlerInterface
 
 		for (const options of optionsList)
 		{
-			const { trackId, kind, rtpParameters } = options;
+			const { trackId, kind, rtpParameters, streamId } = options;
 
 			logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
 
@@ -704,7 +703,7 @@ export class Chrome67 extends HandlerInterface
 					mid,
 					kind,
 					offerRtpParameters : rtpParameters,
-					streamId           : rtpParameters.rtcp!.cname!,
+					streamId           : streamId || rtpParameters.rtcp!.cname!,
 					trackId
 				});
 		}

--- a/src/handlers/Chrome70.ts
+++ b/src/handlers/Chrome70.ts
@@ -712,7 +712,7 @@ export class Chrome70 extends HandlerInterface
 
 		for (const options of optionsList)
 		{
-			const { trackId, kind, rtpParameters } = options;
+			const { trackId, kind, rtpParameters, streamId } = options;
 
 			logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
 
@@ -725,7 +725,7 @@ export class Chrome70 extends HandlerInterface
 					mid                : localId,
 					kind,
 					offerRtpParameters : rtpParameters,
-					streamId           : rtpParameters.rtcp!.cname!,
+					streamId           : streamId || rtpParameters.rtcp!.cname!,
 					trackId
 				});
 		}

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -749,7 +749,7 @@ export class Chrome74 extends HandlerInterface
 
 		for (const options of optionsList)
 		{
-			const { trackId, kind, rtpParameters } = options;
+			const { trackId, kind, rtpParameters, streamId } = options;
 
 			logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
 
@@ -762,7 +762,7 @@ export class Chrome74 extends HandlerInterface
 					mid                : localId,
 					kind,
 					offerRtpParameters : rtpParameters,
-					streamId           : rtpParameters.rtcp!.cname!,
+					streamId           : streamId || rtpParameters.rtcp!.cname!,
 					trackId
 				});
 		}

--- a/src/handlers/Firefox60.ts
+++ b/src/handlers/Firefox60.ts
@@ -742,7 +742,7 @@ export class Firefox60 extends HandlerInterface
 
 		for (const options of optionsList)
 		{
-			const { trackId, kind, rtpParameters } = options;
+			const { trackId, kind, rtpParameters, streamId } = options;
 
 			logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
 
@@ -755,7 +755,7 @@ export class Firefox60 extends HandlerInterface
 					mid                : localId,
 					kind,
 					offerRtpParameters : rtpParameters,
-					streamId           : rtpParameters.rtcp!.cname!,
+					streamId           : streamId || rtpParameters.rtcp!.cname!,
 					trackId
 				});
 		}

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -54,6 +54,13 @@ export type HandlerReceiveOptions =
 	trackId: string;
 	kind: 'audio' | 'video';
 	rtpParameters: RtpParameters;
+	/**
+	 * Stream id. WebRTC based devices try to synchronize inbound streams with
+	 * same streamId. If not given, the consuming device will be told to
+	 * synchronize all streams produced by the same endpoint. However libwebrtc
+	 * can just synchronize up to one audio stream with one video stream.
+	 */
+	streamId?: string;
 };
 
 export type HandlerReceiveResult =

--- a/src/handlers/ReactNative.ts
+++ b/src/handlers/ReactNative.ts
@@ -629,7 +629,7 @@ export class ReactNative extends HandlerInterface
 			logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
 
 			const mid = kind;
-			let streamId = rtpParameters.rtcp!.cname!;
+			let streamId = options.streamId || rtpParameters.rtcp!.cname!;
 
 			// NOTE: In React-Native we cannot reuse the same remote MediaStream for new
 			// remote tracks. This is because react-native-webrtc does not react on new

--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -754,7 +754,7 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 
 		for (const options of optionsList)
 		{
-			const { trackId, kind, rtpParameters } = options;
+			const { trackId, kind, rtpParameters, streamId } = options;
 
 			logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
 
@@ -767,7 +767,7 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 					mid                : localId,
 					kind,
 					offerRtpParameters : rtpParameters,
-					streamId           : rtpParameters.rtcp!.cname!,
+					streamId           : streamId || rtpParameters.rtcp!.cname!,
 					trackId
 				});
 		}

--- a/src/handlers/Safari11.ts
+++ b/src/handlers/Safari11.ts
@@ -686,7 +686,7 @@ export class Safari11 extends HandlerInterface
 
 		for (const options of optionsList)
 		{
-			const { trackId, kind, rtpParameters } = options;
+			const { trackId, kind, rtpParameters, streamId } = options;
 
 			logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
 
@@ -697,7 +697,7 @@ export class Safari11 extends HandlerInterface
 					mid,
 					kind,
 					offerRtpParameters : rtpParameters,
-					streamId           : rtpParameters.rtcp!.cname!,
+					streamId           : streamId || rtpParameters.rtcp!.cname!,
 					trackId
 				});
 		}

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -704,7 +704,7 @@ export class Safari12 extends HandlerInterface
 
 		for (const options of optionsList)
 		{
-			const { trackId, kind, rtpParameters } = options;
+			const { trackId, kind, rtpParameters, streamId } = options;
 
 			logger.debug('receive() [trackId:%s, kind:%s]', trackId, kind);
 
@@ -717,7 +717,7 @@ export class Safari12 extends HandlerInterface
 					mid                : localId,
 					kind,
 					offerRtpParameters : rtpParameters,
-					streamId           : rtpParameters.rtcp!.cname!,
+					streamId           : streamId || rtpParameters.rtcp!.cname!,
 					trackId
 				});
 		}


### PR DESCRIPTION
Fixes #233

Given that libwebrtc can synchronize up to one inbound audio stream and one inbound video stream, the app may wish to have inbound mic and webcam streams synchronized rather than synchronizing inbound mic and screen share streams.

Usage example:

* When consuming a mic Producer:
  ```ts
  transport.consume({ streamId: `${remotePeerId}-mic-webcam`, etc })
  ```
* When consuming a webcam Producer:
  ```ts
  transport.consume({ streamId: `${remotePeerId}-mic-webcam`, etc })
  ```
* When consuming an screen sharing Producer:
  ```ts
  transport.consume({ streamId: `${remotePeerId}-screensharing`, etc })
  ```

Remote SDP offer in latest Chrome when receiving mic, webcam and screen sharing:

```
v=0
o=- 10000 4 IN IP4 127.0.0.1
s=-
t=0 0
a=group:BUNDLE 0 datachannel 1 probator
a=msid-semantic: WMS gye9ipnt-mic-webcam
a=ice-lite
m=audio 44444 UDP/TLS/RTP/SAVPF 100
c=IN IP4 172.20.10.2
a=rtcp:9 IN IP4 0.0.0.0
a=candidate:udpcandidate 1 udp 1076302079 172.20.10.2 44444 typ host generation 0
a=ice-ufrag:55kaxkm797xc5i7qi69bypr8msm9qrcf
a=ice-pwd:3jiwn24dztvmzkd0ss3l8v1u4ion0tqp
a=ice-options:renomination
a=fingerprint:sha-224 95:0A:90:2E:A4:E9:29:D1:73:06:F9:12:8D:70:8B:F0:24:A9:C4:3D:0D:25:05:74:E6:D2:6A:B2
a=setup:actpass
a=mid:0
a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:10 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=sendonly
a=msid:gye9ipnt-mic-webcam 3dc5dfe9-80ac-41b8-bf2b-48a1cdbfc162
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:100 opus/48000/2
a=fmtp:100 minptime=10;sprop-stereo=1;usedtx=1;useinbandfec=1
a=ssrc:408884778 cname:y+HmaGqrdr+ldLD9
m=application 44444 UDP/DTLS/SCTP webrtc-datachannel
c=IN IP4 172.20.10.2
a=candidate:udpcandidate 1 udp 1076302079 172.20.10.2 44444 typ host generation 0
a=ice-ufrag:55kaxkm797xc5i7qi69bypr8msm9qrcf
a=ice-pwd:3jiwn24dztvmzkd0ss3l8v1u4ion0tqp
a=ice-options:renomination
a=fingerprint:sha-224 95:0A:90:2E:A4:E9:29:D1:73:06:F9:12:8D:70:8B:F0:24:A9:C4:3D:0D:25:05:74:E6:D2:6A:B2
a=setup:actpass
a=mid:datachannel
a=sctp-port:5000
a=max-message-size:262144
m=video 44444 UDP/TLS/RTP/SAVPF 101 102
c=IN IP4 172.20.10.2
a=rtcp:9 IN IP4 0.0.0.0
a=candidate:udpcandidate 1 udp 1076302079 172.20.10.2 44444 typ host generation 0
a=ice-ufrag:55kaxkm797xc5i7qi69bypr8msm9qrcf
a=ice-pwd:3jiwn24dztvmzkd0ss3l8v1u4ion0tqp
a=ice-options:renomination
a=fingerprint:sha-224 95:0A:90:2E:A4:E9:29:D1:73:06:F9:12:8D:70:8B:F0:24:A9:C4:3D:0D:25:05:74:E6:D2:6A:B2
a=setup:actpass
a=mid:1
a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:11 urn:3gpp:video-orientation
a=extmap:12 urn:ietf:params:rtp-hdrext:toffset
a=sendonly
a=msid:gye9ipnt-mic-webcam 894e5e01-7337-4ad1-a786-6361239ecc86
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:101 VP8/90000
a=rtcp-fb:101 transport-cc
a=rtcp-fb:101 ccm fir
a=rtcp-fb:101 nack
a=rtcp-fb:101 nack pli
a=rtpmap:102 rtx/90000
a=fmtp:102 apt=101
a=ssrc-group:FID 327518264 327518265
a=ssrc:327518264 cname:y+HmaGqrdr+ldLD9
a=ssrc:327518265 cname:y+HmaGqrdr+ldLD9
m=video 44444 UDP/TLS/RTP/SAVPF 127
c=IN IP4 172.20.10.2
a=rtcp:9 IN IP4 0.0.0.0
a=candidate:udpcandidate 1 udp 1076302079 172.20.10.2 44444 typ host generation 0
a=ice-ufrag:55kaxkm797xc5i7qi69bypr8msm9qrcf
a=ice-pwd:3jiwn24dztvmzkd0ss3l8v1u4ion0tqp
a=ice-options:renomination
a=fingerprint:sha-224 95:0A:90:2E:A4:E9:29:D1:73:06:F9:12:8D:70:8B:F0:24:A9:C4:3D:0D:25:05:74:E6:D2:6A:B2
a=setup:actpass
a=mid:probator
a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:4 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=extmap:5 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
a=extmap:11 urn:3gpp:video-orientation
a=extmap:12 urn:ietf:params:rtp-hdrext:toffset
a=sendonly
a=msid:probator probator
a=rtcp-mux
a=rtcp-rsize
a=rtpmap:127 VP8/90000
a=rtcp-fb:127 transport-cc
a=rtcp-fb:127 ccm fir
a=rtcp-fb:127 nack
a=rtcp-fb:127 nack pli
a=ssrc:1234 cname:probator
```