### PR TITLE
Add vp9 to fakeParameters

### DIFF
--- a/src/test/fakeParameters.ts
+++ b/src/test/fakeParameters.ts
@@ -282,7 +282,7 @@ export function generateNativeRtpCapabilities(): mediasoupClient.types.RtpCapabi
 				parameters: {
 					apt: 98,
 				},
-			}
+			},
 		],
 		headerExtensions: [
 			{

--- a/src/test/fakeParameters.ts
+++ b/src/test/fakeParameters.ts
@@ -1,4 +1,4 @@
-import * as mediasoupClient from '../index';
+import * as mediasoupClient from '../';
 import * as utils from '../utils';
 
 function generateFakeUuid(): string {
@@ -72,6 +72,33 @@ export function generateRouterRtpCapabilities(): mediasoupClient.types.RtpCapabi
 				rtcpFeedback: [],
 				parameters: {
 					apt: 103,
+				},
+			},
+			{
+				mimeType: 'video/VP9',
+				kind: 'video',
+				preferredPayloadType: 105,
+				clockRate: 90000,
+				rtcpFeedback: [
+					{ type: 'nack' },
+					{ type: 'nack', parameter: 'pli' },
+					{ type: 'ccm', parameter: 'fir' },
+					{ type: 'goog-remb' },
+					{ type: 'transport-cc' },
+				],
+				parameters: {
+					'profile-id': 0,
+					'x-google-start-bitrate': 1500,
+				},
+			},
+			{
+				mimeType: 'video/rtx',
+				kind: 'video',
+				preferredPayloadType: 106,
+				clockRate: 90000,
+				rtcpFeedback: [],
+				parameters: {
+					apt: 105,
 				},
 			},
 		],
@@ -230,6 +257,32 @@ export function generateNativeRtpCapabilities(): mediasoupClient.types.RtpCapabi
 					apt: 96,
 				},
 			},
+			{
+				mimeType: 'video/VP9',
+				kind: 'video',
+				preferredPayloadType: 98,
+				clockRate: 90000,
+				rtcpFeedback: [
+					{ type: 'goog-remb' },
+					{ type: 'transport-cc' },
+					{ type: 'ccm', parameter: 'fir' },
+					{ type: 'nack' },
+					{ type: 'nack', parameter: 'pli' },
+				],
+				parameters: {
+					'profile-id': 0,
+				},
+			},
+			{
+				mimeType: 'video/rtx',
+				kind: 'video',
+				preferredPayloadType: 99,
+				clockRate: 90000,
+				rtcpFeedback: [],
+				parameters: {
+					apt: 98,
+				},
+			}
 		],
 		headerExtensions: [
 			{
@@ -264,18 +317,19 @@ export function generateNativeRtpCapabilities(): mediasoupClient.types.RtpCapabi
 			},
 			{
 				kind: 'video',
+				// @ts-ignore
 				uri: 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay',
 				preferredId: 6,
 			},
 			{
 				kind: 'video',
-				// @ts-expect-error --- ON purpose.
+				// @ts-ignore
 				uri: 'http://www.webrtc.org/experiments/rtp-hdrext/video-content-type',
 				preferredId: 7,
 			},
 			{
 				kind: 'video',
-				// @ts-expect-error --- ON purpose.
+				// @ts-ignore
 				uri: 'http://www.webrtc.org/experiments/rtp-hdrext/video-timing',
 				preferredId: 8,
 			},
@@ -382,7 +436,7 @@ export function generateConsumerRemoteParameters({
 	switch (codecMimeType) {
 		case 'audio/opus': {
 			return {
-				id: id ?? generateFakeUuid(),
+				id: id || generateFakeUuid(),
 				producerId: generateFakeUuid(),
 				kind: 'audio',
 				rtpParameters: utils.deepFreeze<mediasoupClient.types.RtpParameters>({
@@ -429,7 +483,7 @@ export function generateConsumerRemoteParameters({
 
 		case 'audio/ISAC': {
 			return {
-				id: id ?? generateFakeUuid(),
+				id: id || generateFakeUuid(),
 				producerId: generateFakeUuid(),
 				kind: 'audio',
 				rtpParameters: utils.deepFreeze<mediasoupClient.types.RtpParameters>({
@@ -469,7 +523,7 @@ export function generateConsumerRemoteParameters({
 
 		case 'video/VP8': {
 			return {
-				id: id ?? generateFakeUuid(),
+				id: id || generateFakeUuid(),
 				producerId: generateFakeUuid(),
 				kind: 'video',
 				rtpParameters: utils.deepFreeze<mediasoupClient.types.RtpParameters>({
@@ -540,7 +594,7 @@ export function generateConsumerRemoteParameters({
 
 		case 'video/H264': {
 			return {
-				id: id ?? generateFakeUuid(),
+				id: id || generateFakeUuid(),
 				producerId: generateFakeUuid(),
 				kind: 'video',
 				rtpParameters: utils.deepFreeze<mediasoupClient.types.RtpParameters>({
@@ -627,7 +681,7 @@ export function generateDataConsumerRemoteParameters({
 	id,
 }: { id?: string } = {}): mediasoupClient.types.DataConsumerOptions {
 	return {
-		id: id ?? generateFakeUuid(),
+		id: id || generateFakeUuid(),
 		dataProducerId: generateFakeUuid(),
 		sctpStreamParameters:
 			utils.deepFreeze<mediasoupClient.types.SctpStreamParameters>({

--- a/src/test/fakeParameters.ts
+++ b/src/test/fakeParameters.ts
@@ -1,4 +1,4 @@
-import * as mediasoupClient from '../';
+import * as mediasoupClient from '../index';
 import * as utils from '../utils';
 
 function generateFakeUuid(): string {
@@ -317,19 +317,18 @@ export function generateNativeRtpCapabilities(): mediasoupClient.types.RtpCapabi
 			},
 			{
 				kind: 'video',
-				// @ts-ignore
 				uri: 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay',
 				preferredId: 6,
 			},
 			{
 				kind: 'video',
-				// @ts-ignore
+				// @ts-expect-error --- ON purpose.
 				uri: 'http://www.webrtc.org/experiments/rtp-hdrext/video-content-type',
 				preferredId: 7,
 			},
 			{
 				kind: 'video',
-				// @ts-ignore
+				// @ts-expect-error --- ON purpose.
 				uri: 'http://www.webrtc.org/experiments/rtp-hdrext/video-timing',
 				preferredId: 8,
 			},
@@ -436,7 +435,7 @@ export function generateConsumerRemoteParameters({
 	switch (codecMimeType) {
 		case 'audio/opus': {
 			return {
-				id: id || generateFakeUuid(),
+				id: id ?? generateFakeUuid(),
 				producerId: generateFakeUuid(),
 				kind: 'audio',
 				rtpParameters: utils.deepFreeze<mediasoupClient.types.RtpParameters>({
@@ -483,7 +482,7 @@ export function generateConsumerRemoteParameters({
 
 		case 'audio/ISAC': {
 			return {
-				id: id || generateFakeUuid(),
+				id: id ?? generateFakeUuid(),
 				producerId: generateFakeUuid(),
 				kind: 'audio',
 				rtpParameters: utils.deepFreeze<mediasoupClient.types.RtpParameters>({
@@ -523,7 +522,7 @@ export function generateConsumerRemoteParameters({
 
 		case 'video/VP8': {
 			return {
-				id: id || generateFakeUuid(),
+				id: id ?? generateFakeUuid(),
 				producerId: generateFakeUuid(),
 				kind: 'video',
 				rtpParameters: utils.deepFreeze<mediasoupClient.types.RtpParameters>({
@@ -594,7 +593,7 @@ export function generateConsumerRemoteParameters({
 
 		case 'video/H264': {
 			return {
-				id: id || generateFakeUuid(),
+				id: id ?? generateFakeUuid(),
 				producerId: generateFakeUuid(),
 				kind: 'video',
 				rtpParameters: utils.deepFreeze<mediasoupClient.types.RtpParameters>({
@@ -681,7 +680,7 @@ export function generateDataConsumerRemoteParameters({
 	id,
 }: { id?: string } = {}): mediasoupClient.types.DataConsumerOptions {
 	return {
-		id: id || generateFakeUuid(),
+		id: id ?? generateFakeUuid(),
 		dataProducerId: generateFakeUuid(),
 		sctpStreamParameters:
 			utils.deepFreeze<mediasoupClient.types.SctpStreamParameters>({

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -506,7 +506,7 @@ test('transport.produce() succeeds', async () => {
 	expect(videoProducer.track).toBe(videoTrack);
 	expect(typeof videoProducer.rtpParameters).toBe('object');
 	expect(typeof videoProducer.rtpParameters.mid).toBe('string');
-	expect(videoProducer.rtpParameters.codecs.length).toBe(2);
+	expect(videoProducer.rtpParameters.codecs.length).toBe(4);
 
 	codecs = videoProducer.rtpParameters.codecs;
 
@@ -533,6 +533,32 @@ test('transport.produce() succeeds', async () => {
 		rtcpFeedback: [],
 		parameters: {
 			apt: 96,
+		},
+	});
+
+	expect(codecs[2]).toEqual({
+		mimeType: 'video/VP9',
+		payloadType: 98,
+		clockRate: 90000,
+		rtcpFeedback: [
+			{ type: 'goog-remb', parameter: '' },
+			{ type: 'transport-cc', parameter: '' },
+			{ type: 'ccm', parameter: 'fir' },
+			{ type: 'nack', parameter: '' },
+			{ type: 'nack', parameter: 'pli' },
+		],
+		parameters: {
+			'profile-id': 0,
+		},
+	});
+
+	expect(codecs[3]).toEqual({
+		mimeType: 'video/rtx',
+		payloadType: 99,
+		clockRate: 90000,
+		rtcpFeedback: [],
+		parameters: {
+			apt: 98,
 		},
 	});
 


### PR DESCRIPTION
Adding VP9 codec to `generateNativeRtpCapabilities()` and `generateRouterRtpCapabilities()`.

NOTE: I didn't add VP9 in `generateConsumerRemoteParameters()` but if it's required I can add it there too.