### PR TITLE
fix: Improve batching behaviour with parallel calls to consume()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "debug": "^4.3.4",
         "events": "^3.3.0",
         "h264-profile-level-id": "^1.0.1",
+        "queue-microtask": "^1.2.3",
         "sdp-transform": "^2.14.1",
         "supports-color": "^9.3.1"
       },
@@ -4671,7 +4672,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9202,8 +9202,7 @@
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
     },
     "quick-lru": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "debug": "^4.3.4",
     "events": "^3.3.0",
     "h264-profile-level-id": "^1.0.1",
+    "queue-microtask": "^1.2.3",
     "sdp-transform": "^2.14.1",
     "supports-color": "^9.3.1"
   },

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -674,6 +674,10 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 		// There is no Consumer creation in progress, create it now.
 		queueMicrotask(() => 
 		{
+			if (this._closed) {
+				throw new InvalidStateError('closed');
+			}
+
 			if (this._consumerCreationInProgress === false)
 			{
 				this.createPendingConsumers();

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -11,6 +11,7 @@ import { DataProducer, DataProducerOptions } from './DataProducer';
 import { DataConsumer, DataConsumerOptions } from './DataConsumer';
 import { RtpParameters, MediaKind } from './RtpParameters';
 import { SctpParameters, SctpStreamParameters } from './SctpParameters';
+import queueMicrotask from 'queue-microtask';
 
 const logger = new Logger('Transport');
 
@@ -671,10 +672,13 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 		this._pendingConsumerTasks.push(consumerCreationTask);
 
 		// There is no Consumer creation in progress, create it now.
-		if (this._consumerCreationInProgress === false)
+		queueMicrotask(() => 
 		{
-			this.createPendingConsumers();
-		}
+			if (this._consumerCreationInProgress === false)
+			{
+				this.createPendingConsumers();
+			}
+		});
 
 		return consumerCreationTask.promise;
 	}
@@ -1231,10 +1235,13 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 			this._pendingPauseConsumers.set(consumer.id, consumer);
 
 			// There is no Consumer pause in progress, do it now.
-			if (this._consumerPauseInProgress === false)
+			queueMicrotask(() => 
 			{
-				this.pausePendingConsumers();
-			}
+				if (this._consumerPauseInProgress === false)
+				{
+					this.pausePendingConsumers();
+				}
+			});
 		});
 
 		consumer.on('@resume', () =>
@@ -1249,10 +1256,13 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 			this._pendingResumeConsumers.set(consumer.id, consumer);
 
 			// There is no Consumer resume in progress, do it now.
-			if (this._consumerResumeInProgress === false)
+			queueMicrotask(() => 
 			{
-				this.resumePendingConsumers();
-			}
+				if (this._consumerResumeInProgress === false)
+				{
+					this.resumePendingConsumers();
+				}
+			});
 		});
 
 		consumer.on('@getstats', (callback, errback) =>

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -11,6 +11,7 @@ import * as utils from '../utils';
 import { RemoteSdp } from '../handlers/sdp/RemoteSdp';
 import { FakeHandler } from '../handlers/FakeHandler';
 import * as fakeParameters from './fakeParameters';
+import { AwaitQueue } from 'awaitqueue';
 
 const {
 	Device,
@@ -785,6 +786,55 @@ test('transport.consume() succeeds', async () =>
 	expect(videoConsumer.appData).toEqual({});
 
 	recvTransport.removeAllListeners('connect');
+}, 500);
+
+test('transport.consume() batches consumers created in same macrotask into the same task', async () =>
+{
+	const videoConsumerRemoteParameters1 =
+		fakeParameters.generateConsumerRemoteParameters({ codecMimeType: 'video/VP8' });
+	const videoConsumerRemoteParameters2 =
+		fakeParameters.generateConsumerRemoteParameters({ codecMimeType: 'video/VP8' });
+
+	const pushSpy = jest.spyOn((recvTransport as unknown as { _awaitQueue: AwaitQueue })._awaitQueue, 'push');
+
+	const waitForConsumer = (id: string | undefined): Promise<void> =>
+	{
+		return new Promise<void>((resolve) =>
+		{
+			recvTransport.observer.on('newconsumer', (consumer) =>
+			{
+				if (consumer.id === id)
+				{
+					resolve();
+				}
+			});
+		});
+	};
+	const allConsumersCreated = Promise.all([
+		waitForConsumer(videoConsumerRemoteParameters1.id),
+		waitForConsumer(videoConsumerRemoteParameters2.id)
+	]);
+
+	await Promise.all([
+		recvTransport.consume(
+			{
+				id            : videoConsumerRemoteParameters1.id,
+				producerId    : videoConsumerRemoteParameters1.producerId,
+				kind          : videoConsumerRemoteParameters1.kind,
+				rtpParameters : videoConsumerRemoteParameters1.rtpParameters
+			}),
+		recvTransport.consume(
+			{
+				id            : videoConsumerRemoteParameters2.id,
+				producerId    : videoConsumerRemoteParameters2.producerId,
+				kind          : videoConsumerRemoteParameters2.kind,
+				rtpParameters : videoConsumerRemoteParameters2.rtpParameters
+			})
+	]);
+
+	await allConsumersCreated;
+
+	expect(pushSpy).toBeCalledTimes(1);
 }, 500);
 
 test('transport.consume() without remote Consumer parameters rejects with TypeError', async () =>

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -810,10 +810,12 @@ test('transport.consume() batches consumers created in same macrotask into the s
 			});
 		});
 	};
-	const allConsumersCreated = Promise.all([
-		waitForConsumer(videoConsumerRemoteParameters1.id),
-		waitForConsumer(videoConsumerRemoteParameters2.id)
-	]);
+
+	const allConsumersCreated = Promise.all(
+		[
+			waitForConsumer(videoConsumerRemoteParameters1.id),
+			waitForConsumer(videoConsumerRemoteParameters2.id)
+		]);
 
 	await Promise.all([
 		recvTransport.consume(


### PR DESCRIPTION
When creating multiple consumers in parallel like this:
```
await Promise.all([
  transport.consume(/* ... */), 
  transport.consume(/* ... */), 
  // ...
])
```
The awaitQueue will be pushed a consumer creation task with the first consumer, then another with all the other consumers. This inefficient batching slows down consumer creation.

To improve this, this PR waits for any existing microtasks to finish before creating the first task. This results in at most one task pushed to the awaitQueue for any calls to consume() still in the microtask queue. The same optimization was applied to pausing/resuming consumers.