### PR TITLE
RtpParameters: enrich RtpParameters types

### DIFF
--- a/src/RtpParameters.ts
+++ b/src/RtpParameters.ts
@@ -96,7 +96,7 @@ export type RtpHeaderExtension =
 	/*
 	 * The URI of the RTP header extension, as defined in RFC 5285.
 	 */
-	uri: string;
+	uri: RtpHeaderExtensionUri;
 	/**
 	 * The preferred numeric identifier that goes in the RTP packet. Must be
 	 * unique.
@@ -272,6 +272,22 @@ export type RtpEncodingParameters =
 };
 
 /**
+ * Supported RTP header extension URIs.
+ */
+export type RtpHeaderExtensionUri =
+    'urn:ietf:params:rtp-hdrext:sdes:mid' |
+    'urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id' |
+    'urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id' |
+    'http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07' |
+    'urn:ietf:params:rtp-hdrext:framemarking' |
+    'urn:ietf:params:rtp-hdrext:ssrc-audio-level' |
+    'urn:3gpp:video-orientation' |
+    'urn:ietf:params:rtp-hdrext:toffset' |
+    'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01' |
+    'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time' |
+    'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time';
+
+/**
  * Defines a RTP header extension within the RTP parameters. The list of RTP
  * header extensions supported by mediasoup is defined in the
  * supportedRtpCapabilities.ts file.
@@ -284,7 +300,7 @@ export type RtpHeaderExtensionParameters =
 	/**
 	 * The URI of the RTP header extension, as defined in RFC 5285.
 	 */
-	uri: string;
+	uri: RtpHeaderExtensionUri;
 	/**
 	 * The numeric identifier that goes in the RTP packet. Must be unique.
 	 */

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -100,13 +100,19 @@ export type DtlsParameters =
 
 /**
  * The hash function algorithm (as defined in the "Hash function Textual Names"
+ * registry initially specified in RFC 4572 Section 8).
+ */
+export type FingerprintAlgorithm = 'sha-1'| 'sha-224'| 'sha-256'| 'sha-384'| 'sha-512';
+
+/**
+ * The hash function algorithm (as defined in the "Hash function Textual Names"
  * registry initially specified in RFC 4572 Section 8) and its corresponding
  * certificate fingerprint value (in lowercase hex string as expressed utilizing
  * the syntax of "fingerprint" in RFC 4572 Section 5).
  */
 export type DtlsFingerprint =
 {
-	algorithm: string;
+	algorithm: FingerprintAlgorithm;
 	value: string;
 };
 

--- a/src/tests/fakeParameters.ts
+++ b/src/tests/fakeParameters.ts
@@ -294,16 +294,19 @@ export function generateNativeRtpCapabilities(): mediasoupClient.types.RtpCapabi
 			},
 			{
 				kind        : 'video',
+				// @ts-ignore
 				uri         : 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay',
 				preferredId : 6
 			},
 			{
 				kind        : 'video',
+				// @ts-ignore
 				uri         : 'http://www.webrtc.org/experiments/rtp-hdrext/video-content-type',
 				preferredId : 7
 			},
 			{
 				kind        : 'video',
+				// @ts-ignore
 				uri         : 'http://www.webrtc.org/experiments/rtp-hdrext/video-timing',
 				preferredId : 8
 			},


### PR DESCRIPTION
Since `flatbuffers` branch adds these new types in server side, we need to keep them in sync in case the application signalling relies in typed messages between client and server. 