### PR TITLE
Detect embedded webview on iPadOS.

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -106,7 +106,7 @@ export function detectDevice(): BuiltinHandlerName | undefined
 		const device = uaParser.getDevice();
 		const deviceModel = device.model?.toLowerCase() ?? '';
 
-		const isIOS = osName === 'ios' || (osName === 'mac os' && deviceModel === 'ipad');
+		const isIOS = osName === 'ios' || deviceModel === 'ipad';
 
 		const isChrome =
 		[

--- a/src/Device.ts
+++ b/src/Device.ts
@@ -103,8 +103,10 @@ export function detectDevice(): BuiltinHandlerName | undefined
 		const os = uaParser.getOS();
 		const osName = os.name?.toLowerCase() ?? '';
 		const osVersion = parseFloat(os.version ?? '0');
+		const device = uaParser.getDevice();
+		const deviceModel = device.model?.toLowerCase() ?? '';
 
-		const isIOS = osName === 'ios';
+		const isIOS = osName === 'ios' || (osName === 'mac os' && deviceModel === 'ipad');
 
 		const isChrome =
 		[
@@ -188,7 +190,6 @@ export function detectDevice(): BuiltinHandlerName | undefined
 		else if (
 			engineName === 'webkit' &&
 			isIOS &&
-			osVersion >= 14.3 &&
 			typeof RTCRtpTransceiver !== 'undefined' &&
 			RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection'))
 		{


### PR DESCRIPTION
iPadOS identifies as Mac OS, but ua-parser-js does the extra detection to determine if it's an iPad. Use the device model to detect when we're in an embedded webview on iPadOS.

Also removes the version check for best effort webkit detection as iPadOS sends version 10.15 and checking RTCRtpTransceiver should be sufficient without the version check.