### PR TITLE
Support a=extmap-allow-mixed attribute at SDP session level

### DIFF
--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -395,7 +395,7 @@ export class Chrome111 extends HandlerInterface {
 		const offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -449,7 +449,6 @@ export class Chrome111 extends HandlerInterface {
 			offerRtpParameters: sendingRtpParameters,
 			answerRtpParameters: sendingRemoteRtpParameters,
 			codecOptions,
-			extmapAllowMixed: true,
 		});
 
 		const answer = { type: 'answer', sdp: this._remoteSdp!.getSdp() };

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -395,6 +395,12 @@ export class Chrome111 extends HandlerInterface {
 		const offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		if (!this._transportReady) {
 			await this.setupTransport({
 				localDtlsRole: this._forcedLocalDtlsRole ?? 'client',

--- a/src/handlers/Chrome55.ts
+++ b/src/handlers/Chrome55.ts
@@ -338,7 +338,7 @@ export class Chrome55 extends HandlerInterface {
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/Chrome55.ts
+++ b/src/handlers/Chrome55.ts
@@ -337,6 +337,13 @@ export class Chrome55 extends HandlerInterface {
 
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
+
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		let offerMediaObject;
 		const sendingRtpParameters = utils.clone<RtpParameters>(
 			this._sendingRtpParametersByKind![track.kind]

--- a/src/handlers/Chrome67.ts
+++ b/src/handlers/Chrome67.ts
@@ -338,7 +338,7 @@ export class Chrome67 extends HandlerInterface {
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/Chrome67.ts
+++ b/src/handlers/Chrome67.ts
@@ -337,6 +337,13 @@ export class Chrome67 extends HandlerInterface {
 
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
+
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		let offerMediaObject;
 		const sendingRtpParameters = utils.clone<RtpParameters>(
 			this._sendingRtpParametersByKind![track.kind]

--- a/src/handlers/Chrome70.ts
+++ b/src/handlers/Chrome70.ts
@@ -340,6 +340,13 @@ export class Chrome70 extends HandlerInterface {
 		});
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
+
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		let offerMediaObject;
 
 		if (!this._transportReady) {

--- a/src/handlers/Chrome70.ts
+++ b/src/handlers/Chrome70.ts
@@ -341,7 +341,7 @@ export class Chrome70 extends HandlerInterface {
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -472,7 +472,6 @@ export class Chrome74 extends HandlerInterface {
 			offerRtpParameters: sendingRtpParameters,
 			answerRtpParameters: sendingRemoteRtpParameters,
 			codecOptions,
-			extmapAllowMixed: true,
 		});
 
 		const answer = { type: 'answer', sdp: this._remoteSdp!.getSdp() };

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -371,6 +371,13 @@ export class Chrome74 extends HandlerInterface {
 		});
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
+
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		let offerMediaObject;
 
 		if (!this._transportReady) {

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -372,7 +372,7 @@ export class Chrome74 extends HandlerInterface {
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -401,7 +401,7 @@ export class Firefox120 extends HandlerInterface {
 		const offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -401,6 +401,12 @@ export class Firefox120 extends HandlerInterface {
 		const offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		// In Firefox use DTLS role client even if we are the "offerer" since
 		// Firefox does not respect ICE-Lite.
 		if (!this._transportReady) {

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -472,7 +472,6 @@ export class Firefox120 extends HandlerInterface {
 			offerRtpParameters: sendingRtpParameters,
 			answerRtpParameters: sendingRemoteRtpParameters,
 			codecOptions,
-			extmapAllowMixed: true,
 		});
 
 		const answer = { type: 'answer', sdp: this._remoteSdp!.getSdp() };

--- a/src/handlers/Firefox60.ts
+++ b/src/handlers/Firefox60.ts
@@ -411,6 +411,12 @@ export class Firefox60 extends HandlerInterface {
 		const offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		// In Firefox use DTLS role client even if we are the "offerer" since
 		// Firefox does not respect ICE-Lite.
 		if (!this._transportReady) {

--- a/src/handlers/Firefox60.ts
+++ b/src/handlers/Firefox60.ts
@@ -483,7 +483,6 @@ export class Firefox60 extends HandlerInterface {
 			offerRtpParameters: sendingRtpParameters,
 			answerRtpParameters: sendingRemoteRtpParameters,
 			codecOptions,
-			extmapAllowMixed: true,
 		});
 
 		const answer = { type: 'answer', sdp: this._remoteSdp!.getSdp() };

--- a/src/handlers/Firefox60.ts
+++ b/src/handlers/Firefox60.ts
@@ -411,7 +411,7 @@ export class Firefox60 extends HandlerInterface {
 		const offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/ReactNative.ts
+++ b/src/handlers/ReactNative.ts
@@ -342,6 +342,13 @@ export class ReactNative extends HandlerInterface {
 
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
+
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		let offerMediaObject;
 		const sendingRtpParameters = utils.clone<RtpParameters>(
 			this._sendingRtpParametersByKind![track.kind]

--- a/src/handlers/ReactNative.ts
+++ b/src/handlers/ReactNative.ts
@@ -343,7 +343,7 @@ export class ReactNative extends HandlerInterface {
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -498,7 +498,6 @@ export class ReactNativeUnifiedPlan extends HandlerInterface {
 			offerRtpParameters: sendingRtpParameters,
 			answerRtpParameters: sendingRemoteRtpParameters,
 			codecOptions,
-			extmapAllowMixed: true,
 		});
 
 		const answer = { type: 'answer', sdp: this._remoteSdp!.getSdp() };

--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -385,7 +385,7 @@ export class ReactNativeUnifiedPlan extends HandlerInterface {
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/ReactNativeUnifiedPlan.ts
+++ b/src/handlers/ReactNativeUnifiedPlan.ts
@@ -384,6 +384,13 @@ export class ReactNativeUnifiedPlan extends HandlerInterface {
 
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
+
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		let offerMediaObject;
 
 		if (!this._transportReady) {

--- a/src/handlers/Safari11.ts
+++ b/src/handlers/Safari11.ts
@@ -337,7 +337,7 @@ export class Safari11 extends HandlerInterface {
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/Safari11.ts
+++ b/src/handlers/Safari11.ts
@@ -336,6 +336,13 @@ export class Safari11 extends HandlerInterface {
 
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
+
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		let offerMediaObject;
 		const sendingRtpParameters = utils.clone<RtpParameters>(
 			this._sendingRtpParametersByKind![track.kind]

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -366,6 +366,13 @@ export class Safari12 extends HandlerInterface {
 
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
+
+		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// define extmapAllowMixed field.
+		if (localSdpObject.extmapAllowMixed) {
+			this._remoteSdp!.setSessionExtmapAllowMixed();
+		}
+
 		let offerMediaObject;
 
 		if (!this._transportReady) {

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -367,7 +367,7 @@ export class Safari12 extends HandlerInterface {
 		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp);
 
-		// @ts-expect-error --- sdpTransport.SessionDescription type doesn't
+		// @ts-expect-error --- sdpTransform.SessionDescription type doesn't
 		// define extmapAllowMixed field.
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp!.setSessionExtmapAllowMixed();

--- a/src/handlers/sdp/MediaSection.ts
+++ b/src/handlers/sdp/MediaSection.ts
@@ -131,7 +131,6 @@ export class AnswerMediaSection extends MediaSection {
 		offerRtpParameters,
 		answerRtpParameters,
 		codecOptions,
-		extmapAllowMixed = false,
 	}: {
 		iceParameters?: IceParameters;
 		iceCandidates?: IceCandidate[];
@@ -143,7 +142,6 @@ export class AnswerMediaSection extends MediaSection {
 		offerRtpParameters?: RtpParameters;
 		answerRtpParameters?: RtpParameters;
 		codecOptions?: ProducerCodecOptions;
-		extmapAllowMixed?: boolean;
 	}) {
 		super({ iceParameters, iceCandidates, dtlsParameters, planB });
 
@@ -324,11 +322,9 @@ export class AnswerMediaSection extends MediaSection {
 					});
 				}
 
-				// Allow both 1 byte and 2 bytes length header extensions.
-				if (
-					extmapAllowMixed &&
-					offerMediaObject.extmapAllowMixed === 'extmap-allow-mixed'
-				) {
+				// Allow both 1 byte and 2 bytes length header extensions since
+				// mediasoup can receive both at any time.
+				if (offerMediaObject.extmapAllowMixed === 'extmap-allow-mixed') {
 					this._mediaObject.extmapAllowMixed = 'extmap-allow-mixed';
 				}
 

--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -144,14 +144,12 @@ export class RemoteSdp {
 		offerRtpParameters,
 		answerRtpParameters,
 		codecOptions,
-		extmapAllowMixed = false,
 	}: {
 		offerMediaObject: any;
 		reuseMid?: string;
 		offerRtpParameters: RtpParameters;
 		answerRtpParameters: RtpParameters;
 		codecOptions?: ProducerCodecOptions;
-		extmapAllowMixed?: boolean;
 	}): void {
 		const mediaSection = new AnswerMediaSection({
 			iceParameters: this._iceParameters,
@@ -163,7 +161,6 @@ export class RemoteSdp {
 			offerRtpParameters,
 			answerRtpParameters,
 			codecOptions,
-			extmapAllowMixed,
 		});
 
 		// Unified-Plan with closed media section replacement.

--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -124,6 +124,15 @@ export class RemoteSdp {
 		}
 	}
 
+	/**
+	 * Set session level a=extmap-allow-mixed attibute.
+	 */
+	setSessionExtmapAllowMixed(): void {
+		logger.debug('setSessionExtmapAllowMixed()');
+
+		this._sdpObject.extmapAllowMixed = 'extmap-allow-mixed';
+	}
+
 	getNextMediaSectionIdx(): { idx: number; reuseMid?: string } {
 		// If a closed media section is found, return its index.
 		for (let idx = 0; idx < this._mediaSections.length; ++idx) {


### PR DESCRIPTION
## Details

- If the browser's generated SDP offer contains session level `a=extmap-allow-mixed` attribute, then add it also in the artificially generated SDP answer (also at session level).
- This effectively allows the browser to send both, 1 byte and 2 bytes, RTP header extensions within the same stream at any time.
- Note that this used to work at media level, but Chrome changed it to be at session level and we were not ready.