### PR TITLE
Export TS types and extras in a separate module entry point

### DIFF
--- a/.github/workflows/mediasoup-client.yaml
+++ b/.github/workflows/mediasoup-client.yaml
@@ -19,9 +19,11 @@ jobs:
             node: 20
           - os: ubuntu-24.04
             node: 22
-          - os: macos-12
-            node: 20
+          - os: macos-13
+            node: 18
           - os: macos-14
+            node: 20
+          - os: macos-15
             node: 22
           - os: windows-2022
             node: 22

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
 				"@types/node": "22",
 				"@types/sdp-transform": "^2.4.9",
 				"@types/ua-parser-js": "^0.7.39",
-				"@typescript-eslint/eslint-plugin": "^8.18.0",
-				"@typescript-eslint/parser": "^8.18.0",
+				"@typescript-eslint/eslint-plugin": "^8.18.1",
+				"@typescript-eslint/parser": "^8.18.1",
 				"eslint": "^9.17.0",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-jest": "^28.9.0",
@@ -39,7 +39,7 @@
 				"prettier": "^3.4.2",
 				"ts-jest": "^29.2.5",
 				"typescript": "^5.7.2",
-				"typescript-eslint": "^8.18.0"
+				"typescript-eslint": "^8.18.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -1495,17 +1495,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.0.tgz",
-			"integrity": "sha512-NR2yS7qUqCL7AIxdJUQf2MKKNDVNaig/dEB0GBLU7D+ZdHgK1NoH/3wsgO3OnPVipn51tG3MAwaODEGil70WEw==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.1.tgz",
+			"integrity": "sha512-Ncvsq5CT3Gvh+uJG0Lwlho6suwDfUXH0HztslDf5I+F2wAFAZMRwYLEorumpKLzmO2suAXZ/td1tBg4NZIi9CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.18.0",
-				"@typescript-eslint/type-utils": "8.18.0",
-				"@typescript-eslint/utils": "8.18.0",
-				"@typescript-eslint/visitor-keys": "8.18.0",
+				"@typescript-eslint/scope-manager": "8.18.1",
+				"@typescript-eslint/type-utils": "8.18.1",
+				"@typescript-eslint/utils": "8.18.1",
+				"@typescript-eslint/visitor-keys": "8.18.1",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -1525,16 +1525,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.0.tgz",
-			"integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.1.tgz",
+			"integrity": "sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==",
 			"dev": true,
-			"license": "MITClause",
+			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.18.0",
-				"@typescript-eslint/types": "8.18.0",
-				"@typescript-eslint/typescript-estree": "8.18.0",
-				"@typescript-eslint/visitor-keys": "8.18.0",
+				"@typescript-eslint/scope-manager": "8.18.1",
+				"@typescript-eslint/types": "8.18.1",
+				"@typescript-eslint/typescript-estree": "8.18.1",
+				"@typescript-eslint/visitor-keys": "8.18.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1550,14 +1550,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.0.tgz",
-			"integrity": "sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.1.tgz",
+			"integrity": "sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.18.0",
-				"@typescript-eslint/visitor-keys": "8.18.0"
+				"@typescript-eslint/types": "8.18.1",
+				"@typescript-eslint/visitor-keys": "8.18.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1568,14 +1568,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.0.tgz",
-			"integrity": "sha512-er224jRepVAVLnMF2Q7MZJCq5CsdH2oqjP4dT7K6ij09Kyd+R21r7UVJrF0buMVdZS5QRhDzpvzAxHxabQadow==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.1.tgz",
+			"integrity": "sha512-jAhTdK/Qx2NJPNOTxXpMwlOiSymtR2j283TtPqXkKBdH8OAMmhiUfP0kJjc/qSE51Xrq02Gj9NY7MwK+UxVwHQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.18.0",
-				"@typescript-eslint/utils": "8.18.0",
+				"@typescript-eslint/typescript-estree": "8.18.1",
+				"@typescript-eslint/utils": "8.18.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			},
@@ -1592,9 +1592,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.0.tgz",
-			"integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.1.tgz",
+			"integrity": "sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1606,14 +1606,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.0.tgz",
-			"integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.1.tgz",
+			"integrity": "sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.18.0",
-				"@typescript-eslint/visitor-keys": "8.18.0",
+				"@typescript-eslint/types": "8.18.1",
+				"@typescript-eslint/visitor-keys": "8.18.1",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -1659,16 +1659,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.0.tgz",
-			"integrity": "sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.1.tgz",
+			"integrity": "sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.18.0",
-				"@typescript-eslint/types": "8.18.0",
-				"@typescript-eslint/typescript-estree": "8.18.0"
+				"@typescript-eslint/scope-manager": "8.18.1",
+				"@typescript-eslint/types": "8.18.1",
+				"@typescript-eslint/typescript-estree": "8.18.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1683,13 +1683,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.0.tgz",
-			"integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.1.tgz",
+			"integrity": "sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.18.0",
+				"@typescript-eslint/types": "8.18.1",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
@@ -5273,15 +5273,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.0.tgz",
-			"integrity": "sha512-Xq2rRjn6tzVpAyHr3+nmSg1/9k9aIHnJ2iZeOH7cfGOWqTkXTm3kwpQglEuLGdNrYvPF+2gtAs+/KF5rjVo+WQ==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.1.tgz",
+			"integrity": "sha512-Mlaw6yxuaDEPQvb/2Qwu3/TfgeBHy9iTJ3mTwe7OvpPmF6KPQjVOfGyEJpPv6Ez2C34OODChhXrzYw/9phI0MQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.18.0",
-				"@typescript-eslint/parser": "8.18.0",
-				"@typescript-eslint/utils": "8.18.0"
+				"@typescript-eslint/eslint-plugin": "8.18.1",
+				"@typescript-eslint/parser": "8.18.1",
+				"@typescript-eslint/utils": "8.18.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6612,16 +6612,16 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.0.tgz",
-			"integrity": "sha512-NR2yS7qUqCL7AIxdJUQf2MKKNDVNaig/dEB0GBLU7D+ZdHgK1NoH/3wsgO3OnPVipn51tG3MAwaODEGil70WEw==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.1.tgz",
+			"integrity": "sha512-Ncvsq5CT3Gvh+uJG0Lwlho6suwDfUXH0HztslDf5I+F2wAFAZMRwYLEorumpKLzmO2suAXZ/td1tBg4NZIi9CQ==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.18.0",
-				"@typescript-eslint/type-utils": "8.18.0",
-				"@typescript-eslint/utils": "8.18.0",
-				"@typescript-eslint/visitor-keys": "8.18.0",
+				"@typescript-eslint/scope-manager": "8.18.1",
+				"@typescript-eslint/type-utils": "8.18.1",
+				"@typescript-eslint/utils": "8.18.1",
+				"@typescript-eslint/visitor-keys": "8.18.1",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -6629,54 +6629,54 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.0.tgz",
-			"integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.1.tgz",
+			"integrity": "sha512-rBnTWHCdbYM2lh7hjyXqxk70wvon3p2FyaniZuey5TrcGBpfhVp0OxOa6gxr9Q9YhZFKyfbEnxc24ZnVbbUkCA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "8.18.0",
-				"@typescript-eslint/types": "8.18.0",
-				"@typescript-eslint/typescript-estree": "8.18.0",
-				"@typescript-eslint/visitor-keys": "8.18.0",
+				"@typescript-eslint/scope-manager": "8.18.1",
+				"@typescript-eslint/types": "8.18.1",
+				"@typescript-eslint/typescript-estree": "8.18.1",
+				"@typescript-eslint/visitor-keys": "8.18.1",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.0.tgz",
-			"integrity": "sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.1.tgz",
+			"integrity": "sha512-HxfHo2b090M5s2+/9Z3gkBhI6xBH8OJCFjH9MhQ+nnoZqxU3wNxkLT+VWXWSFWc3UF3Z+CfPAyqdCTdoXtDPCQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.18.0",
-				"@typescript-eslint/visitor-keys": "8.18.0"
+				"@typescript-eslint/types": "8.18.1",
+				"@typescript-eslint/visitor-keys": "8.18.1"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.0.tgz",
-			"integrity": "sha512-er224jRepVAVLnMF2Q7MZJCq5CsdH2oqjP4dT7K6ij09Kyd+R21r7UVJrF0buMVdZS5QRhDzpvzAxHxabQadow==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.1.tgz",
+			"integrity": "sha512-jAhTdK/Qx2NJPNOTxXpMwlOiSymtR2j283TtPqXkKBdH8OAMmhiUfP0kJjc/qSE51Xrq02Gj9NY7MwK+UxVwHQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "8.18.0",
-				"@typescript-eslint/utils": "8.18.0",
+				"@typescript-eslint/typescript-estree": "8.18.1",
+				"@typescript-eslint/utils": "8.18.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.0.tgz",
-			"integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.1.tgz",
+			"integrity": "sha512-7uoAUsCj66qdNQNpH2G8MyTFlgerum8ubf21s3TSM3XmKXuIn+H2Sifh/ES2nPOPiYSRJWAk0fDkW0APBWcpfw==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.0.tgz",
-			"integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.1.tgz",
+			"integrity": "sha512-z8U21WI5txzl2XYOW7i9hJhxoKKNG1kcU4RzyNvKrdZDmbjkmLBo8bgeiOJmA06kizLI76/CCBAAGlTlEeUfyg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.18.0",
-				"@typescript-eslint/visitor-keys": "8.18.0",
+				"@typescript-eslint/types": "8.18.1",
+				"@typescript-eslint/visitor-keys": "8.18.1",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -6706,24 +6706,24 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.0.tgz",
-			"integrity": "sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.1.tgz",
+			"integrity": "sha512-8vikiIj2ebrC4WRdcAdDcmnu9Q/MXXwg+STf40BVfT8exDqBCUPdypvzcUPxEqRGKg9ALagZ0UWcYCtn+4W2iQ==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.18.0",
-				"@typescript-eslint/types": "8.18.0",
-				"@typescript-eslint/typescript-estree": "8.18.0"
+				"@typescript-eslint/scope-manager": "8.18.1",
+				"@typescript-eslint/types": "8.18.1",
+				"@typescript-eslint/typescript-estree": "8.18.1"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.0.tgz",
-			"integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.1.tgz",
+			"integrity": "sha512-Vj0WLm5/ZsD013YeUKn+K0y8p1M0jPpxOkKdbD1wB0ns53a5piVY02zjf072TblEweAbcYiFiPoSMF3kp+VhhQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.18.0",
+				"@typescript-eslint/types": "8.18.1",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"dependencies": {
@@ -9054,14 +9054,14 @@
 			"dev": true
 		},
 		"typescript-eslint": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.0.tgz",
-			"integrity": "sha512-Xq2rRjn6tzVpAyHr3+nmSg1/9k9aIHnJ2iZeOH7cfGOWqTkXTm3kwpQglEuLGdNrYvPF+2gtAs+/KF5rjVo+WQ==",
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.1.tgz",
+			"integrity": "sha512-Mlaw6yxuaDEPQvb/2Qwu3/TfgeBHy9iTJ3mTwe7OvpPmF6KPQjVOfGyEJpPv6Ez2C34OODChhXrzYw/9phI0MQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/eslint-plugin": "8.18.0",
-				"@typescript-eslint/parser": "8.18.0",
-				"@typescript-eslint/utils": "8.18.0"
+				"@typescript-eslint/eslint-plugin": "8.18.1",
+				"@typescript-eslint/parser": "8.18.1",
+				"@typescript-eslint/utils": "8.18.1"
 			}
 		},
 		"ua-is-frozen": {

--- a/package.json
+++ b/package.json
@@ -16,11 +16,21 @@
 		"type": "opencollective",
 		"url": "https://opencollective.com/mediasoup"
 	},
-	"main": "lib/index.js",
-	"types": "lib/index.d.ts",
+	"main": "./lib/index.js",
+	"types": "./lib/index.d.ts",
+	"exports": {
+	  ".": {
+	    "import": "./lib/index.js",
+	    "types": "./lib/index.d.ts"
+	  },
+	  "./types": {
+	  	"import": "./lib/types.js",
+	    "types": "./lib/types.d.ts"
+	  }
+	},
 	"files": [
-		"npm-scripts.mjs",
-		"lib"
+		"./npm-scripts.mjs",
+		"./lib"
 	],
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,6 @@
 		"type": "opencollective",
 		"url": "https://opencollective.com/mediasoup"
 	},
-	"main": "./lib/index.js",
-	"types": "./lib/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./lib/index.js",

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
 	"main": "./lib/index.js",
 	"types": "./lib/index.d.ts",
 	"exports": {
-	  ".": {
-	    "import": "./lib/index.js",
-	    "types": "./lib/index.d.ts"
-	  },
-	  "./types": {
-	  	"import": "./lib/types.js",
-	    "types": "./lib/types.d.ts"
-	  }
+		".": {
+			"import": "./lib/index.js",
+			"types": "./lib/index.d.ts"
+		},
+		"./types": {
+			"import": "./lib/types.js",
+			"types": "./lib/types.d.ts"
+		}
 	},
 	"files": [
 		"./npm-scripts.mjs",

--- a/package.json
+++ b/package.json
@@ -104,8 +104,8 @@
 		"@types/node": "22",
 		"@types/sdp-transform": "^2.4.9",
 		"@types/ua-parser-js": "^0.7.39",
-		"@typescript-eslint/eslint-plugin": "^8.18.0",
-		"@typescript-eslint/parser": "^8.18.0",
+		"@typescript-eslint/eslint-plugin": "^8.18.1",
+		"@typescript-eslint/parser": "^8.18.1",
 		"eslint": "^9.17.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-jest": "^28.9.0",
@@ -116,6 +116,6 @@
 		"prettier": "^3.4.2",
 		"ts-jest": "^29.2.5",
 		"typescript": "^5.7.2",
-		"typescript-eslint": "^8.18.0"
+		"typescript-eslint": "^8.18.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
 		"type": "opencollective",
 		"url": "https://opencollective.com/mediasoup"
 	},
+	"main": "lib/index.js",
+	"types": "lib/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./lib/index.js",
@@ -24,6 +26,18 @@
 		"./types": {
 			"import": "./lib/types.js",
 			"types": "./lib/types.d.ts"
+		},
+		"./extras/HandlerInterface": {
+			"import": "./lib/handlers/HandlerInterface.js",
+			"types": "./lib/handlers/HandlerInterface.d.ts"
+		},
+		"./extras/FakeHandler": {
+			"import": "./lib/handlers/FakeHandler.js",
+			"types": "./lib/handlers/FakeHandler.d.ts"
+		},
+		"./extras/fakeParameters": {
+			"import": "./lib/test/fakeParameters.js",
+			"types": "./lib/test/fakeParameters.d.ts"
 		}
 	},
 	"files": [

--- a/src/extras.ts
+++ b/src/extras.ts
@@ -1,0 +1,3 @@
+export * as HandlerInterface from './handlers/HandlerInterface';
+export * as FakeHandler from './handlers/FakeHandler';
+export * as fakeParameters from './test/fakeParameters';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,17 @@
 import debug from 'debug';
 import { Device, detectDevice } from './Device';
 import * as types from './types';
+import * as extras from './extras';
 
 /**
  * Expose all types.
  */
 export { types };
+
+/**
+ * Expose all extras.
+ */
+export { extras };
 
 /**
  * Expose mediasoup-client version.


### PR DESCRIPTION
## Details

- Instead of exporting `types` like this:
  ```ts
  import { types as mediasoupClientTypes } from 'mediasoup-client';
  ```
- Now we import them this way:
  ```ts
  import * as mediasoupClientTypes from 'mediasoup-client/types';
  ```
- Also export new `extras` namespaces in both ways:
  ```ts
  import { extras } from 'mediasoup-client';
  ```
- And this way:
  ```ts
  import { HandlerInterface, HandlerFactory } from 'mediasoup-client/extras/HandlerInterface';
  import { FakeHandler } from 'mediasoup-client/extras/FakeHandler';
  import * as mediasoupClientTestFakeParameters from 'mediasoup-client/extras/fakeParameters';
  ```

## NOTE 1

It looks like for this to work, the parent application must have in its `tsconfig.json`:

```
"module": "nodenext",
"moduleResolution": "nodenext",
```

But take into account that using "moduleResolution: node" means "Node 10". Please, we can kill that already.

## NOTE 2

Should we stop exporting `types` from 'mediasoup-client' and instead force applications to import them from 'mediasoup-client/types'?

Well, we don't do it yet.
