### PR TITLE
Allow createEncodedStreams on PCs without encodedInsertableStreams parameter

### DIFF
--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -2,7 +2,7 @@ import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import { InvalidStateError } from './errors';
 import { MediaKind, RtpParameters } from './RtpParameters';
-import { AppData } from './types';
+import { AppData, ReceiverCallback } from './types';
 
 const logger = new Logger('Consumer');
 
@@ -12,6 +12,7 @@ export type ConsumerOptions<ConsumerAppData extends AppData = AppData> = {
 	kind?: 'audio' | 'video';
 	rtpParameters: RtpParameters;
 	streamId?: string;
+	onRtpReceiver?: ReceiverCallback;
 	appData?: ConsumerAppData;
 };
 

--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -7,7 +7,7 @@ import {
 	RtpParameters,
 	RtpEncodingParameters,
 } from './RtpParameters';
-import { AppData } from './types';
+import { AppData, SenderCallback } from './types';
 
 const logger = new Logger('Producer');
 
@@ -19,6 +19,7 @@ export type ProducerOptions<ProducerAppData extends AppData = AppData> = {
 	stopTracks?: boolean;
 	disableTrackOnPause?: boolean;
 	zeroRtpOnPause?: boolean;
+	onRtpSender?: SenderCallback;
 	appData?: ProducerAppData;
 };
 

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -490,6 +490,7 @@ export class Transport<
 		stopTracks = true,
 		disableTrackOnPause = true,
 		zeroRtpOnPause = false,
+		onRtpSender,
 		appData = {} as ProducerAppData,
 	}: ProducerOptions<ProducerAppData> = {}): Promise<
 		Producer<ProducerAppData>
@@ -570,6 +571,7 @@ export class Transport<
 							encodings: normalizedEncodings,
 							codecOptions,
 							codec,
+							onRtpSender,
 						});
 
 					try {
@@ -639,6 +641,7 @@ export class Transport<
 		kind,
 		rtpParameters,
 		streamId,
+		onRtpReceiver,
 		appData = {} as ConsumerAppData,
 	}: ConsumerOptions<ConsumerAppData>): Promise<Consumer<ConsumerAppData>> {
 		logger.debug('consume()');
@@ -681,6 +684,7 @@ export class Transport<
 			kind,
 			rtpParameters: clonedRtpParameters,
 			streamId,
+			onRtpReceiver,
 			appData,
 		});
 
@@ -876,13 +880,14 @@ export class Transport<
 				const optionsList: HandlerReceiveOptions[] = [];
 
 				for (const task of pendingConsumerTasks) {
-					const { id, kind, rtpParameters, streamId } = task.consumerOptions;
+					const { id, kind, rtpParameters, streamId, onRtpReceiver } = task.consumerOptions;
 
 					optionsList.push({
 						trackId: id!,
 						kind: kind as MediaKind,
 						rtpParameters,
 						streamId,
+						onRtpReceiver,
 					});
 				}
 

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -321,6 +321,7 @@ export class Chrome111 extends HandlerInterface {
 		encodings,
 		codecOptions,
 		codec,
+		onRtpSender,
 	}: HandlerSendOptions): Promise<HandlerSendResult> {
 		this.assertNotClosed();
 		this.assertSendDirection();
@@ -378,6 +379,11 @@ export class Chrome111 extends HandlerInterface {
 			streams: [this._sendStream],
 			sendEncodings: encodings,
 		});
+
+		if (onRtpSender) {
+			onRtpSender(transceiver.sender);
+		}
+
 		const offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
@@ -825,6 +831,22 @@ export class Chrome111 extends HandlerInterface {
 		);
 
 		await this._pc.setRemoteDescription(offer);
+
+		for (const options of optionsList) {
+			const { trackId, onRtpReceiver } = options;
+
+			if (onRtpReceiver) {
+				const localId = mapLocalId.get(trackId);
+				const transceiver = this._pc.getTransceivers()
+					.find((t: RTCRtpTransceiver) => t.mid === localId);
+				
+				if (!transceiver) {
+					throw new Error('transceiver not found');
+				}
+
+				onRtpReceiver(transceiver.receiver);
+			}
+		}
 
 		let answer = await this._pc.createAnswer();
 		const localSdpObject = sdpTransform.parse(answer.sdp);

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -34,11 +34,18 @@ export type HandlerRunOptions = {
 	extendedRtpCapabilities: any;
 };
 
+/*
+ * Invoked synchronously immediately after a new RTCRtpSender is created.
+ * This allows for creating encoded streams in chromium browsers.
+ */
+export type SenderCallback = (sender: RTCRtpSender) => void;
+
 export type HandlerSendOptions = {
 	track: MediaStreamTrack;
 	encodings?: RtpEncodingParameters[];
 	codecOptions?: ProducerCodecOptions;
 	codec?: RtpCodecCapability;
+	onRtpSender?: SenderCallback;
 };
 
 export type HandlerSendResult = {
@@ -46,6 +53,12 @@ export type HandlerSendResult = {
 	rtpParameters: RtpParameters;
 	rtpSender?: RTCRtpSender;
 };
+
+/*
+ * Invoked synchronously immediately after a new RTCRtpReceiver is created.
+ * This allows for creating encoded streams in chromium browsers.
+ */
+export type ReceiverCallback = (receiver: RTCRtpReceiver) => void;
 
 export type HandlerReceiveOptions = {
 	trackId: string;
@@ -58,6 +71,7 @@ export type HandlerReceiveOptions = {
 	 * can just synchronize up to one audio stream with one video stream.
 	 */
 	streamId?: string;
+	onRtpReceiver?: ReceiverCallback;
 };
 
 export type HandlerReceiveResult = {


### PR DESCRIPTION
Fixes #299 

Allows calling clients to add sender and receiver callback functions which are executed synchronously after `RTCRTPSender/Receiver` creation. This feature is targeted to Chromium browsers and allows applications to call `createEncodedStreams()` in the callback functions in order to create [WebRTC Encoded Transforms](https://www.w3.org/TR/webrtc-encoded-transform/).

### Example Usage

``` ts
const consumer = await recvTransport.consume({
  xxxxx,
  xxxxx,
  onRtpReceiver: (receiver) => {
    const { readable, writable } = receiver.createEncodedStreams();
    readable.pipeTo(writable);
  }
});
```