### PR TITLE
Force TypeScript usage of NPM `events` dep instead of Node built-in `events` module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,18 +12,18 @@
 				"@types/debug": "^4.1.12",
 				"awaitqueue": "^3.0.2",
 				"debug": "^4.3.5",
-				"events": "^3.3.0",
 				"fake-mediastreamtrack": "^1.2.0",
 				"h264-profile-level-id": "^2.0.0",
+				"npm-events-package": "npm:events@^3.3.0",
 				"queue-microtask": "^1.2.3",
 				"sdp-transform": "^2.14.2",
 				"supports-color": "^9.4.0",
 				"ua-parser-js": "^1.0.38"
 			},
 			"devDependencies": {
-				"@types/events": "^3.0.3",
 				"@types/jest": "^29.5.12",
 				"@types/node": "20",
+				"@types/npm-events-package": "npm:@types/events@^3.0.3",
 				"@types/sdp-transform": "^2.4.9",
 				"@types/ua-parser-js": "^0.7.39",
 				"@typescript-eslint/eslint-plugin": "^7.12.0",
@@ -1258,12 +1258,6 @@
 				"@types/ms": "*"
 			}
 		},
-		"node_modules/@types/events": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
-			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
-			"dev": true
-		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.6",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -1316,6 +1310,13 @@
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
+		},
+		"node_modules/@types/npm-events-package": {
+			"name": "@types/events",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
+			"dev": true
 		},
 		"node_modules/@types/sdp-transform": {
 			"version": "2.4.9",
@@ -2493,13 +2494,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/mysticatea"
-			}
-		},
-		"node_modules/events": {
-			"version": "3.3.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.x"
 			}
 		},
 		"node_modules/execa": {
@@ -4006,6 +4000,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm-events-package": {
+			"name": "events",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"engines": {
+				"node": ">=0.8.x"
 			}
 		},
 		"node_modules/npm-run-path": {
@@ -6138,12 +6141,6 @@
 				"@types/ms": "*"
 			}
 		},
-		"@types/events": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
-			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
-			"dev": true
-		},
 		"@types/graceful-fs": {
 			"version": "4.1.6",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -6192,6 +6189,12 @@
 			"requires": {
 				"undici-types": "~5.26.4"
 			}
+		},
+		"@types/npm-events-package": {
+			"version": "npm:@types/events@3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+			"integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
+			"dev": true
 		},
 		"@types/sdp-transform": {
 			"version": "2.4.9",
@@ -6936,9 +6939,6 @@
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
 			"integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA=="
-		},
-		"events": {
-			"version": "3.3.0"
 		},
 		"execa": {
 			"version": "5.1.1",
@@ -7991,6 +7991,11 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 			"dev": true
+		},
+		"npm-events-package": {
+			"version": "npm:events@3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
 		},
 		"npm-run-path": {
 			"version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"@types/debug": "^4.1.12",
 		"awaitqueue": "^3.0.2",
 		"debug": "^4.3.5",
-		"events": "^3.3.0",
+		"npm-events-package": "npm:events@^3.3.0",
 		"fake-mediastreamtrack": "^1.2.0",
 		"h264-profile-level-id": "^2.0.0",
 		"queue-microtask": "^1.2.3",
@@ -76,7 +76,7 @@
 		"ua-parser-js": "^1.0.38"
 	},
 	"devDependencies": {
-		"@types/events": "^3.0.3",
+		"@types/npm-events-package": "npm:@types/events@^3.0.3",
 		"@types/jest": "^29.5.12",
 		"@types/node": "20",
 		"@types/sdp-transform": "^2.4.9",

--- a/src/EnhancedEventEmitter.ts
+++ b/src/EnhancedEventEmitter.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter, Listener } from 'npm-events-package';
 import { Logger } from './Logger';
 
 const logger = new Logger('EnhancedEventEmitter');
@@ -109,11 +109,11 @@ export class EnhancedEventEmitter<
 		return super.listenerCount(eventName);
 	}
 
-	listeners<K extends keyof E & string>(eventName: K): Function[] {
+	listeners<K extends keyof E & string>(eventName: K): Listener[] {
 		return super.listeners(eventName);
 	}
 
-	rawListeners<K extends keyof E & string>(eventName: K): Function[] {
+	rawListeners<K extends keyof E & string>(eventName: K): Listener[] {
 		return super.rawListeners(eventName);
 	}
 }


### PR DESCRIPTION
### Details

- Generated TS types should not depend on Node types.
- So let's force module resolution to take and read `events` from the NPM **events** module.