### PR TITLE
npm-scripts.ts: Fix replaceVersion() in Node 20

### DIFF
--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -128,7 +128,8 @@ function replaceVersion()
 			continue;
 		}
 
-		const filePath = path.join('lib', file.name);
+		// NOTE: dirent.path is only available in Node >= 20.
+		const filePath = path.join(file.path ?? 'lib', file.name);
 		const text = fs.readFileSync(filePath, { encoding: 'utf8' });
 		const result = text.replace(/__MEDIASOUP_CLIENT_VERSION__/g, PKG.version);
 


### PR DESCRIPTION
Just that. Wrong usage of `fs.readdirSync()`.