### PR TITLE
Honor given encoding.scalabilityMode

### DIFF
--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -433,7 +433,16 @@ export class Chrome74 extends HandlerInterface
 		{
 			for (const encoding of sendingRtpParameters.encodings)
 			{
-				encoding.scalabilityMode = 'S1T2';
+				if (encoding.scalabilityMode)
+				{
+					encoding.scalabilityMode = `S1T${layers.temporalLayers}`;
+				}
+				else
+				{
+					// By default Chrome enables 2 temporal layers (not in all OS but
+					// anyway).
+					encoding.scalabilityMode = 'S1T2';
+				}
 			}
 		}
 

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -18,6 +18,7 @@ import {
 	HandlerReceiveDataChannelResult
 } from './HandlerInterface';
 import { RemoteSdp } from './sdp/RemoteSdp';
+import { parse as parseScalabilityMode } from '../scalabilityModes';
 import { IceParameters, DtlsRole } from '../Transport';
 import { RtpCapabilities, RtpParameters } from '../RtpParameters';
 import { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
@@ -327,6 +328,9 @@ export class Safari12 extends HandlerInterface
 				});
 		}
 
+		const layers =
+			parseScalabilityMode((encodings || [ {} ])[0].scalabilityMode);
+
 		if (encodings && encodings.length > 1)
 		{
 			logger.debug('send() | enabling legacy simulcast');
@@ -388,7 +392,15 @@ export class Safari12 extends HandlerInterface
 		{
 			for (const encoding of sendingRtpParameters.encodings)
 			{
-				encoding.scalabilityMode = 'S1T3';
+				if (encoding.scalabilityMode)
+				{
+					encoding.scalabilityMode = `S1T${layers.temporalLayers}`;
+				}
+				else
+				{
+					// By default Safari enables 3 temporal layers.
+					encoding.scalabilityMode = 'S1T3';
+				}
 			}
 		}
 


### PR DESCRIPTION
`transport.produce()`: If the app includes  `scalabilityMode` field in `encodings`, honor given number of temporal layers.

Maybe important thing here:

- Imagine the app passes `scalabilityMode: 'S2T2'.
- We honor it. We are in Safari (which as per today generates **3 temporal layers**).
- In mediasoup Producer stats we'll just see stats for 2 temporal layers (since we signaled `S2T2` to mediasoup `produce()`).
- Are we discarding temporal layer 2 in mediasoup???? NOTE: This is another topic anyway.