### PR TITLE
Add support for RTCP NACK in OPUS

### DIFF
--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -31,6 +31,7 @@ export type ProducerCodecOptions =
 	opusMaxPlaybackRate?: number;
 	opusMaxAverageBitrate?: number;
 	opusPtime?: number;
+	opusNack?: boolean;
 	videoGoogleStartBitrate?: number;
 	videoGoogleMaxBitrate?: number;
 	videoGoogleMinBitrate?: number;

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -4,6 +4,7 @@ import * as utils from '../utils';
 import * as ortc from '../ortc';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
+import * as ortcUtils from './ortc/utils';
 import {
 	HandlerFactory,
 	HandlerInterface,
@@ -113,6 +114,9 @@ export class Chrome111 extends HandlerInterface
 			const sdpObject = sdpTransform.parse(offer.sdp);
 			const nativeRtpCapabilities =
 				sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+
+			// libwebrtc supports NACK for OPUS but doesn't announce it.
+			ortcUtils.addNackSuppportForOpus(nativeRtpCapabilities);
 
 			return nativeRtpCapabilities;
 		}

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -4,6 +4,7 @@ import * as utils from '../utils';
 import * as ortc from '../ortc';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
+import * as ortcUtils from './ortc/utils';
 import {
 	HandlerFactory,
 	HandlerInterface,
@@ -117,6 +118,9 @@ export class Chrome74 extends HandlerInterface
 			const sdpObject = sdpTransform.parse(offer.sdp);
 			const nativeRtpCapabilities =
 				sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+
+			// libwebrtc supports NACK for OPUS but doesn't announce it.
+			ortcUtils.addNackSuppportForOpus(nativeRtpCapabilities);
 
 			return nativeRtpCapabilities;
 		}

--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -4,6 +4,7 @@ import * as utils from '../utils';
 import * as ortc from '../ortc';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
+import * as ortcUtils from './ortc/utils';
 import {
 	HandlerFactory,
 	HandlerInterface,
@@ -122,6 +123,9 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 			const sdpObject = sdpTransform.parse(offer.sdp);
 			const nativeRtpCapabilities =
 				sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+
+			// libwebrtc supports NACK for OPUS but doesn't announce it.
+			ortcUtils.addNackSuppportForOpus(nativeRtpCapabilities);
 
 			return nativeRtpCapabilities;
 		}

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -4,6 +4,7 @@ import * as utils from '../utils';
 import * as ortc from '../ortc';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
+import * as ortcUtils from './ortc/utils';
 import {
 	HandlerFactory,
 	HandlerInterface,
@@ -112,6 +113,9 @@ export class Safari12 extends HandlerInterface
 			const sdpObject = sdpTransform.parse(offer.sdp);
 			const nativeRtpCapabilities =
 				sdpCommonUtils.extractRtpCapabilities({ sdpObject });
+
+			// libwebrtc supports NACK for OPUS but doesn't announce it.
+			ortcUtils.addNackSuppportForOpus(nativeRtpCapabilities);
 
 			return nativeRtpCapabilities;
 		}

--- a/src/handlers/ortc/utils.ts
+++ b/src/handlers/ortc/utils.ts
@@ -1,0 +1,26 @@
+import { RtpCapabilities } from '../../RtpParameters';
+
+/**
+ * This function adds RTCP NACK support for OPUS codec in given capabilities.
+ */
+export function addNackSuppportForOpus(rtpCapabilities: RtpCapabilities): void
+{
+	for (const codec of (rtpCapabilities.codecs || []))
+	{
+		if (
+			(
+				codec.mimeType.toLowerCase() === 'audio/opus' ||
+				codec.mimeType.toLowerCase() === 'audio/multiopus'
+			) &&
+			!codec.rtcpFeedback?.some((fb) => fb.type === 'nack' && !fb.parameter)
+		)
+		{
+			if (!codec.rtcpFeedback)
+			{
+				codec.rtcpFeedback = [];
+			}
+
+			codec.rtcpFeedback.push({ type: 'nack' });
+		}
+	}
+}


### PR DESCRIPTION
Inspired by PR https://github.com/versatica/mediasoup-client/pull/242 by @t-mullen.

### Details

- Make modern libwebrtc based mediasoup-client handlers announce support for NACK in OPUS codec.
- Add a new `opusNack` boolean option in `ProducerOptions`. It's false by default. If set to `true` (and assuming the mediasoup endpoint supports NACK for OPUS AKA https://github.com/versatica/mediasoup/pull/1015), then NACK will be negotiated.
- When it comes to consume an OPUS stream, if the Consumer's RTCP feedback includes NACK, then it will be honoured so the browser will request OPUS packet retransmission to mediasoup in case of packet loss.

Those are mediasoup side Producer and Consumer stats when artificial packet loss is generated in inbound and outbound streams:

* `producer.getStats()`:
  ```json
  {
    "bitrate": 12400,
    "byteCount": 97681,
    "firCount": 0,
    "fractionLost": 0,
    "jitter": 0,
    "kind": "audio",
    "mimeType": "audio/opus",
    "nackCount": 40,
    "nackPacketCount": 40,
    "packetCount": 3151,
    "packetsDiscarded": 0,
    "packetsLost": 0,
    "packetsRepaired": 38,
    "packetsRetransmitted": 38,
    "pliCount": 0,
    "roundTripTime": 0,
    "score": 10,
    "ssrc": 2401510280,
    "timestamp": 95675530,
    "type": "inbound-rtp"
  }
  ```

* `consumer.getStats()`:
  ```json
  {
    "bitrate": 12400,
    "byteCount": 97619,
    "firCount": 0,
    "fractionLost": 0,
    "kind": "audio",
    "mimeType": "audio/opus",
    "nackCount": 641,
    "nackPacketCount": 641,
    "packetCount": 3149,
    "packetsDiscarded": 0,
    "packetsLost": 14,
    "packetsRepaired": 607,
    "packetsRetransmitted": 607,
    "pliCount": 0,
    "roundTripTime": 0.42724609375,
    "score": 10,
    "ssrc": 686300680,
    "timestamp": 95675530,
    "type": "outbound-rtp"
  }
  ```
