### PR TITLE
Option to prefer local codecs order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@types/debug": "^4.1.12",
 				"@types/npm-events-package": "npm:@types/events@^3.0.3",
 				"awaitqueue": "^3.2.0",
-				"debug": "^4.4.0",
+				"debug": "^4.4.1",
 				"fake-mediastreamtrack": "^2.1.0",
 				"h264-profile-level-id": "^2.2.0",
 				"npm-events-package": "npm:events@^3.3.0",
@@ -23,22 +23,22 @@
 			"devDependencies": {
 				"@eslint/js": "^9.26.0",
 				"@types/jest": "^29.5.14",
-				"@types/node": "^22.15.3",
+				"@types/node": "^22.15.18",
 				"@types/sdp-transform": "^2.4.9",
 				"@types/ua-parser-js": "^0.7.39",
-				"@typescript-eslint/eslint-plugin": "^8.31.1",
-				"@typescript-eslint/parser": "^8.31.1",
+				"@typescript-eslint/eslint-plugin": "^8.32.1",
+				"@typescript-eslint/parser": "^8.32.1",
 				"eslint": "^9.26.0",
-				"eslint-config-prettier": "^10.1.2",
+				"eslint-config-prettier": "^10.1.5",
 				"eslint-plugin-jest": "^28.11.0",
 				"eslint-plugin-prettier": "^5.4.0",
-				"globals": "^16.0.0",
+				"globals": "^16.1.0",
 				"jest": "^29.7.0",
 				"open-cli": "^8.0.0",
 				"prettier": "^3.5.3",
 				"ts-jest": "^29.3.2",
 				"typescript": "^5.8.3",
-				"typescript-eslint": "^8.31.1"
+				"typescript-eslint": "^8.32.1"
 			},
 			"engines": {
 				"node": ">=18"
@@ -553,15 +553,19 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.3"
 			},
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			},
 			"peerDependencies": {
 				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
@@ -1434,9 +1438,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.15.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-			"integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+			"version": "22.15.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
+			"integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -1489,21 +1493,21 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz",
-			"integrity": "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
+			"integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.31.1",
-				"@typescript-eslint/type-utils": "8.31.1",
-				"@typescript-eslint/utils": "8.31.1",
-				"@typescript-eslint/visitor-keys": "8.31.1",
+				"@typescript-eslint/scope-manager": "8.32.1",
+				"@typescript-eslint/type-utils": "8.32.1",
+				"@typescript-eslint/utils": "8.32.1",
+				"@typescript-eslint/visitor-keys": "8.32.1",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.3.1",
+				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.0.1"
+				"ts-api-utils": "^2.1.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1518,17 +1522,27 @@
 				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+			"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.1.tgz",
-			"integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
+			"integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.31.1",
-				"@typescript-eslint/types": "8.31.1",
-				"@typescript-eslint/typescript-estree": "8.31.1",
-				"@typescript-eslint/visitor-keys": "8.31.1",
+				"@typescript-eslint/scope-manager": "8.32.1",
+				"@typescript-eslint/types": "8.32.1",
+				"@typescript-eslint/typescript-estree": "8.32.1",
+				"@typescript-eslint/visitor-keys": "8.32.1",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -1544,14 +1558,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.1.tgz",
-			"integrity": "sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
+			"integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.31.1",
-				"@typescript-eslint/visitor-keys": "8.31.1"
+				"@typescript-eslint/types": "8.32.1",
+				"@typescript-eslint/visitor-keys": "8.32.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1562,16 +1576,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.1.tgz",
-			"integrity": "sha512-fNaT/m9n0+dpSp8G/iOQ05GoHYXbxw81x+yvr7TArTuZuCA6VVKbqWYVZrV5dVagpDTtj/O8k5HBEE/p/HM5LA==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
+			"integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.31.1",
-				"@typescript-eslint/utils": "8.31.1",
+				"@typescript-eslint/typescript-estree": "8.32.1",
+				"@typescript-eslint/utils": "8.32.1",
 				"debug": "^4.3.4",
-				"ts-api-utils": "^2.0.1"
+				"ts-api-utils": "^2.1.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1586,9 +1600,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.1.tgz",
-			"integrity": "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
+			"integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1600,20 +1614,20 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.1.tgz",
-			"integrity": "sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
+			"integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.31.1",
-				"@typescript-eslint/visitor-keys": "8.31.1",
+				"@typescript-eslint/types": "8.32.1",
+				"@typescript-eslint/visitor-keys": "8.32.1",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
 				"minimatch": "^9.0.4",
 				"semver": "^7.6.0",
-				"ts-api-utils": "^2.0.1"
+				"ts-api-utils": "^2.1.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1653,16 +1667,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.1.tgz",
-			"integrity": "sha512-2DSI4SNfF5T4oRveQ4nUrSjUqjMND0nLq9rEkz0gfGr3tg0S5KB6DhwR+WZPCjzkZl3cH+4x2ce3EsL50FubjQ==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
+			"integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.31.1",
-				"@typescript-eslint/types": "8.31.1",
-				"@typescript-eslint/typescript-estree": "8.31.1"
+				"@eslint-community/eslint-utils": "^4.7.0",
+				"@typescript-eslint/scope-manager": "8.32.1",
+				"@typescript-eslint/types": "8.32.1",
+				"@typescript-eslint/typescript-estree": "8.32.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1677,13 +1691,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.1.tgz",
-			"integrity": "sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
+			"integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.31.1",
+				"@typescript-eslint/types": "8.32.1",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
@@ -2443,9 +2457,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -2813,13 +2827,16 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
-			"integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
+			"version": "10.1.5",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+			"integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-config-prettier"
 			},
 			"peerDependencies": {
 				"eslint": ">=7.0.0"
@@ -3559,9 +3576,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
-			"integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
+			"integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6210,9 +6227,9 @@
 			"license": "MIT"
 		},
 		"node_modules/ts-api-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-			"integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6411,15 +6428,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.1.tgz",
-			"integrity": "sha512-j6DsEotD/fH39qKzXTQRwYYWlt7D+0HmfpOK+DVhwJOFLcdmn92hq3mBb7HlKJHbjjI/gTOqEcc9d6JfpFf/VA==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
+			"integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.31.1",
-				"@typescript-eslint/parser": "8.31.1",
-				"@typescript-eslint/utils": "8.31.1"
+				"@typescript-eslint/eslint-plugin": "8.32.1",
+				"@typescript-eslint/parser": "8.32.1",
+				"@typescript-eslint/utils": "8.32.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7125,12 +7142,12 @@
 			}
 		},
 		"@eslint-community/eslint-utils": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.3"
 			}
 		},
 		"@eslint-community/regexpp": {
@@ -7792,9 +7809,9 @@
 			"version": "0.7.31"
 		},
 		"@types/node": {
-			"version": "22.15.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.3.tgz",
-			"integrity": "sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==",
+			"version": "22.15.18",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.18.tgz",
+			"integrity": "sha512-v1DKRfUdyW+jJhZNEI1PYy29S2YRxMV5AOO/x/SjKmW0acCIOqmbj6Haf9eHAhsPmrhlHSxEhv/1WszcLWV4cg==",
 			"requires": {
 				"undici-types": "~6.21.0"
 			}
@@ -7841,77 +7858,85 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz",
-			"integrity": "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.32.1.tgz",
+			"integrity": "sha512-6u6Plg9nP/J1GRpe/vcjjabo6Uc5YQPAMxsgQyGC/I0RuukiG1wIe3+Vtg3IrSCVJDmqK3j8adrtzXSENRtFgg==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.31.1",
-				"@typescript-eslint/type-utils": "8.31.1",
-				"@typescript-eslint/utils": "8.31.1",
-				"@typescript-eslint/visitor-keys": "8.31.1",
+				"@typescript-eslint/scope-manager": "8.32.1",
+				"@typescript-eslint/type-utils": "8.32.1",
+				"@typescript-eslint/utils": "8.32.1",
+				"@typescript-eslint/visitor-keys": "8.32.1",
 				"graphemer": "^1.4.0",
-				"ignore": "^5.3.1",
+				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.0.1"
+				"ts-api-utils": "^2.1.0"
+			},
+			"dependencies": {
+				"ignore": {
+					"version": "7.0.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+					"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+					"dev": true
+				}
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.1.tgz",
-			"integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.32.1.tgz",
+			"integrity": "sha512-LKMrmwCPoLhM45Z00O1ulb6jwyVr2kr3XJp+G+tSEZcbauNnScewcQwtJqXDhXeYPDEjZ8C1SjXm015CirEmGg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "8.31.1",
-				"@typescript-eslint/types": "8.31.1",
-				"@typescript-eslint/typescript-estree": "8.31.1",
-				"@typescript-eslint/visitor-keys": "8.31.1",
+				"@typescript-eslint/scope-manager": "8.32.1",
+				"@typescript-eslint/types": "8.32.1",
+				"@typescript-eslint/typescript-estree": "8.32.1",
+				"@typescript-eslint/visitor-keys": "8.32.1",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.1.tgz",
-			"integrity": "sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
+			"integrity": "sha512-7IsIaIDeZn7kffk7qXC3o6Z4UblZJKV3UBpkvRNpr5NSyLji7tvTcvmnMNYuYLyh26mN8W723xpo3i4MlD33vA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.31.1",
-				"@typescript-eslint/visitor-keys": "8.31.1"
+				"@typescript-eslint/types": "8.32.1",
+				"@typescript-eslint/visitor-keys": "8.32.1"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.1.tgz",
-			"integrity": "sha512-fNaT/m9n0+dpSp8G/iOQ05GoHYXbxw81x+yvr7TArTuZuCA6VVKbqWYVZrV5dVagpDTtj/O8k5HBEE/p/HM5LA==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.32.1.tgz",
+			"integrity": "sha512-mv9YpQGA8iIsl5KyUPi+FGLm7+bA4fgXaeRcFKRDRwDMu4iwrSHeDPipwueNXhdIIZltwCJv+NkxftECbIZWfA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "8.31.1",
-				"@typescript-eslint/utils": "8.31.1",
+				"@typescript-eslint/typescript-estree": "8.32.1",
+				"@typescript-eslint/utils": "8.32.1",
 				"debug": "^4.3.4",
-				"ts-api-utils": "^2.0.1"
+				"ts-api-utils": "^2.1.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.1.tgz",
-			"integrity": "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.32.1.tgz",
+			"integrity": "sha512-YmybwXUJcgGqgAp6bEsgpPXEg6dcCyPyCSr0CAAueacR/CCBi25G3V8gGQ2kRzQRBNol7VQknxMs9HvVa9Rvfg==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.1.tgz",
-			"integrity": "sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.32.1.tgz",
+			"integrity": "sha512-Y3AP9EIfYwBb4kWGb+simvPaqQoT5oJuzzj9m0i6FCY6SPvlomY2Ei4UEMm7+FXtlNJbor80ximyslzaQF6xhg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.31.1",
-				"@typescript-eslint/visitor-keys": "8.31.1",
+				"@typescript-eslint/types": "8.32.1",
+				"@typescript-eslint/visitor-keys": "8.32.1",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
 				"minimatch": "^9.0.4",
 				"semver": "^7.6.0",
-				"ts-api-utils": "^2.0.1"
+				"ts-api-utils": "^2.1.0"
 			},
 			"dependencies": {
 				"brace-expansion": {
@@ -7935,24 +7960,24 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.1.tgz",
-			"integrity": "sha512-2DSI4SNfF5T4oRveQ4nUrSjUqjMND0nLq9rEkz0gfGr3tg0S5KB6DhwR+WZPCjzkZl3cH+4x2ce3EsL50FubjQ==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.32.1.tgz",
+			"integrity": "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA==",
 			"dev": true,
 			"requires": {
-				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.31.1",
-				"@typescript-eslint/types": "8.31.1",
-				"@typescript-eslint/typescript-estree": "8.31.1"
+				"@eslint-community/eslint-utils": "^4.7.0",
+				"@typescript-eslint/scope-manager": "8.32.1",
+				"@typescript-eslint/types": "8.32.1",
+				"@typescript-eslint/typescript-estree": "8.32.1"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.1.tgz",
-			"integrity": "sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.32.1.tgz",
+			"integrity": "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.31.1",
+				"@typescript-eslint/types": "8.32.1",
 				"eslint-visitor-keys": "^4.2.0"
 			},
 			"dependencies": {
@@ -8460,9 +8485,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
 			"requires": {
 				"ms": "^2.1.3"
 			}
@@ -8697,9 +8722,9 @@
 			}
 		},
 		"eslint-config-prettier": {
-			"version": "10.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
-			"integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
+			"version": "10.1.5",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+			"integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
 			"dev": true,
 			"requires": {}
 		},
@@ -9176,9 +9201,9 @@
 			}
 		},
 		"globals": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
-			"integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-16.1.0.tgz",
+			"integrity": "sha512-aibexHNbb/jiUSObBgpHLj+sIuUmJnYcgXBlrfsiDZ9rt4aF2TFRbyLgZ2iFQuVZ1K5Mx3FVkbKRSgKrbK3K2g==",
 			"dev": true
 		},
 		"gopd": {
@@ -10919,9 +10944,9 @@
 			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
 		},
 		"ts-api-utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.0.1.tgz",
-			"integrity": "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
 			"dev": true,
 			"requires": {}
 		},
@@ -11026,14 +11051,14 @@
 			"dev": true
 		},
 		"typescript-eslint": {
-			"version": "8.31.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.1.tgz",
-			"integrity": "sha512-j6DsEotD/fH39qKzXTQRwYYWlt7D+0HmfpOK+DVhwJOFLcdmn92hq3mBb7HlKJHbjjI/gTOqEcc9d6JfpFf/VA==",
+			"version": "8.32.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.32.1.tgz",
+			"integrity": "sha512-D7el+eaDHAmXvrZBy1zpzSNIRqnCOrkwTgZxTu3MUqRWk8k0q9m9Ho4+vPf7iHtgUfrK/o8IZaEApsxPlHTFCg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/eslint-plugin": "8.31.1",
-				"@typescript-eslint/parser": "8.31.1",
-				"@typescript-eslint/utils": "8.31.1"
+				"@typescript-eslint/eslint-plugin": "8.32.1",
+				"@typescript-eslint/parser": "8.32.1",
+				"@typescript-eslint/utils": "8.32.1"
 			}
 		},
 		"ua-is-frozen": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		"@types/debug": "^4.1.12",
 		"@types/npm-events-package": "npm:@types/events@^3.0.3",
 		"awaitqueue": "^3.2.0",
-		"debug": "^4.4.0",
+		"debug": "^4.4.1",
 		"fake-mediastreamtrack": "^2.1.0",
 		"h264-profile-level-id": "^2.2.0",
 		"npm-events-package": "npm:events@^3.3.0",
@@ -81,21 +81,21 @@
 	"devDependencies": {
 		"@eslint/js": "^9.26.0",
 		"@types/jest": "^29.5.14",
-		"@types/node": "^22.15.3",
+		"@types/node": "^22.15.18",
 		"@types/sdp-transform": "^2.4.9",
 		"@types/ua-parser-js": "^0.7.39",
-		"@typescript-eslint/eslint-plugin": "^8.31.1",
-		"@typescript-eslint/parser": "^8.31.1",
+		"@typescript-eslint/eslint-plugin": "^8.32.1",
+		"@typescript-eslint/parser": "^8.32.1",
 		"eslint": "^9.26.0",
-		"eslint-config-prettier": "^10.1.2",
+		"eslint-config-prettier": "^10.1.5",
 		"eslint-plugin-jest": "^28.11.0",
 		"eslint-plugin-prettier": "^5.4.0",
-		"globals": "^16.0.0",
+		"globals": "^16.1.0",
 		"jest": "^29.7.0",
 		"open-cli": "^8.0.0",
 		"prettier": "^3.5.3",
 		"ts-jest": "^29.3.2",
 		"typescript": "^5.8.3",
-		"typescript-eslint": "^8.31.1"
+		"typescript-eslint": "^8.32.1"
 	}
 }

--- a/src/Device.ts
+++ b/src/Device.ts
@@ -322,8 +322,10 @@ export class Device {
 	 */
 	async load({
 		routerRtpCapabilities,
+		preferLocalCodecsOrder = false,
 	}: {
 		routerRtpCapabilities: RtpCapabilities;
+		preferLocalCodecsOrder?: boolean;
 	}): Promise<void> {
 		logger.debug('load() [routerRtpCapabilities:%o]', routerRtpCapabilities);
 
@@ -363,7 +365,8 @@ export class Device {
 			// Get extended RTP capabilities.
 			this._extendedRtpCapabilities = ortc.getExtendedRtpCapabilities(
 				clonedNativeRtpCapabilities,
-				clonedRouterRtpCapabilities
+				clonedRouterRtpCapabilities,
+				preferLocalCodecsOrder
 			);
 
 			logger.debug(

--- a/src/ortc.ts
+++ b/src/ortc.ts
@@ -202,46 +202,85 @@ export function validateSctpCapabilities(caps: SctpCapabilities): void {
 
 /**
  * Generate extended RTP capabilities for sending and receiving.
+ *
+ * Resulting codecs keep order preferrred by local or remote capabilities
+ * depending on `preferLocalCodecsOrder`.
  */
 export function getExtendedRtpCapabilities(
 	localCaps: RtpCapabilities,
-	remoteCaps: RtpCapabilities
+	remoteCaps: RtpCapabilities,
+	preferLocalCodecsOrder: boolean
 ): any {
 	const extendedRtpCapabilities: any = {
 		codecs: [],
 		headerExtensions: [],
 	};
 
-	// Match media codecs and keep the order preferred by remoteCaps.
-	for (const remoteCodec of remoteCaps.codecs ?? []) {
-		if (isRtxCodec(remoteCodec)) {
-			continue;
+	// Match media codecs and keep the order preferred by local capabilities.
+	if (preferLocalCodecsOrder) {
+		for (const localCodec of localCaps.codecs ?? []) {
+			if (isRtxCodec(localCodec)) {
+				continue;
+			}
+
+			const matchingRemoteCodec = (remoteCaps.codecs ?? []).find(
+				(remoteCodec: RtpCodecCapability) =>
+					matchCodecs(remoteCodec, localCodec, { strict: true, modify: true })
+			);
+
+			if (!matchingRemoteCodec) {
+				continue;
+			}
+
+			const extendedCodec: any = {
+				mimeType: localCodec.mimeType,
+				kind: localCodec.kind,
+				clockRate: localCodec.clockRate,
+				channels: localCodec.channels,
+				localPayloadType: localCodec.preferredPayloadType,
+				localRtxPayloadType: undefined,
+				remotePayloadType: matchingRemoteCodec.preferredPayloadType,
+				remoteRtxPayloadType: undefined,
+				localParameters: localCodec.parameters,
+				remoteParameters: matchingRemoteCodec.parameters,
+				rtcpFeedback: reduceRtcpFeedback(localCodec, matchingRemoteCodec),
+			};
+
+			extendedRtpCapabilities.codecs.push(extendedCodec);
 		}
+	}
+	// Match media codecs and keep the order preferred by remote capabilities.
+	else {
+		for (const remoteCodec of remoteCaps.codecs ?? []) {
+			if (isRtxCodec(remoteCodec)) {
+				continue;
+			}
 
-		const matchingLocalCodec = (localCaps.codecs ?? []).find(
-			(localCodec: RtpCodecCapability) =>
-				matchCodecs(localCodec, remoteCodec, { strict: true, modify: true })
-		);
+			const matchingLocalCodec = (localCaps.codecs ?? []).find(
+				(localCodec: RtpCodecCapability) =>
+					matchCodecs(localCodec, remoteCodec, { strict: true, modify: true })
+			);
 
-		if (!matchingLocalCodec) {
-			continue;
+			if (!matchingLocalCodec) {
+				continue;
+			}
+
+			const extendedCodec: any = {
+				mimeType: matchingLocalCodec.mimeType,
+				kind: matchingLocalCodec.kind,
+				clockRate: matchingLocalCodec.clockRate,
+				channels: matchingLocalCodec.channels,
+				localPayloadType: matchingLocalCodec.preferredPayloadType,
+				localRtxPayloadType: undefined,
+				remotePayloadType: remoteCodec.preferredPayloadType,
+				remoteRtxPayloadType: undefined,
+				localParameters: matchingLocalCodec.parameters,
+				remoteParameters: remoteCodec.parameters,
+				rtcpFeedback: reduceRtcpFeedback(matchingLocalCodec, remoteCodec),
+			};
+
+			extendedRtpCapabilities.codecs.push(extendedCodec);
 		}
-
-		const extendedCodec: any = {
-			mimeType: matchingLocalCodec.mimeType,
-			kind: matchingLocalCodec.kind,
-			clockRate: matchingLocalCodec.clockRate,
-			channels: matchingLocalCodec.channels,
-			localPayloadType: matchingLocalCodec.preferredPayloadType,
-			localRtxPayloadType: undefined,
-			remotePayloadType: remoteCodec.preferredPayloadType,
-			remoteRtxPayloadType: undefined,
-			localParameters: matchingLocalCodec.parameters,
-			remoteParameters: remoteCodec.parameters,
-			rtcpFeedback: reduceRtcpFeedback(matchingLocalCodec, remoteCodec),
-		};
-
-		extendedRtpCapabilities.codecs.push(extendedCodec);
 	}
 
 	// Match RTX codecs.


### PR DESCRIPTION
## Details

- Based on this old topic in the forum: https://mediasoup.discourse.group/t/prefer-client-side-codecs-order/2167/9
- Add a new boolean option in `device.load()` method: `preferLocalCodecsOrder` (which is `false` by default).
- If set to `true`, then when producing video (without specifying a codec) mediasoup-client will select the first compatible video codec in browser's preferred order rather than honouring the order of codecs provided to mediasoup server`s `Router`.
- Also update NPM dev deps.