### PR TITLE
Handlers: check if the handler is closed and call handler methods with await

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -449,7 +449,7 @@ export class Transport<TransportAppData extends AppData = AppData>
 
 		// Enqueue command.
 		return this._awaitQueue.push(
-			async () => this._handler.restartIce(iceParameters),
+			async () => await this._handler.restartIce(iceParameters),
 			'transport.restartIce()');
 	}
 
@@ -1247,7 +1247,7 @@ export class Transport<TransportAppData extends AppData = AppData>
 			}
 
 			this._awaitQueue.push(
-				async () => this._handler.stopSending(producer.localId),
+				async () => await this._handler.stopSending(producer.localId),
 				'producer @close event')
 				.catch((error: Error) => logger.warn('producer.close() failed:%o', error));
 		});
@@ -1255,7 +1255,7 @@ export class Transport<TransportAppData extends AppData = AppData>
 		producer.on('@pause', (callback, errback) =>
 		{
 			this._awaitQueue.push(
-				async () => this._handler.pauseSending(producer.localId),
+				async () => await this._handler.pauseSending(producer.localId),
 				'producer @pause event')
 				.then(callback)
 				.catch(errback);
@@ -1264,7 +1264,7 @@ export class Transport<TransportAppData extends AppData = AppData>
 		producer.on('@resume', (callback, errback) =>
 		{
 			this._awaitQueue.push(
-				async () => this._handler.resumeSending(producer.localId),
+				async () => await this._handler.resumeSending(producer.localId),
 				'producer @resume event')
 				.then(callback)
 				.catch(errback);
@@ -1273,7 +1273,7 @@ export class Transport<TransportAppData extends AppData = AppData>
 		producer.on('@replacetrack', (track, callback, errback) =>
 		{
 			this._awaitQueue.push(
-				async () => this._handler.replaceTrack(producer.localId, track),
+				async () => await this._handler.replaceTrack(producer.localId, track),
 				'producer @replacetrack event')
 				.then(callback)
 				.catch(errback);
@@ -1283,7 +1283,7 @@ export class Transport<TransportAppData extends AppData = AppData>
 		{
 			this._awaitQueue.push(
 				async () => (
-					this._handler.setMaxSpatialLayer(producer.localId, spatialLayer)
+					await this._handler.setMaxSpatialLayer(producer.localId, spatialLayer)
 				), 'producer @setmaxspatiallayer event')
 				.then(callback)
 				.catch(errback);
@@ -1293,7 +1293,7 @@ export class Transport<TransportAppData extends AppData = AppData>
 		{
 			this._awaitQueue.push(
 				async () => (
-					this._handler.setRtpEncodingParameters(producer.localId, params)
+					await this._handler.setRtpEncodingParameters(producer.localId, params)
 				), 'producer @setrtpencodingparameters event')
 				.then(callback)
 				.catch(errback);

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -163,6 +163,8 @@ export class Chrome111 extends HandlerInterface
 		}: HandlerRunOptions
 	): void
 	{
+		this.assertNotClosed();
+
 		logger.debug('run()');
 
 		this._direction = direction;
@@ -257,6 +259,8 @@ export class Chrome111 extends HandlerInterface
 
 	async restartIce(iceParameters: IceParameters): Promise<void>
 	{
+		this.assertNotClosed();
+
 		logger.debug('restartIce()');
 
 		// Provide the remote SDP handler with new remote ICE parameters.

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -5,6 +5,7 @@ import * as ortc from '../ortc';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
 import * as ortcUtils from './ortc/utils';
+import { InvalidStateError } from '../errors';
 import {
 	HandlerFactory,
 	HandlerInterface,
@@ -30,6 +31,8 @@ const SCTP_NUM_STREAMS = { OS: 1024, MIS: 1024 };
 
 export class Chrome111 extends HandlerInterface
 {
+	// Closed flag.
+	private _closed = false;
 	// Handler direction.
 	private _direction?: 'send' | 'recv';
 	// Remote SDP handler.
@@ -77,6 +80,13 @@ export class Chrome111 extends HandlerInterface
 	close(): void
 	{
 		logger.debug('close()');
+
+		if (this._closed)
+		{
+			return;
+		}
+
+		this._closed = true;
 
 		// Close RTCPeerConnection.
 		if (this._pc)
@@ -234,6 +244,8 @@ export class Chrome111 extends HandlerInterface
 
 	async updateIceServers(iceServers: RTCIceServer[]): Promise<void>
 	{
+		this.assertNotClosed();
+
 		logger.debug('updateIceServers()');
 
 		const configuration = this._pc.getConfiguration();
@@ -295,6 +307,8 @@ export class Chrome111 extends HandlerInterface
 
 	async getTransportStats(): Promise<RTCStatsReport>
 	{
+		this.assertNotClosed();
+
 		return this._pc.getStats();
 	}
 
@@ -302,6 +316,7 @@ export class Chrome111 extends HandlerInterface
 		{ track, encodings, codecOptions, codec }: HandlerSendOptions
 	): Promise<HandlerSendResult>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
@@ -452,6 +467,11 @@ export class Chrome111 extends HandlerInterface
 
 		logger.debug('stopSending() [localId:%s]', localId);
 
+		if (this._closed)
+		{
+			return;
+		}
+
 		const transceiver = this._mapMidTransceiver.get(localId);
 
 		if (!transceiver)
@@ -497,6 +517,7 @@ export class Chrome111 extends HandlerInterface
 
 	async pauseSending(localId: string): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug('pauseSending() [localId:%s]', localId);
@@ -530,6 +551,7 @@ export class Chrome111 extends HandlerInterface
 
 	async resumeSending(localId: string): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug('resumeSending() [localId:%s]', localId);
@@ -566,6 +588,7 @@ export class Chrome111 extends HandlerInterface
 		localId: string, track: MediaStreamTrack | null
 	): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		if (track)
@@ -590,6 +613,7 @@ export class Chrome111 extends HandlerInterface
 
 	async setMaxSpatialLayer(localId: string, spatialLayer: number): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug(
@@ -640,6 +664,7 @@ export class Chrome111 extends HandlerInterface
 
 	async setRtpEncodingParameters(localId: string, params: any): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug(
@@ -683,6 +708,7 @@ export class Chrome111 extends HandlerInterface
 
 	async getSenderStats(localId: string): Promise<RTCStatsReport>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		const transceiver = this._mapMidTransceiver.get(localId);
@@ -705,6 +731,7 @@ export class Chrome111 extends HandlerInterface
 		}: HandlerSendDataChannelOptions
 	): Promise<HandlerSendDataChannelResult>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		const options =
@@ -777,6 +804,7 @@ export class Chrome111 extends HandlerInterface
 		optionsList: HandlerReceiveOptions[]
 	) : Promise<HandlerReceiveResult[]>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		const results: HandlerReceiveResult[] = [];
@@ -877,6 +905,11 @@ export class Chrome111 extends HandlerInterface
 	{
 		this.assertRecvDirection();
 
+		if (this._closed)
+		{
+			return;
+		}
+
 		for (const localId of localIds)
 		{
 			logger.debug('stopReceiving() [localId:%s]', localId);
@@ -915,6 +948,7 @@ export class Chrome111 extends HandlerInterface
 
 	async pauseReceiving(localIds: string[]): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		for (const localId of localIds)
@@ -951,6 +985,7 @@ export class Chrome111 extends HandlerInterface
 
 	async resumeReceiving(localIds: string[]): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		for (const localId of localIds)
@@ -987,6 +1022,7 @@ export class Chrome111 extends HandlerInterface
 
 	async getReceiverStats(localId: string): Promise<RTCStatsReport>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		const transceiver = this._mapMidTransceiver.get(localId);
@@ -1003,6 +1039,7 @@ export class Chrome111 extends HandlerInterface
 		{ sctpStreamParameters, label, protocol }: HandlerReceiveDataChannelOptions
 	): Promise<HandlerReceiveDataChannelResult>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		const {
@@ -1104,6 +1141,14 @@ export class Chrome111 extends HandlerInterface
 		});
 
 		this._transportReady = true;
+	}
+
+	private assertNotClosed(): void
+	{
+		if (this._closed)
+		{
+			throw new InvalidStateError('method called in a closed handler');
+		}
 	}
 
 	private assertSendDirection(): void

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -5,6 +5,7 @@ import * as ortc from '../ortc';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
 import * as ortcUtils from './ortc/utils';
+import { InvalidStateError } from '../errors';
 import {
 	HandlerFactory,
 	HandlerInterface,
@@ -34,6 +35,8 @@ const SCTP_NUM_STREAMS = { OS: 1024, MIS: 1024 };
 
 export class Chrome74 extends HandlerInterface
 {
+	// Closed flag.
+	private _closed = false;
 	// Handler direction.
 	private _direction?: 'send' | 'recv';
 	// Remote SDP handler.
@@ -81,6 +84,13 @@ export class Chrome74 extends HandlerInterface
 	close(): void
 	{
 		logger.debug('close()');
+
+		if (this._closed)
+		{
+			return;
+		}
+
+		this._closed = true;
 
 		// Close RTCPeerConnection.
 		if (this._pc)
@@ -238,6 +248,8 @@ export class Chrome74 extends HandlerInterface
 
 	async updateIceServers(iceServers: RTCIceServer[]): Promise<void>
 	{
+		this.assertNotClosed();
+
 		logger.debug('updateIceServers()');
 
 		const configuration = this._pc.getConfiguration();
@@ -249,6 +261,8 @@ export class Chrome74 extends HandlerInterface
 
 	async restartIce(iceParameters: IceParameters): Promise<void>
 	{
+		this.assertNotClosed();
+
 		logger.debug('restartIce()');
 
 		// Provide the remote SDP handler with new remote ICE parameters.
@@ -299,6 +313,8 @@ export class Chrome74 extends HandlerInterface
 
 	async getTransportStats(): Promise<RTCStatsReport>
 	{
+		this.assertNotClosed();
+
 		return this._pc.getStats();
 	}
 
@@ -306,6 +322,7 @@ export class Chrome74 extends HandlerInterface
 		{ track, encodings, codecOptions, codec }: HandlerSendOptions
 	): Promise<HandlerSendResult>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
@@ -486,6 +503,11 @@ export class Chrome74 extends HandlerInterface
 
 		logger.debug('stopSending() [localId:%s]', localId);
 
+		if (this._closed)
+		{
+			return;
+		}
+
 		const transceiver = this._mapMidTransceiver.get(localId);
 
 		if (!transceiver)
@@ -531,6 +553,7 @@ export class Chrome74 extends HandlerInterface
 
 	async pauseSending(localId: string): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug('pauseSending() [localId:%s]', localId);
@@ -564,6 +587,7 @@ export class Chrome74 extends HandlerInterface
 
 	async resumeSending(localId: string): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug('resumeSending() [localId:%s]', localId);
@@ -600,6 +624,7 @@ export class Chrome74 extends HandlerInterface
 		localId: string, track: MediaStreamTrack | null
 	): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		if (track)
@@ -624,6 +649,7 @@ export class Chrome74 extends HandlerInterface
 
 	async setMaxSpatialLayer(localId: string, spatialLayer: number): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug(
@@ -674,6 +700,7 @@ export class Chrome74 extends HandlerInterface
 
 	async setRtpEncodingParameters(localId: string, params: any): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug(
@@ -717,6 +744,7 @@ export class Chrome74 extends HandlerInterface
 
 	async getSenderStats(localId: string): Promise<RTCStatsReport>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		const transceiver = this._mapMidTransceiver.get(localId);
@@ -739,6 +767,7 @@ export class Chrome74 extends HandlerInterface
 		}: HandlerSendDataChannelOptions
 	): Promise<HandlerSendDataChannelResult>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		const options =
@@ -811,6 +840,7 @@ export class Chrome74 extends HandlerInterface
 		optionsList: HandlerReceiveOptions[]
 	) : Promise<HandlerReceiveResult[]>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		const results: HandlerReceiveResult[] = [];
@@ -911,6 +941,11 @@ export class Chrome74 extends HandlerInterface
 	{
 		this.assertRecvDirection();
 
+		if (this._closed)
+		{
+			return;
+		}
+
 		for (const localId of localIds)
 		{
 			logger.debug('stopReceiving() [localId:%s]', localId);
@@ -949,6 +984,7 @@ export class Chrome74 extends HandlerInterface
 
 	async pauseReceiving(localIds: string[]): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		for (const localId of localIds)
@@ -985,6 +1021,7 @@ export class Chrome74 extends HandlerInterface
 
 	async resumeReceiving(localIds: string[]): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		for (const localId of localIds)
@@ -1021,6 +1058,7 @@ export class Chrome74 extends HandlerInterface
 
 	async getReceiverStats(localId: string): Promise<RTCStatsReport>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		const transceiver = this._mapMidTransceiver.get(localId);
@@ -1037,6 +1075,7 @@ export class Chrome74 extends HandlerInterface
 		{ sctpStreamParameters, label, protocol }: HandlerReceiveDataChannelOptions
 	): Promise<HandlerReceiveDataChannelResult>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		const {
@@ -1138,6 +1177,14 @@ export class Chrome74 extends HandlerInterface
 		});
 
 		this._transportReady = true;
+	}
+
+	private assertNotClosed(): void
+	{
+		if (this._closed)
+		{
+			throw new InvalidStateError('method called in a closed handler');
+		}
 	}
 
 	private assertSendDirection(): void

--- a/src/handlers/Firefox60.ts
+++ b/src/handlers/Firefox60.ts
@@ -1,6 +1,6 @@
 import * as sdpTransform from 'sdp-transform';
 import { Logger } from '../Logger';
-import { UnsupportedError } from '../errors';
+import { UnsupportedError, InvalidStateError } from '../errors';
 import * as utils from '../utils';
 import * as ortc from '../ortc';
 import * as sdpCommonUtils from './sdp/commonUtils';
@@ -30,6 +30,8 @@ const SCTP_NUM_STREAMS = { OS: 16, MIS: 2048 };
 
 export class Firefox60 extends HandlerInterface
 {
+	// Closed flag.
+	private _closed = false;
 	// Handler direction.
 	private _direction?: 'send' | 'recv';
 	// Remote SDP handler.
@@ -74,6 +76,13 @@ export class Firefox60 extends HandlerInterface
 	close(): void
 	{
 		logger.debug('close()');
+
+		if (this._closed)
+		{
+			return;
+		}
+
+		this._closed = true;
 
 		// Close RTCPeerConnection.
 		if (this._pc)
@@ -178,6 +187,8 @@ export class Firefox60 extends HandlerInterface
 		}: HandlerRunOptions
 	): void
 	{
+		this.assertNotClosed();
+
 		logger.debug('run()');
 
 		this._direction = direction;
@@ -252,12 +263,16 @@ export class Firefox60 extends HandlerInterface
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async updateIceServers(iceServers: RTCIceServer[]): Promise<void>
 	{
+		this.assertNotClosed();
+
 		// NOTE: Firefox does not implement pc.setConfiguration().
 		throw new UnsupportedError('not supported');
 	}
 
 	async restartIce(iceParameters: IceParameters): Promise<void>
 	{
+		this.assertNotClosed();
+
 		logger.debug('restartIce()');
 
 		// Provide the remote SDP handler with new remote ICE parameters.
@@ -308,6 +323,8 @@ export class Firefox60 extends HandlerInterface
 
 	async getTransportStats(): Promise<RTCStatsReport>
 	{
+		this.assertNotClosed();
+
 		return this._pc.getStats();
 	}
 
@@ -315,6 +332,7 @@ export class Firefox60 extends HandlerInterface
 		{ track, encodings, codecOptions, codec }: HandlerSendOptions
 	): Promise<HandlerSendResult>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
@@ -477,7 +495,14 @@ export class Firefox60 extends HandlerInterface
 
 	async stopSending(localId: string): Promise<void>
 	{
+		this.assertSendDirection();
+
 		logger.debug('stopSending() [localId:%s]', localId);
+
+		if (this._closed)
+		{
+			return;
+		}
 
 		const transceiver = this._mapMidTransceiver.get(localId);
 
@@ -525,6 +550,7 @@ export class Firefox60 extends HandlerInterface
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async pauseSending(localId: string): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug('pauseSending() [localId:%s]', localId);
@@ -559,6 +585,7 @@ export class Firefox60 extends HandlerInterface
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	async resumeSending(localId: string): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug('resumeSending() [localId:%s]', localId);
@@ -594,6 +621,7 @@ export class Firefox60 extends HandlerInterface
 		localId: string, track: MediaStreamTrack | null
 	): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		if (track)
@@ -618,6 +646,7 @@ export class Firefox60 extends HandlerInterface
 
 	async setMaxSpatialLayer(localId: string, spatialLayer: number): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug(
@@ -672,6 +701,7 @@ export class Firefox60 extends HandlerInterface
 
 	async setRtpEncodingParameters(localId: string, params: any): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		logger.debug(
@@ -715,6 +745,7 @@ export class Firefox60 extends HandlerInterface
 
 	async getSenderStats(localId: string): Promise<RTCStatsReport>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		const transceiver = this._mapMidTransceiver.get(localId);
@@ -737,6 +768,7 @@ export class Firefox60 extends HandlerInterface
 		}: HandlerSendDataChannelOptions
 	): Promise<HandlerSendDataChannelResult>
 	{
+		this.assertNotClosed();
 		this.assertSendDirection();
 
 		const options =
@@ -806,6 +838,7 @@ export class Firefox60 extends HandlerInterface
 		optionsList: HandlerReceiveOptions[]
 	) : Promise<HandlerReceiveResult[]>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		const results: HandlerReceiveResult[] = [];
@@ -900,6 +933,11 @@ export class Firefox60 extends HandlerInterface
 	{
 		this.assertRecvDirection();
 
+		if (this._closed)
+		{
+			return;
+		}
+
 		for (const localId of localIds)
 		{
 			logger.debug('stopReceiving() [localId:%s]', localId);
@@ -938,6 +976,7 @@ export class Firefox60 extends HandlerInterface
 
 	async pauseReceiving(localIds: string[]): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		for (const localId of localIds)
@@ -974,6 +1013,7 @@ export class Firefox60 extends HandlerInterface
 
 	async resumeReceiving(localIds: string[]): Promise<void>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		for (const localId of localIds)
@@ -1026,6 +1066,7 @@ export class Firefox60 extends HandlerInterface
 		{ sctpStreamParameters, label, protocol }: HandlerReceiveDataChannelOptions
 	): Promise<HandlerReceiveDataChannelResult>
 	{
+		this.assertNotClosed();
 		this.assertRecvDirection();
 
 		const {
@@ -1123,6 +1164,14 @@ export class Firefox60 extends HandlerInterface
 		});
 
 		this._transportReady = true;
+	}
+
+	private assertNotClosed(): void
+	{
+		if (this._closed)
+		{
+			throw new InvalidStateError('method called in a closed handler');
+		}
 	}
 
 	private assertSendDirection(): void


### PR DESCRIPTION
**NOTE:** Draft PR for now since chnages are only done in `Chrome111` handler.

- Fixes #274
- Add "closed" flag in handlers.
- Make some handler methods throw if closed.
- Make some other methods return early (without doing anything) if the handler is closed. Yes, methods that close or stop things should be idempotent and never throw.
- `Transport.ts`: use `await` in all calls to handler methods given to the `AwaitQueue`.