### PR TITLE
fix(svc): simulcast/svc broken on M111 because S1T2 is not valid for VP8, use L1T2 instead

### DIFF
--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -435,13 +435,13 @@ export class Chrome74 extends HandlerInterface
 			{
 				if (encoding.scalabilityMode)
 				{
-					encoding.scalabilityMode = `S1T${layers.temporalLayers}`;
+					encoding.scalabilityMode = `L1T${layers.temporalLayers}`;
 				}
 				else
 				{
 					// By default Chrome enables 2 temporal layers (not in all OS but
 					// anyway).
-					encoding.scalabilityMode = 'S1T2';
+					encoding.scalabilityMode = 'L1T2';
 				}
 			}
 		}

--- a/src/handlers/Firefox60.ts
+++ b/src/handlers/Firefox60.ts
@@ -435,12 +435,12 @@ export class Firefox60 extends HandlerInterface
 			{
 				if (encoding.scalabilityMode)
 				{
-					encoding.scalabilityMode = `S1T${layers.temporalLayers}`;
+					encoding.scalabilityMode = `L1T${layers.temporalLayers}`;
 				}
 				else
 				{
 					// By default Firefox enables 2 temporal layers.
-					encoding.scalabilityMode = 'S1T2';
+					encoding.scalabilityMode = 'L1T2';
 				}
 			}
 		}


### PR DESCRIPTION
Chrome M111 (just became "beta" version yesterday), is rolling out support for SVC, which was previously only behind a flag called "RTCSvcScalabilityMode". 

(Chromium commit: https://chromium.googlesource.com/chromium/src/+/a32ab6f178f6aeb5674afad69c1dfcf83d2a41db%5E%21/#F0)
(I2S:https://groups.google.com/a/chromium.org/g/blink-dev/c/XzygOFuas2A/m/imTtbDqPBgAJ)


This means that chrome will now actually check if the `scalabilityMode` passed in the encodings array is a valid string, because of this patch (https://webrtc-review.googlesource.com/c/src/+/277403). This also means that number of temporal layers are actually respected by chrome.

According to the SVC spec (https://w3c.github.io/webrtc-svc/#scalabilitymodes*):

> For example, VP8 [[RFC6386](https://w3c.github.io/webrtc-svc/#bib-rfc6386)] only supports temporal scalability (e.g. ["L1T2"](https://w3c.github.io/webrtc-svc/#dfn-l1t2), ["L1T3"](https://w3c.github.io/webrtc-svc/#dfn-l1t3))

Therefore, "S" can't be passed for the vp8 codec.

This is also enforced by libwebrtc: 

- for vp8, valid scalability modes are: 
```
ScalabilityMode::kL1T1, ScalabilityMode::kL1T2, ScalabilityMode::kL1T3
```
https://webrtc.googlesource.com/src/+/a1a7c638ece600a0d9e2a1f7d77e1a9050737e90/modules/video_coding/codecs/vp8/vp8_scalability.h
- for vp9/h264, valid scalability modes are documented here (https://webrtc.googlesource.com/src/+/ecfe8da46b22883363a66d0909d7d2246cb13c48/modules/video_coding/svc/create_scalability_structure.cc)

This PR switches from using "S" in scalability modes to "L" to prevent mediasoup from crashing on M111.

**Steps to Reproduce**
1. Open mediasoup demo in chrome dev (Version: M111 or above)
2. Start producing video
3. Console should show folllowing error, and addTransceiver should fail:

![image](https://user-images.githubusercontent.com/7080652/218861871-b5206fcf-f2b2-49f9-821b-9bb58e9d99f6.png)


thanks @CallMeTarush , @palashgo for discovering this