### PR TITLE
chore: add missing shadow dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 			"devDependencies": {
 				"@types/events": "^3.0.3",
 				"@types/jest": "^29.5.12",
+				"@types/node": "20",
 				"@types/sdp-transform": "^2.4.9",
 				"@types/ua-parser-js": "^0.7.39",
 				"@typescript-eslint/eslint-plugin": "^7.10.0",
@@ -1308,9 +1309,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "18.11.9",
+			"version": "20.14.2",
+			"resolved": "https://registry.npmmirror.com/@types/node/-/node-20.14.2.tgz",
+			"integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
 			"dev": true,
-			"license": "MIT"
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"node_modules/@types/sdp-transform": {
 			"version": "2.4.9",
@@ -5067,6 +5072,12 @@
 				"node": "*"
 			}
 		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
+		},
 		"node_modules/unique-string": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
@@ -6173,8 +6184,13 @@
 			"version": "0.7.31"
 		},
 		"@types/node": {
-			"version": "18.11.9",
-			"dev": true
+			"version": "20.14.2",
+			"resolved": "https://registry.npmmirror.com/@types/node/-/node-20.14.2.tgz",
+			"integrity": "sha512-xyu6WAMVwv6AKFLB+e/7ySZVr/0zLCzOa7rSpq6jNwpqOrUbcACDWC+53d4n2QHOnDou0fbIsg8wZu/sxrnI4Q==",
+			"dev": true,
+			"requires": {
+				"undici-types": "~5.26.4"
+			}
 		},
 		"@types/sdp-transform": {
 			"version": "2.4.9",
@@ -8605,6 +8621,12 @@
 			"version": "1.0.37",
 			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
 			"integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ=="
+		},
+		"undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
 		},
 		"unique-string": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
 	"devDependencies": {
 		"@types/events": "^3.0.3",
 		"@types/jest": "^29.5.12",
+		"@types/node": "20",
 		"@types/sdp-transform": "^2.4.9",
 		"@types/ua-parser-js": "^0.7.39",
 		"@typescript-eslint/eslint-plugin": "^7.10.0",


### PR DESCRIPTION
`npm` has a known problem of shadow dependencies. 
When installing with `pnpm`, the package `@types/node` is not there where `tsc` expects it, which itself is indirect dependency of `jest`.

And also, I would suggest use `pnpm` as a drop-in replacement for `npm`, which helps much on multi-package management, prevention of shadow deps, and quicker installation.