### PR TITLE
Update scalability mode for latest Chrome and Firefox

### DIFF
--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -421,7 +421,7 @@ export class Chrome74 extends HandlerInterface
 		{
 			for (const encoding of sendingRtpParameters.encodings)
 			{
-				encoding.scalabilityMode = 'S1T3';
+				encoding.scalabilityMode = 'S1T2';
 			}
 		}
 

--- a/src/handlers/Firefox60.ts
+++ b/src/handlers/Firefox60.ts
@@ -417,7 +417,7 @@ export class Firefox60 extends HandlerInterface
 		{
 			for (const encoding of sendingRtpParameters.encodings)
 			{
-				encoding.scalabilityMode = 'S1T3';
+				encoding.scalabilityMode = 'S1T2';
 			}
 		}
 


### PR DESCRIPTION
Temporal layers per stream were downgraded from three to two time ago.

* Safari Tech Preview still uses 3 temporal layers.
* I did not test ReactNative, so I'm keeping it as it was.

https://bugs.chromium.org/p/webrtc/issues/detail?id=11366
https://groups.google.com/g/discuss-webrtc/c/N1sMEBJhOz4