### PR TITLE
Transport: new event 'icecandidateerror'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
 				"@types/node": "22",
 				"@types/sdp-transform": "^2.4.9",
 				"@types/ua-parser-js": "^0.7.39",
-				"@typescript-eslint/eslint-plugin": "^8.25.0",
-				"@typescript-eslint/parser": "^8.25.0",
+				"@typescript-eslint/eslint-plugin": "^8.26.0",
+				"@typescript-eslint/parser": "^8.26.0",
 				"eslint": "^9.21.0",
 				"eslint-config-prettier": "^10.0.2",
 				"eslint-plugin-jest": "^28.11.0",
@@ -36,10 +36,10 @@
 				"globals": "^16.0.0",
 				"jest": "^29.7.0",
 				"open-cli": "^8.0.0",
-				"prettier": "^3.5.2",
+				"prettier": "^3.5.3",
 				"ts-jest": "^29.2.6",
-				"typescript": "^5.7.3",
-				"typescript-eslint": "^8.25.0"
+				"typescript": "^5.8.2",
+				"typescript-eslint": "^8.26.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -1509,17 +1509,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
-			"integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.0.tgz",
+			"integrity": "sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.25.0",
-				"@typescript-eslint/type-utils": "8.25.0",
-				"@typescript-eslint/utils": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0",
+				"@typescript-eslint/scope-manager": "8.26.0",
+				"@typescript-eslint/type-utils": "8.26.0",
+				"@typescript-eslint/utils": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -1535,20 +1535,20 @@
 			"peerDependencies": {
 				"@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
-			"integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.0.tgz",
+			"integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.25.0",
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/typescript-estree": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0",
+				"@typescript-eslint/scope-manager": "8.26.0",
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/typescript-estree": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1560,18 +1560,18 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
-			"integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz",
+			"integrity": "sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0"
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1582,14 +1582,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
-			"integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.0.tgz",
+			"integrity": "sha512-ruk0RNChLKz3zKGn2LwXuVoeBcUMh+jaqzN461uMMdxy5H9epZqIBtYj7UiPXRuOpaALXGbmRuZQhmwHhaS04Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.25.0",
-				"@typescript-eslint/utils": "8.25.0",
+				"@typescript-eslint/typescript-estree": "8.26.0",
+				"@typescript-eslint/utils": "8.26.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.0.1"
 			},
@@ -1602,13 +1602,13 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
-			"integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.0.tgz",
+			"integrity": "sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1620,14 +1620,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
-			"integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz",
+			"integrity": "sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0",
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -1643,7 +1643,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -1673,16 +1673,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
-			"integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.0.tgz",
+			"integrity": "sha512-2L2tU3FVwhvU14LndnQCA2frYC8JnPDVKyQtWFPf8IYFMt/ykEN1bPolNhNbCVgOmdzTlWdusCTKA/9nKrf8Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.25.0",
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/typescript-estree": "8.25.0"
+				"@typescript-eslint/scope-manager": "8.26.0",
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/typescript-estree": "8.26.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1693,17 +1693,17 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
-			"integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz",
+			"integrity": "sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/types": "8.26.0",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
@@ -4827,9 +4827,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
-			"integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+			"integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5542,9 +5542,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -5556,15 +5556,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.25.0.tgz",
-			"integrity": "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.26.0.tgz",
+			"integrity": "sha512-PtVz9nAnuNJuAVeUFvwztjuUgSnJInODAUx47VDwWPXzd5vismPOtPtt83tzNXyOjVQbPRp786D6WFW/M2koIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.25.0",
-				"@typescript-eslint/parser": "8.25.0",
-				"@typescript-eslint/utils": "8.25.0"
+				"@typescript-eslint/eslint-plugin": "8.26.0",
+				"@typescript-eslint/parser": "8.26.0",
+				"@typescript-eslint/utils": "8.26.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5575,7 +5575,7 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
-				"typescript": ">=4.8.4 <5.8.0"
+				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
 		"node_modules/ua-is-frozen": {
@@ -6924,16 +6924,16 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.25.0.tgz",
-			"integrity": "sha512-VM7bpzAe7JO/BFf40pIT1lJqS/z1F8OaSsUB3rpFJucQA4cOSuH2RVVVkFULN+En0Djgr29/jb4EQnedUo95KA==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.26.0.tgz",
+			"integrity": "sha512-cLr1J6pe56zjKYajK6SSSre6nl1Gj6xDp1TY0trpgPzjVbgDwd09v2Ws37LABxzkicmUjhEeg/fAUjPJJB1v5Q==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.25.0",
-				"@typescript-eslint/type-utils": "8.25.0",
-				"@typescript-eslint/utils": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0",
+				"@typescript-eslint/scope-manager": "8.26.0",
+				"@typescript-eslint/type-utils": "8.26.0",
+				"@typescript-eslint/utils": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -6941,54 +6941,54 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.25.0.tgz",
-			"integrity": "sha512-4gbs64bnbSzu4FpgMiQ1A+D+urxkoJk/kqlDJ2W//5SygaEiAP2B4GoS7TEdxgwol2el03gckFV9lJ4QOMiiHg==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.26.0.tgz",
+			"integrity": "sha512-mNtXP9LTVBy14ZF3o7JG69gRPBK/2QWtQd0j0oH26HcY/foyJJau6pNUez7QrM5UHnSvwlQcJXKsk0I99B9pOA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "8.25.0",
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/typescript-estree": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0",
+				"@typescript-eslint/scope-manager": "8.26.0",
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/typescript-estree": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.25.0.tgz",
-			"integrity": "sha512-6PPeiKIGbgStEyt4NNXa2ru5pMzQ8OYKO1hX1z53HMomrmiSB+R5FmChgQAP1ro8jMtNawz+TRQo/cSXrauTpg==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.26.0.tgz",
+			"integrity": "sha512-E0ntLvsfPqnPwng8b8y4OGuzh/iIOm2z8U3S9zic2TeMLW61u5IH2Q1wu0oSTkfrSzwbDJIB/Lm8O3//8BWMPA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0"
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.25.0.tgz",
-			"integrity": "sha512-d77dHgHWnxmXOPJuDWO4FDWADmGQkN5+tt6SFRZz/RtCWl4pHgFl3+WdYCn16+3teG09DY6XtEpf3gGD0a186g==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.26.0.tgz",
+			"integrity": "sha512-ruk0RNChLKz3zKGn2LwXuVoeBcUMh+jaqzN461uMMdxy5H9epZqIBtYj7UiPXRuOpaALXGbmRuZQhmwHhaS04Q==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "8.25.0",
-				"@typescript-eslint/utils": "8.25.0",
+				"@typescript-eslint/typescript-estree": "8.26.0",
+				"@typescript-eslint/utils": "8.26.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.0.1"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.25.0.tgz",
-			"integrity": "sha512-+vUe0Zb4tkNgznQwicsvLUJgZIRs6ITeWSCclX1q85pR1iOiaj+4uZJIUp//Z27QWu5Cseiw3O3AR8hVpax7Aw==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.26.0.tgz",
+			"integrity": "sha512-89B1eP3tnpr9A8L6PZlSjBvnJhWXtYfZhECqlBl1D9Lme9mHO6iWlsprBtVenQvY1HMhax1mWOjhtL3fh/u+pA==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.25.0.tgz",
-			"integrity": "sha512-ZPaiAKEZ6Blt/TPAx5Ot0EIB/yGtLI2EsGoY6F7XKklfMxYQyvtL+gT/UCqkMzO0BVFHLDlzvFqQzurYahxv9Q==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.26.0.tgz",
+			"integrity": "sha512-tiJ1Hvy/V/oMVRTbEOIeemA2XoylimlDQ03CgPPNaHYZbpsc78Hmngnt+WXZfJX1pjQ711V7g0H7cSJThGYfPQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/visitor-keys": "8.25.0",
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/visitor-keys": "8.26.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -7018,24 +7018,24 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.25.0.tgz",
-			"integrity": "sha512-syqRbrEv0J1wywiLsK60XzHnQe/kRViI3zwFALrNEgnntn1l24Ra2KvOAWwWbWZ1lBZxZljPDGOq967dsl6fkA==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.26.0.tgz",
+			"integrity": "sha512-2L2tU3FVwhvU14LndnQCA2frYC8JnPDVKyQtWFPf8IYFMt/ykEN1bPolNhNbCVgOmdzTlWdusCTKA/9nKrf8Ig==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.25.0",
-				"@typescript-eslint/types": "8.25.0",
-				"@typescript-eslint/typescript-estree": "8.25.0"
+				"@typescript-eslint/scope-manager": "8.26.0",
+				"@typescript-eslint/types": "8.26.0",
+				"@typescript-eslint/typescript-estree": "8.26.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.25.0.tgz",
-			"integrity": "sha512-kCYXKAum9CecGVHGij7muybDfTS2sD3t0L4bJsEZLkyrXUImiCTq1M3LG2SRtOhiHFwMR9wAFplpT6XHYjTkwQ==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.26.0.tgz",
+			"integrity": "sha512-2z8JQJWAzPdDd51dRQ/oqIJxe99/hoLIqmf8RMCAJQtYDc535W/Jt2+RTP4bP0aKeBG1F65yjIZuczOXCmbWwg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.25.0",
+				"@typescript-eslint/types": "8.26.0",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"dependencies": {
@@ -9098,9 +9098,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.2.tgz",
-			"integrity": "sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==",
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+			"integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -9523,20 +9523,20 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
 			"dev": true
 		},
 		"typescript-eslint": {
-			"version": "8.25.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.25.0.tgz",
-			"integrity": "sha512-TxRdQQLH4g7JkoFlYG3caW5v1S6kEkz8rqt80iQJZUYPq1zD1Ra7HfQBJJ88ABRaMvHAXnwRvRB4V+6sQ9xN5Q==",
+			"version": "8.26.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.26.0.tgz",
+			"integrity": "sha512-PtVz9nAnuNJuAVeUFvwztjuUgSnJInODAUx47VDwWPXzd5vismPOtPtt83tzNXyOjVQbPRp786D6WFW/M2koIA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/eslint-plugin": "8.25.0",
-				"@typescript-eslint/parser": "8.25.0",
-				"@typescript-eslint/utils": "8.25.0"
+				"@typescript-eslint/eslint-plugin": "8.26.0",
+				"@typescript-eslint/parser": "8.26.0",
+				"@typescript-eslint/utils": "8.26.0"
 			}
 		},
 		"ua-is-frozen": {

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
 		"@types/node": "22",
 		"@types/sdp-transform": "^2.4.9",
 		"@types/ua-parser-js": "^0.7.39",
-		"@typescript-eslint/eslint-plugin": "^8.25.0",
-		"@typescript-eslint/parser": "^8.25.0",
+		"@typescript-eslint/eslint-plugin": "^8.26.0",
+		"@typescript-eslint/parser": "^8.26.0",
 		"eslint": "^9.21.0",
 		"eslint-config-prettier": "^10.0.2",
 		"eslint-plugin-jest": "^28.11.0",
@@ -91,9 +91,9 @@
 		"globals": "^16.0.0",
 		"jest": "^29.7.0",
 		"open-cli": "^8.0.0",
-		"prettier": "^3.5.2",
+		"prettier": "^3.5.3",
 		"ts-jest": "^29.2.6",
-		"typescript": "^5.7.3",
-		"typescript-eslint": "^8.25.0"
+		"typescript": "^5.8.2",
+		"typescript-eslint": "^8.26.0"
 	}
 }

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -149,6 +149,7 @@ export type TransportEvents = {
 		(error: Error) => void,
 	];
 	icegatheringstatechange: [IceGatheringState];
+	icecandidateerror: [RTCPeerConnectionIceErrorEvent];
 	connectionstatechange: [ConnectionState];
 	produce: [
 		{
@@ -1143,6 +1144,19 @@ export class Transport<
 
 				if (!this._closed) {
 					this.safeEmit('icegatheringstatechange', iceGatheringState);
+				}
+			}
+		);
+
+		handler.on(
+			'@icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				logger.warn(
+					`ICE candidate error [url:${event.url}, localAddress:${event.address}, localPort:${event.port}]: ${event.errorCode} "${event.errorText}"`
+				);
+
+				if (!this._closed) {
+					this.safeEmit('icecandidateerror', event);
 				}
 			}
 		);

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -202,6 +202,13 @@ export class Chrome111 extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/Chrome55.ts
+++ b/src/handlers/Chrome55.ts
@@ -199,6 +199,13 @@ export class Chrome55 extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/Chrome67.ts
+++ b/src/handlers/Chrome67.ts
@@ -199,6 +199,13 @@ export class Chrome67 extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/Chrome70.ts
+++ b/src/handlers/Chrome70.ts
@@ -187,6 +187,13 @@ export class Chrome70 extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -204,6 +204,13 @@ export class Chrome74 extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -225,6 +225,13 @@ export class Firefox120 extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/Firefox60.ts
+++ b/src/handlers/Firefox60.ts
@@ -228,6 +228,13 @@ export class Firefox60 extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -94,6 +94,7 @@ export type HandlerEvents = {
 		(error: Error) => void,
 	];
 	'@icegatheringstatechange': [IceGatheringState];
+	'@icecandidateerror': [RTCPeerConnectionIceErrorEvent];
 	'@connectionstatechange': [ConnectionState];
 };
 

--- a/src/handlers/ReactNative.ts
+++ b/src/handlers/ReactNative.ts
@@ -204,6 +204,13 @@ export class ReactNative extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -211,6 +211,13 @@ export class ReactNativeUnifiedPlan extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/Safari11.ts
+++ b/src/handlers/Safari11.ts
@@ -198,6 +198,13 @@ export class Safari11 extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -200,6 +200,13 @@ export class Safari12 extends HandlerInterface {
 			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
 		});
 
+		this._pc.addEventListener(
+			'icecandidateerror',
+			(event: RTCPeerConnectionIceErrorEvent) => {
+				this.emit('@icecandidateerror', event);
+			}
+		);
+
 		if (this._pc.connectionState) {
 			this._pc.addEventListener('connectionstatechange', () => {
 				this.emit('@connectionstatechange', this._pc.connectionState);


### PR DESCRIPTION
## Details

- Make `Transport` emit 'icecandidateerror', same as in WebRTC spec: https://www.w3.org/TR/webrtc/#event-icecandidateerror
- Also update dev deps.

Example of ICE candidate errors being logged when browser fail to connect to TURN servers:
![CleanShot 2025-03-04 at 11 51 44@2x](https://github.com/user-attachments/assets/c4556149-636d-495e-b18a-ab99fcdf8fb1)

