### PR TITLE
ReactNative: transceiver.mid is not available until setRemoteDescription is called

### DIFF
--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -393,7 +393,7 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 		await this._pc.setLocalDescription(offer);
 
 		// We can now get the transceiver.mid.
-		const localId = transceiver.mid;
+		let localId = transceiver.mid;
 
 		// Set MID.
 		sendingRtpParameters.mid = localId;
@@ -474,6 +474,9 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 			answer);
 
 		await this._pc.setRemoteDescription(answer);
+
+		// on iOS with react-native-webrtc 111.0.0, transceiver.mid is not available until setRemoteDescription is called
+		localId = localId ?? transceiver.mid;
 
 		// Store in the map.
 		this._mapMidTransceiver.set(localId, transceiver);


### PR DESCRIPTION
This PR attempts to fix https://github.com/versatica/mediasoup-client/issues/263.

The issue is `transciever.mid` is not available after calling `pc.setLocalDescription`. Since mediasoup-client uses `mid` as the key to `_mapMidTransceiver` map, without a valid mid, future call to `producer.close()` finds wrong transceiver to turn off.

After enabling react-native-webrtc logs,I noticed that `transeiver.mid` is properly updated in `pc.setRemoteDescription`, therefore I added code to update the `mid` after the call.