### PR TITLE
Fix ufrag is not required at media level

### DIFF
--- a/src/handlers/sdp/commonUtils.ts
+++ b/src/handlers/sdp/commonUtils.ts
@@ -172,8 +172,8 @@ export function extractDtlsParameters(
 ): DtlsParameters
 {
 	const mediaObject = (sdpObject.media || [])
-		.find((m: { iceUfrag: string; port: number }) => (
-			m.iceUfrag && m.port !== 0
+		.find((m: { port: number }) => (
+			m.port !== 0
 		));
 
 	if (!mediaObject)


### PR DESCRIPTION
Extracting DTLS parameters fails when the iceUFrag/pwd is defined at session level instead of the media level.