### PR TITLE
Add playout-delay URI to RtpHeaderExtensionUri type

### DIFF
--- a/src/RtpParameters.ts
+++ b/src/RtpParameters.ts
@@ -282,7 +282,8 @@ export type RtpHeaderExtensionUri =
 	| 'urn:ietf:params:rtp-hdrext:toffset'
 	| 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01'
 	| 'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time'
-	| 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time';
+	| 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time'
+	| 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay';
 
 /**
  * Defines a RTP header extension within the RTP parameters. The list of RTP


### PR DESCRIPTION
Support for playout-delay added in https://github.com/versatica/mediasoup/pull/1412