### PR TITLE
Expose ICE gathering state and state change event

### DIFF
--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -216,8 +216,6 @@ export class Chrome111 extends HandlerInterface
 		{
 			this._pc.addEventListener('connectionstatechange', () =>
 			{
-				console.log('FOOOO this._pc.iceConnectionState:', this._pc.iceConnectionState);
-
 				this.emit('@connectionstatechange', this._pc.connectionState);
 			});
 		}

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -207,10 +207,17 @@ export class Chrome111 extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>
 			{
+				console.log('FOOOO this._pc.iceConnectionState:', this._pc.iceConnectionState);
+
 				this.emit('@connectionstatechange', this._pc.connectionState);
 			});
 		}

--- a/src/handlers/Chrome55.ts
+++ b/src/handlers/Chrome55.ts
@@ -204,6 +204,11 @@ export class Chrome55 extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>

--- a/src/handlers/Chrome67.ts
+++ b/src/handlers/Chrome67.ts
@@ -205,6 +205,11 @@ export class Chrome67 extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>

--- a/src/handlers/Chrome70.ts
+++ b/src/handlers/Chrome70.ts
@@ -191,6 +191,11 @@ export class Chrome70 extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -209,6 +209,11 @@ export class Chrome74 extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -20,6 +20,7 @@ import {
 	IceParameters,
 	DtlsParameters,
 	DtlsRole,
+	IceGatheringState,
 	ConnectionState
 } from '../Transport';
 import { RtpCapabilities, RtpParameters } from '../RtpParameters';
@@ -136,6 +137,12 @@ export class FakeHandler extends HandlerInterface
 		}
 
 		this._closed = true;
+	}
+
+	// NOTE: Custom method for simulation purposes.
+	setIceGatheringState(iceGatheringState: IceGatheringState): void
+	{
+		this.emit('@icegatheringstatechange', iceGatheringState);
 	}
 
 	// NOTE: Custom method for simulation purposes.

--- a/src/handlers/Firefox60.ts
+++ b/src/handlers/Firefox60.ts
@@ -223,6 +223,11 @@ export class Firefox60 extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -4,6 +4,7 @@ import {
 	IceParameters,
 	IceCandidate,
 	DtlsParameters,
+	IceGatheringState,
 	ConnectionState
 } from '../Transport';
 import {
@@ -99,6 +100,7 @@ export type HandlerEvents =
 		() => void,
 		(error: Error) => void
 	];
+	'@icegatheringstatechange': [IceGatheringState];
 	'@connectionstatechange': [ConnectionState];
 };
 

--- a/src/handlers/ReactNative.ts
+++ b/src/handlers/ReactNative.ts
@@ -209,6 +209,11 @@ export class ReactNative extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>

--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -216,6 +216,11 @@ export class ReactNativeUnifiedPlan extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>

--- a/src/handlers/Safari11.ts
+++ b/src/handlers/Safari11.ts
@@ -204,6 +204,11 @@ export class Safari11 extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -205,6 +205,11 @@ export class Safari12 extends HandlerInterface
 			},
 			proprietaryConstraints);
 
+		this._pc.addEventListener('icegatheringstatechange', () =>
+		{
+			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+		});
+
 		if (this._pc.connectionState)
 		{
 			this._pc.addEventListener('connectionstatechange', () =>


### PR DESCRIPTION
Fixes #253

The problem this PR resolves is perfectly explained in the linked issue:

> ### Problem
>
> Under normal circumstances, in case of connection issues, the ICE connection should eventually fail. `connectionstatechange` event will fire, and the application will have the opportunity to do something with it.
> 
> However, if all ICE candidates error during the gathering, the connection will forever stay in a `new` state and `connectionstatechange` event will never fire.

### Details

- Add `transport.iceGatheringState` getter.
- Add `transport.on('iceGatheringStateChangeEventNumTimesCalled', (iceGatheringState) => { })` event,
- Bonus track: Reset `transport.connectionState` to "closed" within `transport.close()` method.

*NOTE:* This is done in all handlers. It may happen that super old ones (`Chrome55`) don't support `icegatheringstatechange` event. I won't do magic. We'll remove those super old handlers soon anyway.