### PR TITLE
Allow receiving 1 and 2 bytes header extensions

### DIFF
--- a/src/handlers/sdp/MediaSection.ts
+++ b/src/handlers/sdp/MediaSection.ts
@@ -509,6 +509,10 @@ export class OfferMediaSection extends MediaSection {
 			this._mediaObject.port = plainRtpParameters.port;
 		}
 
+		// Allow both 1 byte and 2 bytes length header extensions since
+		// mediasoup can send both at any time.
+		this._mediaObject.extmapAllowMixed = 'extmap-allow-mixed';
+
 		switch (kind) {
 			case 'audio':
 			case 'video': {

--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -206,6 +206,8 @@ export class RemoteSdp {
 			mediaSection = this._mediaSections[idx] as OfferMediaSection;
 		}
 
+		this.setSessionExtmapAllowMixed();
+
 		// Unified-Plan or different media kind.
 		if (!mediaSection) {
 			mediaSection = new OfferMediaSection({

--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -206,6 +206,8 @@ export class RemoteSdp {
 			mediaSection = this._mediaSections[idx] as OfferMediaSection;
 		}
 
+		// Allow both 1 byte and 2 bytes length header extensions since
+		// mediasoup can send both at any time.
 		this.setSessionExtmapAllowMixed();
 
 		// Unified-Plan or different media kind.


### PR DESCRIPTION
Since mediasoup will send both types.

Enable at both session and media level.