### PR TITLE
Make AppData typed and writable

### DIFF
--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -2,17 +2,18 @@ import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import { InvalidStateError } from './errors';
 import { MediaKind, RtpParameters } from './RtpParameters';
+import { AppData } from './types';
 
 const logger = new Logger('Consumer');
 
-export type ConsumerOptions =
+export type ConsumerOptions<ConsumerAppData extends AppData = AppData> =
 {
 	id?: string;
 	producerId?: string;
 	kind?: 'audio' | 'video';
 	rtpParameters: RtpParameters;
 	streamId?: string;
-	appData?: Record<string, unknown>;
+	appData?: ConsumerAppData;
 };
 
 export type ConsumerEvents =
@@ -34,7 +35,8 @@ export type ConsumerObserverEvents =
 	trackended: [];
 };
 
-export class Consumer extends EnhancedEventEmitter<ConsumerEvents>
+export class Consumer<ConsumerAppData extends AppData = AppData>
+	extends EnhancedEventEmitter<ConsumerEvents>
 {
 	// Id.
 	private readonly _id: string;
@@ -53,7 +55,7 @@ export class Consumer extends EnhancedEventEmitter<ConsumerEvents>
 	// Paused flag.
 	private _paused: boolean;
 	// App custom data.
-	private readonly _appData: Record<string, unknown>;
+	private _appData: ConsumerAppData;
 	// Observer instance.
 	protected readonly _observer = new EnhancedEventEmitter<ConsumerObserverEvents>();
 
@@ -74,7 +76,7 @@ export class Consumer extends EnhancedEventEmitter<ConsumerEvents>
 			rtpReceiver?: RTCRtpReceiver;
 			track: MediaStreamTrack;
 			rtpParameters: RtpParameters;
-			appData?: Record<string, unknown>;
+			appData?: ConsumerAppData;
 		}
 	)
 	{
@@ -89,7 +91,7 @@ export class Consumer extends EnhancedEventEmitter<ConsumerEvents>
 		this._track = track;
 		this._rtpParameters = rtpParameters;
 		this._paused = !track.enabled;
-		this._appData = appData || {};
+		this._appData = appData || {} as ConsumerAppData;
 		this.onTrackEnded = this.onTrackEnded.bind(this);
 
 		this.handleTrack();
@@ -170,18 +172,17 @@ export class Consumer extends EnhancedEventEmitter<ConsumerEvents>
 	/**
 	 * App custom data.
 	 */
-	get appData(): Record<string, unknown>
+	get appData(): ConsumerAppData
 	{
 		return this._appData;
 	}
 
 	/**
-	 * Invalid setter.
+	 * App custom data setter.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	set appData(appData: Record<string, unknown>)
+	set appData(appData: ConsumerAppData)
 	{
-		throw new Error('cannot override appData object');
+		this._appData = appData;
 	}
 
 	get observer(): EnhancedEventEmitter

--- a/src/DataConsumer.ts
+++ b/src/DataConsumer.ts
@@ -1,17 +1,18 @@
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import { SctpStreamParameters } from './SctpParameters';
+import { AppData } from './types';
 
 const logger = new Logger('DataConsumer');
 
-export type DataConsumerOptions =
+export type DataConsumerOptions<DataConsumerAppData extends AppData = AppData> =
 {
 	id?: string;
 	dataProducerId?: string;
 	sctpStreamParameters: SctpStreamParameters;
 	label?: string;
 	protocol?: string;
-	appData?: Record<string, unknown>;
+	appData?: DataConsumerAppData;
 };
 
 export type DataConsumerEvents =
@@ -30,7 +31,8 @@ export type DataConsumerObserverEvents =
 	close: [];
 };
 
-export class DataConsumer extends EnhancedEventEmitter<DataConsumerEvents>
+export class DataConsumer<DataConsumerAppData extends AppData = AppData>
+	extends EnhancedEventEmitter<DataConsumerEvents>
 {
 	// Id.
 	private readonly _id: string;
@@ -43,7 +45,7 @@ export class DataConsumer extends EnhancedEventEmitter<DataConsumerEvents>
 	// SCTP stream parameters.
 	private readonly _sctpStreamParameters: SctpStreamParameters;
 	// App custom data.
-	private readonly _appData: Record<string, unknown>;
+	private _appData: DataConsumerAppData;
 	// Observer instance.
 	protected readonly _observer = new EnhancedEventEmitter<DataConsumerObserverEvents>();
 
@@ -60,7 +62,7 @@ export class DataConsumer extends EnhancedEventEmitter<DataConsumerEvents>
 			dataProducerId: string;
 			dataChannel: RTCDataChannel;
 			sctpStreamParameters: SctpStreamParameters;
-			appData?: Record<string, unknown>;
+			appData?: DataConsumerAppData;
 		}
 	)
 	{
@@ -72,7 +74,7 @@ export class DataConsumer extends EnhancedEventEmitter<DataConsumerEvents>
 		this._dataProducerId = dataProducerId;
 		this._dataChannel = dataChannel;
 		this._sctpStreamParameters = sctpStreamParameters;
-		this._appData = appData || {};
+		this._appData = appData || {} as DataConsumerAppData;
 
 		this.handleDataChannel();
 	}
@@ -152,18 +154,17 @@ export class DataConsumer extends EnhancedEventEmitter<DataConsumerEvents>
 	/**
 	 * App custom data.
 	 */
-	get appData(): Record<string, unknown>
+	get appData(): DataConsumerAppData
 	{
 		return this._appData;
 	}
 
 	/**
-	 * Invalid setter.
+	 * App custom data setter.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	set appData(appData: Record<string, unknown>)
+	set appData(appData: DataConsumerAppData)
 	{
-		throw new Error('cannot override appData object');
+		this._appData = appData;
 	}
 
 	get observer(): EnhancedEventEmitter

--- a/src/DataProducer.ts
+++ b/src/DataProducer.ts
@@ -2,17 +2,18 @@ import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import { InvalidStateError } from './errors';
 import { SctpStreamParameters } from './SctpParameters';
+import { AppData } from './types';
 
 const logger = new Logger('DataProducer');
 
-export type DataProducerOptions =
+export type DataProducerOptions<DataProducerAppData extends AppData = AppData> =
 {
 	ordered?: boolean;
 	maxPacketLifeTime?: number;
 	maxRetransmits?: number;
 	label?: string;
 	protocol?: string;
-	appData?: Record<string, unknown>;
+	appData?: DataProducerAppData;
 };
 
 export type DataProducerEvents =
@@ -31,7 +32,8 @@ export type DataProducerObserverEvents =
 	close: [];
 };
 
-export class DataProducer extends EnhancedEventEmitter<DataProducerEvents>
+export class DataProducer<DataProducerAppData extends AppData = AppData>
+	extends EnhancedEventEmitter<DataProducerEvents>
 {
 	// Id.
 	private readonly _id: string;
@@ -42,7 +44,7 @@ export class DataProducer extends EnhancedEventEmitter<DataProducerEvents>
 	// SCTP stream parameters.
 	private readonly _sctpStreamParameters: SctpStreamParameters;
 	// App custom data.
-	private readonly _appData: Record<string, unknown>;
+	private _appData: DataProducerAppData;
 	// Observer instance.
 	protected readonly _observer = new EnhancedEventEmitter<DataProducerObserverEvents>();
 
@@ -57,7 +59,7 @@ export class DataProducer extends EnhancedEventEmitter<DataProducerEvents>
 			id: string;
 			dataChannel: RTCDataChannel;
 			sctpStreamParameters: SctpStreamParameters;
-			appData?: Record<string, unknown>;
+			appData?: DataProducerAppData;
 		}
 	)
 	{
@@ -68,7 +70,7 @@ export class DataProducer extends EnhancedEventEmitter<DataProducerEvents>
 		this._id = id;
 		this._dataChannel = dataChannel;
 		this._sctpStreamParameters = sctpStreamParameters;
-		this._appData = appData || {};
+		this._appData = appData || {} as DataProducerAppData;
 
 		this.handleDataChannel();
 	}
@@ -148,18 +150,17 @@ export class DataProducer extends EnhancedEventEmitter<DataProducerEvents>
 	/**
 	 * App custom data.
 	 */
-	get appData(): Record<string, unknown>
+	get appData(): DataProducerAppData
 	{
 		return this._appData;
 	}
 
 	/**
-	 * Invalid setter.
+	 * App custom data setter.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	set appData(appData: Record<string, unknown>)
+	set appData(appData: DataProducerAppData)
 	{
-		throw new Error('cannot override appData object');
+		this._appData = appData;
 	}
 
 	get observer(): EnhancedEventEmitter

--- a/src/Device.ts
+++ b/src/Device.ts
@@ -19,6 +19,7 @@ import { ReactNativeUnifiedPlan } from './handlers/ReactNativeUnifiedPlan';
 import { ReactNative } from './handlers/ReactNative';
 import { RtpCapabilities, MediaKind } from './RtpParameters';
 import { SctpCapabilities } from './SctpParameters';
+import { AppData } from './types';
 
 const logger = new Logger('Device');
 
@@ -51,11 +52,6 @@ export type DeviceOptions =
 	 */
 	Handler?: string;
 };
-
-interface InternalTransportOptions extends TransportOptions
-{
-	direction: 'send' | 'recv';
-}
 
 export function detectDevice(): BuiltinHandlerName | undefined
 {
@@ -499,7 +495,7 @@ export class Device
 	 * @throws {InvalidStateError} if not loaded.
 	 * @throws {TypeError} if wrong arguments.
 	 */
-	createSendTransport(
+	createSendTransport<TransportAppData extends AppData = AppData>(
 		{
 			id,
 			iceParameters,
@@ -511,12 +507,12 @@ export class Device
 			additionalSettings,
 			proprietaryConstraints,
 			appData
-		}: TransportOptions
-	): Transport
+		}: TransportOptions<TransportAppData>
+	): Transport<TransportAppData>
 	{
 		logger.debug('createSendTransport()');
 
-		return this.createTransport(
+		return this.createTransport<TransportAppData>(
 			{
 				direction              : 'send',
 				id                     : id,
@@ -538,7 +534,7 @@ export class Device
 	 * @throws {InvalidStateError} if not loaded.
 	 * @throws {TypeError} if wrong arguments.
 	 */
-	createRecvTransport(
+	createRecvTransport<TransportAppData extends AppData = AppData>(
 		{
 			id,
 			iceParameters,
@@ -550,12 +546,12 @@ export class Device
 			additionalSettings,
 			proprietaryConstraints,
 			appData
-		}: TransportOptions
-	): Transport
+		}: TransportOptions<TransportAppData>
+	): Transport<TransportAppData>
 	{
 		logger.debug('createRecvTransport()');
 
-		return this.createTransport(
+		return this.createTransport<TransportAppData>(
 			{
 				direction              : 'recv',
 				id                     : id,
@@ -571,7 +567,7 @@ export class Device
 			});
 	}
 
-	private createTransport(
+	private createTransport<TransportAppData extends AppData>(
 		{
 			direction,
 			id,
@@ -584,8 +580,11 @@ export class Device
 			additionalSettings,
 			proprietaryConstraints,
 			appData
-		}: InternalTransportOptions
-	): Transport
+		}:
+		{
+			direction: 'send' | 'recv';
+		} & TransportOptions<TransportAppData>
+	): Transport<TransportAppData>
 	{
 		if (!this._loaded)
 		{
@@ -617,7 +616,7 @@ export class Device
 		}
 
 		// Create a new Transport.
-		const transport = new Transport(
+		const transport = new Transport<TransportAppData>(
 			{
 				direction,
 				id,

--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -7,10 +7,11 @@ import {
 	RtpParameters,
 	RtpEncodingParameters
 } from './RtpParameters';
+import { AppData } from './types';
 
 const logger = new Logger('Producer');
 
-export type ProducerOptions =
+export type ProducerOptions<ProducerAppData extends AppData = AppData> =
 {
 	track?: MediaStreamTrack;
 	encodings?: RtpEncodingParameters[];
@@ -19,7 +20,7 @@ export type ProducerOptions =
 	stopTracks?: boolean;
 	disableTrackOnPause?: boolean;
 	zeroRtpOnPause?: boolean;
-	appData?: Record<string, unknown>;
+	appData?: ProducerAppData;
 };
 
 // https://mediasoup.org/documentation/v3/mediasoup-client/api/#ProducerCodecOptions
@@ -80,7 +81,8 @@ export type ProducerObserverEvents =
 	trackended: [];
 };
 
-export class Producer extends EnhancedEventEmitter<ProducerEvents>
+export class Producer<ProducerAppData extends AppData = AppData>
+	extends EnhancedEventEmitter<ProducerEvents>
 {
 	// Id.
 	private readonly _id: string;
@@ -107,7 +109,7 @@ export class Producer extends EnhancedEventEmitter<ProducerEvents>
 	// Whether we should replace the RTCRtpSender.track with null when paused.
 	private _zeroRtpOnPause: boolean;
 	// App custom data.
-	private readonly _appData: Record<string, unknown>;
+	private _appData: ProducerAppData;
 	// Observer instance.
 	protected readonly _observer = new EnhancedEventEmitter<ProducerObserverEvents>();
 
@@ -132,7 +134,7 @@ export class Producer extends EnhancedEventEmitter<ProducerEvents>
 			stopTracks: boolean;
 			disableTrackOnPause: boolean;
 			zeroRtpOnPause: boolean;
-			appData?: Record<string, unknown>;
+			appData?: ProducerAppData;
 		}
 	)
 	{
@@ -151,7 +153,7 @@ export class Producer extends EnhancedEventEmitter<ProducerEvents>
 		this._stopTracks = stopTracks;
 		this._disableTrackOnPause = disableTrackOnPause;
 		this._zeroRtpOnPause = zeroRtpOnPause;
-		this._appData = appData || {};
+		this._appData = appData || {} as ProducerAppData;
 		this.onTrackEnded = this.onTrackEnded.bind(this);
 
 		// NOTE: Minor issue. If zeroRtpOnPause is true, we cannot emit the
@@ -237,18 +239,17 @@ export class Producer extends EnhancedEventEmitter<ProducerEvents>
 	/**
 	 * App custom data.
 	 */
-	get appData(): Record<string, unknown>
+	get appData(): ProducerAppData
 	{
 		return this._appData;
 	}
 
 	/**
-	 * Invalid setter.
+	 * App custom data setter.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	set appData(appData: Record<string, unknown>)
+	set appData(appData: ProducerAppData)
 	{
-		throw new Error('cannot override appData object');
+		this._appData = appData;
 	}
 
 	get observer(): EnhancedEventEmitter

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -609,7 +609,7 @@ export class Transport<TransportAppData extends AppData = AppData>
 						this.safeEmit(
 							'produce',
 							{
-								kind    : track.kind as MediaKind,
+								kind : track.kind as MediaKind,
 								rtpParameters,
 								appData
 							},

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -12,36 +12,11 @@ import { DataProducer, DataProducerOptions } from './DataProducer';
 import { DataConsumer, DataConsumerOptions } from './DataConsumer';
 import { RtpParameters, MediaKind } from './RtpParameters';
 import { SctpParameters, SctpStreamParameters } from './SctpParameters';
+import { AppData } from './types';
 
 const logger = new Logger('Transport');
 
-interface InternalTransportOptions extends TransportOptions
-{
-	direction: 'send' | 'recv';
-	handlerFactory: HandlerFactory;
-	extendedRtpCapabilities: any;
-	canProduceByKind: CanProduceByKind;
-}
-
-class ConsumerCreationTask
-{
-	consumerOptions: ConsumerOptions;
-	promise: Promise<Consumer>;
-	resolve?: (consumer: Consumer) => void;
-	reject?: (error: Error) => void;
-
-	constructor(consumerOptions: ConsumerOptions)
-	{
-		this.consumerOptions = consumerOptions;
-		this.promise = new Promise<Consumer>((resolve, reject) =>
-		{
-			this.resolve = resolve;
-			this.reject = reject;
-		});
-	}
-}
-
-export type TransportOptions =
+export type TransportOptions<TransportAppData extends AppData = AppData> =
 {
 	id: string;
 	iceParameters: IceParameters;
@@ -52,7 +27,7 @@ export type TransportOptions =
 	iceTransportPolicy?: RTCIceTransportPolicy;
 	additionalSettings?: any;
 	proprietaryConstraints?: any;
-	appData?: Record<string, unknown>;
+	appData?: TransportAppData;
 };
 
 export type CanProduceByKind =
@@ -161,7 +136,7 @@ export type TransportEvents =
 		{
 			kind: MediaKind;
 			rtpParameters: RtpParameters;
-			appData: Record<string, unknown>;
+			appData: AppData;
 		},
 		({ id }: { id: string }) => void,
 		(error: Error) => void
@@ -172,7 +147,7 @@ export type TransportEvents =
 			sctpStreamParameters: SctpStreamParameters;
 			label?: string;
 			protocol?: string;
-			appData: Record<string, unknown>;
+			appData: AppData;
 		},
 		({ id }: { id: string }) => void,
 		(error: Error) => void
@@ -188,7 +163,26 @@ export type TransportObserverEvents =
 	newdataconsumer: [DataConsumer];
 };
 
-export class Transport extends EnhancedEventEmitter<TransportEvents>
+class ConsumerCreationTask
+{
+	consumerOptions: ConsumerOptions;
+	promise: Promise<Consumer>;
+	resolve?: (consumer: Consumer) => void;
+	reject?: (error: Error) => void;
+
+	constructor(consumerOptions: ConsumerOptions)
+	{
+		this.consumerOptions = consumerOptions;
+		this.promise = new Promise((resolve, reject) =>
+		{
+			this.resolve = resolve;
+			this.reject = reject;
+		});
+	}
+}
+
+export class Transport<TransportAppData extends AppData = AppData>
+	extends EnhancedEventEmitter<TransportEvents>
 {
 	// Id.
 	private readonly _id: string;
@@ -208,7 +202,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 	// Transport connection state.
 	private _connectionState: ConnectionState = 'new';
 	// App custom data.
-	private readonly _appData: Record<string, unknown>;
+	private _appData: TransportAppData;
 	// Map of Producers indexed by id.
 	private readonly _producers: Map<string, Producer> = new Map();
 	// Map of Consumers indexed by id.
@@ -256,7 +250,13 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 			handlerFactory,
 			extendedRtpCapabilities,
 			canProduceByKind
-		}: InternalTransportOptions
+		}:
+		{
+			direction: 'send' | 'recv';
+			handlerFactory: HandlerFactory;
+			extendedRtpCapabilities: any;
+			canProduceByKind: CanProduceByKind;
+		} & TransportOptions<TransportAppData>
 	)
 	{
 		super();
@@ -295,7 +295,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 				extendedRtpCapabilities
 			});
 
-		this._appData = appData || {};
+		this._appData = appData || {} as TransportAppData;
 
 		this.handleHandler();
 	}
@@ -343,18 +343,17 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 	/**
 	 * App custom data.
 	 */
-	get appData(): Record<string, unknown>
+	get appData(): TransportAppData
 	{
 		return this._appData;
 	}
 
 	/**
-	 * Invalid setter.
+	 * App custom data setter.
 	 */
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	set appData(appData: Record<string, unknown>)
+	set appData(appData: TransportAppData)
 	{
-		throw new Error('cannot override appData object');
+		this._appData = appData;
 	}
 
 	get observer(): EnhancedEventEmitter
@@ -482,7 +481,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 	/**
 	 * Create a Producer.
 	 */
-	async produce(
+	async produce<ProducerAppData extends AppData = AppData>(
 		{
 			track,
 			encodings,
@@ -491,9 +490,9 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 			stopTracks = true,
 			disableTrackOnPause = true,
 			zeroRtpOnPause = false,
-			appData = {}
-		}: ProducerOptions = {}
-	): Promise<Producer>
+			appData = {} as ProducerAppData
+		}: ProducerOptions<ProducerAppData> = {}
+	): Promise<Producer<ProducerAppData>>
 	{
 		logger.debug('produce() [track:%o]', track);
 
@@ -610,7 +609,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 						this.safeEmit(
 							'produce',
 							{
-								kind : track.kind as MediaKind,
+								kind    : track.kind as MediaKind,
 								rtpParameters,
 								appData
 							},
@@ -619,7 +618,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 						);
 					});
 
-					const producer = new Producer(
+					const producer = new Producer<ProducerAppData>(
 						{
 							id,
 							localId,
@@ -666,16 +665,16 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 	/**
 	 * Create a Consumer to consume a remote Producer.
 	 */
-	async consume(
+	async consume<ConsumerAppData extends AppData = AppData>(
 		{
 			id,
 			producerId,
 			kind,
 			rtpParameters,
 			streamId,
-			appData = {}
-		}: ConsumerOptions
-	): Promise<Consumer>
+			appData = {} as ConsumerAppData
+		}: ConsumerOptions<ConsumerAppData>
+	): Promise<Consumer<ConsumerAppData>>
 	{
 		logger.debug('consume()');
 
@@ -738,31 +737,31 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 		{
 			if (this._closed)
 			{
-				throw new InvalidStateError('closed');
+				return;
 			}
 
 			if (this._consumerCreationInProgress === false)
 			{
-				this.createPendingConsumers();
+				this.createPendingConsumers<ConsumerAppData>();
 			}
 		});
 
-		return consumerCreationTask.promise;
+		return consumerCreationTask.promise as Promise<Consumer<ConsumerAppData>>;
 	}
 
 	/**
 	 * Create a DataProducer
 	 */
-	async produceData(
+	async produceData<DataProducerAppData extends AppData = AppData>(
 		{
 			ordered = true,
 			maxPacketLifeTime,
 			maxRetransmits,
 			label = '',
 			protocol = '',
-			appData = {}
-		}: DataProducerOptions = {}
-	): Promise<DataProducer>
+			appData = {} as DataProducerAppData
+		}: DataProducerOptions<DataProducerAppData> = {}
+	): Promise<DataProducer<DataProducerAppData>>
 	{
 		logger.debug('produceData()');
 
@@ -830,8 +829,13 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 					);
 				});
 
-				const dataProducer =
-					new DataProducer({ id, dataChannel, sctpStreamParameters, appData });
+				const dataProducer = new DataProducer<DataProducerAppData>(
+					{
+						id,
+						dataChannel,
+						sctpStreamParameters,
+						appData
+					});
 
 				this._dataProducers.set(dataProducer.id, dataProducer);
 				this.handleDataProducer(dataProducer);
@@ -847,16 +851,16 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 	/**
 	 * Create a DataConsumer
 	 */
-	async consumeData(
+	async consumeData<ConsumerAppData extends AppData = AppData>(
 		{
 			id,
 			dataProducerId,
 			sctpStreamParameters,
 			label = '',
 			protocol = '',
-			appData = {}
-		}: DataConsumerOptions
-	): Promise<DataConsumer>
+			appData = {} as ConsumerAppData
+		}: DataConsumerOptions<ConsumerAppData>
+	): Promise<DataConsumer<ConsumerAppData>>
 	{
 		logger.debug('consumeData()');
 
@@ -907,7 +911,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 						protocol
 					});
 
-				const dataConsumer = new DataConsumer(
+				const dataConsumer = new DataConsumer<ConsumerAppData>(
 					{
 						id,
 						dataProducerId,
@@ -928,7 +932,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 	}
 
 	// This method is guaranteed to never throw.
-	private async createPendingConsumers(): Promise<void>
+	private async createPendingConsumers<ConsumerAppData extends AppData>(): Promise<void>
 	{
 		this._consumerCreationInProgress = true;
 
@@ -970,13 +974,13 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 				{
 					const results = await this._handler.receive(optionsList);
 
-					for (let idx=0; idx < results.length; idx++)
+					for (let idx = 0; idx < results.length; ++idx)
 					{
 						const task = pendingConsumerTasks[idx];
 						const result = results[idx];
 						const { id, producerId, kind, rtpParameters, appData } = task.consumerOptions;
 						const { localId, rtpReceiver, track } = result;
-						const consumer = new Consumer(
+						const consumer = new Consumer<ConsumerAppData>(
 							{
 								id         : id!,
 								localId,
@@ -984,7 +988,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 								rtpReceiver,
 								track,
 								rtpParameters,
-								appData
+								appData    : appData as ConsumerAppData
 							});
 
 						this._consumers.set(consumer.id, consumer);
@@ -1049,7 +1053,7 @@ export class Transport extends EnhancedEventEmitter<TransportEvents>
 				// There are pending Consumer tasks, enqueue their creation.
 				if (this._pendingConsumerTasks.length > 0)
 				{
-					this.createPendingConsumers();
+					this.createPendingConsumers<ConsumerAppData>();
 				}
 			})
 			// NOTE: We only get here when the await queue is closed.

--- a/src/tests/test.ts
+++ b/src/tests/test.ts
@@ -195,11 +195,6 @@ test('device.createSendTransport() for sending media succeeds', () =>
 			appData : { foo: 123 }
 		});
 
-	console.warn('TODO: THIS SHOULD FAIL AT TS LEVEL BUT IT DOESNT');
-	sendTransport.appData.foo = 'qwe';
-	// Revert for test not to fail (TODO: Remove all this).
-	sendTransport.appData.foo = 123;
-
 	expect(typeof sendTransport).toBe('object');
 	expect(sendTransport.id).toBe(id);
 	expect(sendTransport.closed).toBe(false);
@@ -367,11 +362,6 @@ test('transport.produce() succeeds', async () =>
 	// Use stopTracks: false.
 	audioProducer = await sendTransport.produce<{ foo: string }>(
 		{ track: audioTrack, stopTracks: false, appData: { foo: 'FOO' } });
-
-	console.warn('TODO: THIS SHOULD FAIL AT TS LEVEL BUT IT DOESNT');
-	audioProducer.appData.foo = 123;
-	// Revert for test not to fail (TODO: Remove all this).
-	audioProducer.appData.foo = 'FOO';
 
 	expect(connectEventNumTimesCalled).toBe(1);
 	expect(produceEventNumTimesCalled).toBe(1);

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,3 +9,8 @@ export * from './SctpParameters';
 export * from './handlers/HandlerInterface';
 export * from './errors';
 export type { ScalabilityMode } from './scalabilityModes';
+
+export type AppData =
+{
+	[key: string]: unknown;
+};


### PR DESCRIPTION
Same as done in mediasoup-node.

### Usage

```ts
const audioProducer = await sendTransport.produce<{ foo: string }>(
	{
		track: audioTrack,
		stopTracks: false,
		appData: { foo: 'FOO' }
	});
```

(same in all `device.createSend/RecvTransport()`, `transport.consume()`, `transport.produceData()` and `transport.consumeData()`.
