### PR TITLE
Fix memory leaks due to event listeners that keep objects alive

### DIFF
--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -184,7 +184,7 @@ export class Consumer<
 	/**
 	 * Closes the Consumer.
 	 */
-	close(): void {
+	override close(): void {
 		if (this._closed) {
 			return;
 		}
@@ -199,6 +199,10 @@ export class Consumer<
 
 		// Emit observer event.
 		this._observer.safeEmit('close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
+		this._observer.close();
 	}
 
 	/**

--- a/src/DataConsumer.ts
+++ b/src/DataConsumer.ts
@@ -162,7 +162,7 @@ export class DataConsumer<
 	/**
 	 * Closes the DataConsumer.
 	 */
-	close(): void {
+	override close(): void {
 		if (this._closed) {
 			return;
 		}
@@ -177,6 +177,10 @@ export class DataConsumer<
 
 		// Emit observer event.
 		this._observer.safeEmit('close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
+		this._observer.close();
 	}
 
 	/**

--- a/src/DataProducer.ts
+++ b/src/DataProducer.ts
@@ -157,7 +157,7 @@ export class DataProducer<
 	/**
 	 * Closes the DataProducer.
 	 */
-	close(): void {
+	override close(): void {
 		if (this._closed) {
 			return;
 		}
@@ -172,6 +172,10 @@ export class DataProducer<
 
 		// Emit observer event.
 		this._observer.safeEmit('close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
+		this._observer.close();
 	}
 
 	/**

--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -237,7 +237,7 @@ export class Producer<
 	/**
 	 * Closes the Producer.
 	 */
-	close(): void {
+	override close(): void {
 		if (this._closed) {
 			return;
 		}
@@ -252,6 +252,10 @@ export class Producer<
 
 		// Emit observer event.
 		this._observer.safeEmit('close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
+		this._observer.close();
 	}
 
 	/**

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -376,7 +376,7 @@ export class Transport<
 	/**
 	 * Close the Transport.
 	 */
-	close(): void {
+	override close(): void {
 		if (this._closed) {
 			return;
 		}
@@ -421,6 +421,10 @@ export class Transport<
 
 		// Emit observer event.
 		this._observer.safeEmit('close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
+		this._observer.close();
 	}
 
 	/**

--- a/src/enhancedEvents.ts
+++ b/src/enhancedEvents.ts
@@ -15,6 +15,13 @@ export class EnhancedEventEmitter<
 		this.setMaxListeners(Infinity);
 	}
 
+	/**
+	 * Empties all stored event listeners.
+	 */
+	close(): void {
+		super.removeAllListeners();
+	}
+
 	override emit<K extends keyof E & string>(
 		eventName: K,
 		...args: E[K]

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -1,5 +1,6 @@
 import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
+import { EnhancedEventEmitter } from '../enhancedEvents';
 import { Logger } from '../Logger';
 import * as utils from '../utils';
 import * as ortc from '../ortc';
@@ -15,18 +16,19 @@ import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
 import * as ortcUtils from './ortc/utils';
-import {
-	type HandlerFactory,
+import type {
+	HandlerFactory,
 	HandlerInterface,
-	type HandlerOptions,
-	type HandlerSendOptions,
-	type HandlerSendResult,
-	type HandlerReceiveOptions,
-	type HandlerReceiveResult,
-	type HandlerSendDataChannelOptions,
-	type HandlerSendDataChannelResult,
-	type HandlerReceiveDataChannelOptions,
-	type HandlerReceiveDataChannelResult,
+	HandlerEvents,
+	HandlerOptions,
+	HandlerSendOptions,
+	HandlerSendResult,
+	HandlerReceiveOptions,
+	HandlerReceiveResult,
+	HandlerSendDataChannelOptions,
+	HandlerSendDataChannelResult,
+	HandlerReceiveDataChannelOptions,
+	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
 import { RemoteSdp } from './sdp/RemoteSdp';
 
@@ -35,7 +37,10 @@ const logger = new Logger('Chrome111');
 const NAME = 'Chrome111';
 const SCTP_NUM_STREAMS = { OS: 1024, MIS: 1024 };
 
-export class Chrome111 extends HandlerInterface {
+export class Chrome111
+	extends EnhancedEventEmitter<HandlerEvents>
+	implements HandlerInterface
+{
 	// Closed flag.
 	private _closed = false;
 	// Handler direction.
@@ -76,7 +81,7 @@ export class Chrome111 extends HandlerInterface {
 			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
-				const pc = new RTCPeerConnection({
+				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
 					iceTransportPolicy: 'all',
 					bundlePolicy: 'max-bundle',
@@ -97,6 +102,8 @@ export class Chrome111 extends HandlerInterface {
 						pc.close();
 					} catch (error) {}
 
+					pc = undefined;
+
 					const sdpObject = sdpTransform.parse(offer.sdp!);
 					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
 						sdpObject,
@@ -108,8 +115,10 @@ export class Chrome111 extends HandlerInterface {
 					return nativeRtpCapabilities;
 				} catch (error) {
 					try {
-						pc.close();
+						pc?.close();
 					} catch (error2) {}
+
+					pc = undefined;
 
 					throw error;
 				}
@@ -177,60 +186,27 @@ export class Chrome111 extends HandlerInterface {
 			...additionalSettings,
 		});
 
-		this._pc.addEventListener('icegatheringstatechange', () => {
-			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
-		});
-
 		this._pc.addEventListener(
-			'icecandidateerror',
-			(event: RTCPeerConnectionIceErrorEvent) => {
-				this.emit('@icecandidateerror', event);
-			}
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
 		);
 
+		this._pc.addEventListener('icecandidateerror', this.onIceCandidateError);
+
 		if (this._pc.connectionState) {
-			this._pc.addEventListener('connectionstatechange', () => {
-				this.emit('@connectionstatechange', this._pc.connectionState);
-			});
+			this._pc.addEventListener(
+				'connectionstatechange',
+				this.onConnectionStateChange
+			);
 		} else {
 			logger.warn(
 				'run() | pc.connectionState not supported, using pc.iceConnectionState'
 			);
 
-			this._pc.addEventListener('iceconnectionstatechange', () => {
-				switch (this._pc.iceConnectionState) {
-					case 'checking': {
-						this.emit('@connectionstatechange', 'connecting');
-
-						break;
-					}
-
-					case 'connected':
-					case 'completed': {
-						this.emit('@connectionstatechange', 'connected');
-
-						break;
-					}
-
-					case 'failed': {
-						this.emit('@connectionstatechange', 'failed');
-
-						break;
-					}
-
-					case 'disconnected': {
-						this.emit('@connectionstatechange', 'disconnected');
-
-						break;
-					}
-
-					case 'closed': {
-						this.emit('@connectionstatechange', 'closed');
-
-						break;
-					}
-				}
-			});
+			this._pc.addEventListener(
+				'iceconnectionstatechange',
+				this.onIceConnectionStateChange
+			);
 		}
 	}
 
@@ -238,7 +214,7 @@ export class Chrome111 extends HandlerInterface {
 		return NAME;
 	}
 
-	close(): void {
+	override close(): void {
 		logger.debug('close()');
 
 		if (this._closed) {
@@ -248,13 +224,31 @@ export class Chrome111 extends HandlerInterface {
 		this._closed = true;
 
 		// Close RTCPeerConnection.
-		if (this._pc) {
-			try {
-				this._pc.close();
-			} catch (error) {}
-		}
+		try {
+			this._pc.close();
+		} catch (error) {}
+
+		this._pc.removeEventListener(
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
+		);
+
+		this._pc.removeEventListener('icecandidateerror', this.onIceCandidateError);
+
+		this._pc.removeEventListener(
+			'connectionstatechange',
+			this.onConnectionStateChange
+		);
+
+		this._pc.removeEventListener(
+			'iceconnectionstatechange',
+			this.onIceConnectionStateChange
+		);
 
 		this.emit('@close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
 	}
 
 	async updateIceServers(iceServers: RTCIceServer[]): Promise<void> {
@@ -1192,6 +1186,55 @@ export class Chrome111 extends HandlerInterface {
 
 		this._transportReady = true;
 	}
+
+	private onIceGatheringStateChange = (): void => {
+		this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+	};
+
+	private onIceCandidateError = (
+		event: RTCPeerConnectionIceErrorEvent
+	): void => {
+		this.emit('@icecandidateerror', event);
+	};
+
+	private onConnectionStateChange = (): void => {
+		this.emit('@connectionstatechange', this._pc.connectionState);
+	};
+
+	private onIceConnectionStateChange = (): void => {
+		switch (this._pc.iceConnectionState) {
+			case 'checking': {
+				this.emit('@connectionstatechange', 'connecting');
+
+				break;
+			}
+
+			case 'connected':
+			case 'completed': {
+				this.emit('@connectionstatechange', 'connected');
+
+				break;
+			}
+
+			case 'failed': {
+				this.emit('@connectionstatechange', 'failed');
+
+				break;
+			}
+
+			case 'disconnected': {
+				this.emit('@connectionstatechange', 'disconnected');
+
+				break;
+			}
+
+			case 'closed': {
+				this.emit('@connectionstatechange', 'closed');
+
+				break;
+			}
+		}
+	};
 
 	private assertNotClosed(): void {
 		if (this._closed) {

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -1,6 +1,7 @@
 import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
 import { Logger } from '../Logger';
+import { EnhancedEventEmitter } from '../enhancedEvents';
 import * as utils from '../utils';
 import * as ortc from '../ortc';
 import { InvalidStateError } from '../errors';
@@ -16,18 +17,19 @@ import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
 import * as ortcUtils from './ortc/utils';
-import {
-	type HandlerFactory,
+import type {
+	HandlerFactory,
+	HandlerEvents,
 	HandlerInterface,
-	type HandlerOptions,
-	type HandlerSendOptions,
-	type HandlerSendResult,
-	type HandlerReceiveOptions,
-	type HandlerReceiveResult,
-	type HandlerSendDataChannelOptions,
-	type HandlerSendDataChannelResult,
-	type HandlerReceiveDataChannelOptions,
-	type HandlerReceiveDataChannelResult,
+	HandlerOptions,
+	HandlerSendOptions,
+	HandlerSendResult,
+	HandlerReceiveOptions,
+	HandlerReceiveResult,
+	HandlerSendDataChannelOptions,
+	HandlerSendDataChannelResult,
+	HandlerReceiveDataChannelOptions,
+	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
 import { RemoteSdp } from './sdp/RemoteSdp';
 
@@ -36,7 +38,10 @@ const logger = new Logger('Chrome74');
 const NAME = 'Chrome74';
 const SCTP_NUM_STREAMS = { OS: 1024, MIS: 1024 };
 
-export class Chrome74 extends HandlerInterface {
+export class Chrome74
+	extends EnhancedEventEmitter<HandlerEvents>
+	implements HandlerInterface
+{
 	// Closed flag.
 	private _closed = false;
 	// Handler direction.
@@ -77,7 +82,7 @@ export class Chrome74 extends HandlerInterface {
 			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
-				const pc = new RTCPeerConnection({
+				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
 					iceTransportPolicy: 'all',
 					bundlePolicy: 'max-bundle',
@@ -94,6 +99,8 @@ export class Chrome74 extends HandlerInterface {
 						pc.close();
 					} catch (error) {}
 
+					pc = undefined;
+
 					const sdpObject = sdpTransform.parse(offer.sdp!);
 					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
 						sdpObject,
@@ -105,8 +112,10 @@ export class Chrome74 extends HandlerInterface {
 					return nativeRtpCapabilities;
 				} catch (error) {
 					try {
-						pc.close();
+						pc?.close();
 					} catch (error2) {}
+
+					pc = undefined;
 
 					throw error;
 				}
@@ -174,60 +183,27 @@ export class Chrome74 extends HandlerInterface {
 			...additionalSettings,
 		});
 
-		this._pc.addEventListener('icegatheringstatechange', () => {
-			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
-		});
-
 		this._pc.addEventListener(
-			'icecandidateerror',
-			(event: RTCPeerConnectionIceErrorEvent) => {
-				this.emit('@icecandidateerror', event);
-			}
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
 		);
 
+		this._pc.addEventListener('icecandidateerror', this.onIceCandidateError);
+
 		if (this._pc.connectionState) {
-			this._pc.addEventListener('connectionstatechange', () => {
-				this.emit('@connectionstatechange', this._pc.connectionState);
-			});
+			this._pc.addEventListener(
+				'connectionstatechange',
+				this.onConnectionStateChange
+			);
 		} else {
 			logger.warn(
 				'run() | pc.connectionState not supported, using pc.iceConnectionState'
 			);
 
-			this._pc.addEventListener('iceconnectionstatechange', () => {
-				switch (this._pc.iceConnectionState) {
-					case 'checking': {
-						this.emit('@connectionstatechange', 'connecting');
-
-						break;
-					}
-
-					case 'connected':
-					case 'completed': {
-						this.emit('@connectionstatechange', 'connected');
-
-						break;
-					}
-
-					case 'failed': {
-						this.emit('@connectionstatechange', 'failed');
-
-						break;
-					}
-
-					case 'disconnected': {
-						this.emit('@connectionstatechange', 'disconnected');
-
-						break;
-					}
-
-					case 'closed': {
-						this.emit('@connectionstatechange', 'closed');
-
-						break;
-					}
-				}
-			});
+			this._pc.addEventListener(
+				'iceconnectionstatechange',
+				this.onIceConnectionStateChange
+			);
 		}
 	}
 
@@ -235,7 +211,7 @@ export class Chrome74 extends HandlerInterface {
 		return NAME;
 	}
 
-	close(): void {
+	override close(): void {
 		logger.debug('close()');
 
 		if (this._closed) {
@@ -245,13 +221,31 @@ export class Chrome74 extends HandlerInterface {
 		this._closed = true;
 
 		// Close RTCPeerConnection.
-		if (this._pc) {
-			try {
-				this._pc.close();
-			} catch (error) {}
-		}
+		try {
+			this._pc.close();
+		} catch (error) {}
+
+		this._pc.removeEventListener(
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
+		);
+
+		this._pc.removeEventListener('icecandidateerror', this.onIceCandidateError);
+
+		this._pc.removeEventListener(
+			'connectionstatechange',
+			this.onConnectionStateChange
+		);
+
+		this._pc.removeEventListener(
+			'iceconnectionstatechange',
+			this.onIceConnectionStateChange
+		);
 
 		this.emit('@close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
 	}
 
 	async updateIceServers(iceServers: RTCIceServer[]): Promise<void> {
@@ -1199,6 +1193,55 @@ export class Chrome74 extends HandlerInterface {
 
 		this._transportReady = true;
 	}
+
+	private onIceGatheringStateChange = (): void => {
+		this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+	};
+
+	private onIceCandidateError = (
+		event: RTCPeerConnectionIceErrorEvent
+	): void => {
+		this.emit('@icecandidateerror', event);
+	};
+
+	private onConnectionStateChange = (): void => {
+		this.emit('@connectionstatechange', this._pc.connectionState);
+	};
+
+	private onIceConnectionStateChange = (): void => {
+		switch (this._pc.iceConnectionState) {
+			case 'checking': {
+				this.emit('@connectionstatechange', 'connecting');
+
+				break;
+			}
+
+			case 'connected':
+			case 'completed': {
+				this.emit('@connectionstatechange', 'connected');
+
+				break;
+			}
+
+			case 'failed': {
+				this.emit('@connectionstatechange', 'failed');
+
+				break;
+			}
+
+			case 'disconnected': {
+				this.emit('@connectionstatechange', 'disconnected');
+
+				break;
+			}
+
+			case 'closed': {
+				this.emit('@connectionstatechange', 'closed');
+
+				break;
+			}
+		}
+	};
 
 	private assertNotClosed(): void {
 		if (this._closed) {

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -1,5 +1,6 @@
 import { FakeMediaStreamTrack } from 'fake-mediastreamtrack';
 import type * as SdpTransform from 'sdp-transform';
+import { EnhancedEventEmitter } from '../enhancedEvents';
 import { Logger } from '../Logger';
 import * as utils from '../utils';
 import * as ortc from '../ortc';
@@ -17,18 +18,19 @@ import type {
 	RtpParameters,
 } from '../RtpParameters';
 import type { SctpCapabilities } from '../SctpParameters';
-import {
-	type HandlerFactory,
+import type {
+	HandlerFactory,
 	HandlerInterface,
-	type HandlerOptions,
-	type HandlerSendOptions,
-	type HandlerSendResult,
-	type HandlerReceiveOptions,
-	type HandlerReceiveResult,
-	type HandlerSendDataChannelOptions,
-	type HandlerSendDataChannelResult,
-	type HandlerReceiveDataChannelOptions,
-	type HandlerReceiveDataChannelResult,
+	HandlerEvents,
+	HandlerOptions,
+	HandlerSendOptions,
+	HandlerSendResult,
+	HandlerReceiveOptions,
+	HandlerReceiveResult,
+	HandlerSendDataChannelOptions,
+	HandlerSendDataChannelResult,
+	HandlerReceiveDataChannelOptions,
+	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
 
 const logger = new Logger('FakeHandler');
@@ -41,7 +43,10 @@ export type FakeParameters = {
 	generateLocalDtlsParameters: () => DtlsParameters;
 };
 
-export class FakeHandler extends HandlerInterface {
+export class FakeHandler
+	extends EnhancedEventEmitter<HandlerEvents>
+	implements HandlerInterface
+{
 	// Closed flag.
 	private _closed = false;
 	// Fake parameters source of RTP and SCTP parameters and capabilities.
@@ -112,7 +117,7 @@ export class FakeHandler extends HandlerInterface {
 		return NAME;
 	}
 
-	close(): void {
+	override close(): void {
 		logger.debug('close()');
 
 		if (this._closed) {
@@ -120,6 +125,9 @@ export class FakeHandler extends HandlerInterface {
 		}
 
 		this._closed = true;
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
 	}
 
 	// NOTE: Custom method for simulation purposes.

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -1,5 +1,6 @@
 import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
+import { EnhancedEventEmitter } from '../enhancedEvents';
 import { Logger } from '../Logger';
 import { UnsupportedError, InvalidStateError } from '../errors';
 import * as utils from '../utils';
@@ -15,18 +16,19 @@ import type {
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
-import {
-	type HandlerFactory,
+import type {
+	HandlerFactory,
 	HandlerInterface,
-	type HandlerOptions,
-	type HandlerSendOptions,
-	type HandlerSendResult,
-	type HandlerReceiveOptions,
-	type HandlerReceiveResult,
-	type HandlerSendDataChannelOptions,
-	type HandlerSendDataChannelResult,
-	type HandlerReceiveDataChannelOptions,
-	type HandlerReceiveDataChannelResult,
+	HandlerEvents,
+	HandlerOptions,
+	HandlerSendOptions,
+	HandlerSendResult,
+	HandlerReceiveOptions,
+	HandlerReceiveResult,
+	HandlerSendDataChannelOptions,
+	HandlerSendDataChannelResult,
+	HandlerReceiveDataChannelOptions,
+	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
 import { RemoteSdp } from './sdp/RemoteSdp';
 
@@ -35,7 +37,10 @@ const logger = new Logger('Firefox120');
 const NAME = 'Firefox120';
 const SCTP_NUM_STREAMS = { OS: 16, MIS: 2048 };
 
-export class Firefox120 extends HandlerInterface {
+export class Firefox120
+	extends EnhancedEventEmitter<HandlerEvents>
+	implements HandlerInterface
+{
 	// Closed flag.
 	private _closed = false;
 	// Handler direction.
@@ -73,7 +78,7 @@ export class Firefox120 extends HandlerInterface {
 			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
-				const pc = new RTCPeerConnection({
+				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
 					iceTransportPolicy: 'all',
 					bundlePolicy: 'max-bundle',
@@ -115,6 +120,8 @@ export class Firefox120 extends HandlerInterface {
 						pc.close();
 					} catch (error) {}
 
+					pc = undefined;
+
 					const sdpObject = sdpTransform.parse(offer.sdp!);
 					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
 						sdpObject,
@@ -131,8 +138,10 @@ export class Firefox120 extends HandlerInterface {
 					} catch (error2) {}
 
 					try {
-						pc.close();
+						pc?.close();
 					} catch (error2) {}
+
+					pc = undefined;
 
 					throw error;
 				}
@@ -195,60 +204,27 @@ export class Firefox120 extends HandlerInterface {
 			...additionalSettings,
 		});
 
-		this._pc.addEventListener('icegatheringstatechange', () => {
-			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
-		});
-
 		this._pc.addEventListener(
-			'icecandidateerror',
-			(event: RTCPeerConnectionIceErrorEvent) => {
-				this.emit('@icecandidateerror', event);
-			}
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
 		);
 
+		this._pc.addEventListener('icecandidateerror', this.onIceCandidateError);
+
 		if (this._pc.connectionState) {
-			this._pc.addEventListener('connectionstatechange', () => {
-				this.emit('@connectionstatechange', this._pc.connectionState);
-			});
+			this._pc.addEventListener(
+				'connectionstatechange',
+				this.onConnectionStateChange
+			);
 		} else {
-			this._pc.addEventListener('iceconnectionstatechange', () => {
-				logger.warn(
-					'run() | pc.connectionState not supported, using pc.iceConnectionState'
-				);
+			logger.warn(
+				'run() | pc.connectionState not supported, using pc.iceConnectionState'
+			);
 
-				switch (this._pc.iceConnectionState) {
-					case 'checking': {
-						this.emit('@connectionstatechange', 'connecting');
-
-						break;
-					}
-
-					case 'connected':
-					case 'completed': {
-						this.emit('@connectionstatechange', 'connected');
-
-						break;
-					}
-
-					case 'failed': {
-						this.emit('@connectionstatechange', 'failed');
-
-						break;
-					}
-
-					case 'disconnected': {
-						this.emit('@connectionstatechange', 'disconnected');
-
-						break;
-					}
-
-					case 'closed': {
-						this.emit('@connectionstatechange', 'closed');
-
-						break;
-					}
-				}
-			});
+			this._pc.addEventListener(
+				'iceconnectionstatechange',
+				this.onIceConnectionStateChange
+			);
 		}
 	}
 
@@ -256,7 +232,7 @@ export class Firefox120 extends HandlerInterface {
 		return NAME;
 	}
 
-	close(): void {
+	override close(): void {
 		logger.debug('close()');
 
 		if (this._closed) {
@@ -266,13 +242,31 @@ export class Firefox120 extends HandlerInterface {
 		this._closed = true;
 
 		// Close RTCPeerConnection.
-		if (this._pc) {
-			try {
-				this._pc.close();
-			} catch (error) {}
-		}
+		try {
+			this._pc.close();
+		} catch (error) {}
+
+		this._pc.removeEventListener(
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
+		);
+
+		this._pc.removeEventListener('icecandidateerror', this.onIceCandidateError);
+
+		this._pc.removeEventListener(
+			'connectionstatechange',
+			this.onConnectionStateChange
+		);
+
+		this._pc.removeEventListener(
+			'iceconnectionstatechange',
+			this.onIceConnectionStateChange
+		);
 
 		this.emit('@close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
 	}
 
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -1204,6 +1198,55 @@ export class Firefox120 extends HandlerInterface {
 
 		this._transportReady = true;
 	}
+
+	private onIceGatheringStateChange = (): void => {
+		this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+	};
+
+	private onIceCandidateError = (
+		event: RTCPeerConnectionIceErrorEvent
+	): void => {
+		this.emit('@icecandidateerror', event);
+	};
+
+	private onConnectionStateChange = (): void => {
+		this.emit('@connectionstatechange', this._pc.connectionState);
+	};
+
+	private onIceConnectionStateChange = (): void => {
+		switch (this._pc.iceConnectionState) {
+			case 'checking': {
+				this.emit('@connectionstatechange', 'connecting');
+
+				break;
+			}
+
+			case 'connected':
+			case 'completed': {
+				this.emit('@connectionstatechange', 'connected');
+
+				break;
+			}
+
+			case 'failed': {
+				this.emit('@connectionstatechange', 'failed');
+
+				break;
+			}
+
+			case 'disconnected': {
+				this.emit('@connectionstatechange', 'disconnected');
+
+				break;
+			}
+
+			case 'closed': {
+				this.emit('@connectionstatechange', 'closed');
+
+				break;
+			}
+		}
+	};
 
 	private assertNotClosed(): void {
 		if (this._closed) {

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -110,7 +110,7 @@ export abstract class HandlerInterface extends EnhancedEventEmitter<HandlerEvent
 
 	abstract get name(): string;
 
-	abstract close(): void;
+	abstract override close(): void;
 
 	abstract updateIceServers(iceServers: RTCIceServer[]): Promise<void>;
 

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -1,5 +1,6 @@
 import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
+import { EnhancedEventEmitter } from '../enhancedEvents';
 import { Logger } from '../Logger';
 import * as utils from '../utils';
 import * as ortc from '../ortc';
@@ -13,18 +14,19 @@ import type {
 	RtpEncodingParameters,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
-import {
-	type HandlerFactory,
+import type {
+	HandlerFactory,
 	HandlerInterface,
-	type HandlerOptions,
-	type HandlerSendOptions,
-	type HandlerSendResult,
-	type HandlerReceiveOptions,
-	type HandlerReceiveResult,
-	type HandlerSendDataChannelOptions,
-	type HandlerSendDataChannelResult,
-	type HandlerReceiveDataChannelOptions,
-	type HandlerReceiveDataChannelResult,
+	HandlerEvents,
+	HandlerOptions,
+	HandlerSendOptions,
+	HandlerSendResult,
+	HandlerReceiveOptions,
+	HandlerReceiveResult,
+	HandlerSendDataChannelOptions,
+	HandlerSendDataChannelResult,
+	HandlerReceiveDataChannelOptions,
+	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
 import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
@@ -36,7 +38,10 @@ const logger = new Logger('ReactNative106');
 const NAME = 'ReactNative106';
 const SCTP_NUM_STREAMS = { OS: 1024, MIS: 1024 };
 
-export class ReactNative106 extends HandlerInterface {
+export class ReactNative106
+	extends EnhancedEventEmitter<HandlerEvents>
+	implements HandlerInterface
+{
 	// Closed flag.
 	private _closed = false;
 	// Handler direction.
@@ -78,7 +83,7 @@ export class ReactNative106 extends HandlerInterface {
 			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
-				const pc = new RTCPeerConnection({
+				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
 					iceTransportPolicy: 'all',
 					bundlePolicy: 'max-bundle',
@@ -95,6 +100,8 @@ export class ReactNative106 extends HandlerInterface {
 						pc.close();
 					} catch (error) {}
 
+					pc = undefined;
+
 					const sdpObject = sdpTransform.parse(offer.sdp!);
 					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
 						sdpObject,
@@ -106,8 +113,10 @@ export class ReactNative106 extends HandlerInterface {
 					return nativeRtpCapabilities;
 				} catch (error) {
 					try {
-						pc.close();
+						pc?.close();
 					} catch (error2) {}
+
+					pc = undefined;
 
 					throw error;
 				}
@@ -175,60 +184,27 @@ export class ReactNative106 extends HandlerInterface {
 			...additionalSettings,
 		});
 
-		this._pc.addEventListener('icegatheringstatechange', () => {
-			this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
-		});
-
 		this._pc.addEventListener(
-			'icecandidateerror',
-			(event: RTCPeerConnectionIceErrorEvent) => {
-				this.emit('@icecandidateerror', event);
-			}
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
 		);
 
+		this._pc.addEventListener('icecandidateerror', this.onIceCandidateError);
+
 		if (this._pc.connectionState) {
-			this._pc.addEventListener('connectionstatechange', () => {
-				this.emit('@connectionstatechange', this._pc.connectionState);
-			});
+			this._pc.addEventListener(
+				'connectionstatechange',
+				this.onConnectionStateChange
+			);
 		} else {
-			this._pc.addEventListener('iceconnectionstatechange', () => {
-				logger.warn(
-					'run() | pc.connectionState not supported, using pc.iceConnectionState'
-				);
+			logger.warn(
+				'run() | pc.connectionState not supported, using pc.iceConnectionState'
+			);
 
-				switch (this._pc.iceConnectionState) {
-					case 'checking': {
-						this.emit('@connectionstatechange', 'connecting');
-
-						break;
-					}
-
-					case 'connected':
-					case 'completed': {
-						this.emit('@connectionstatechange', 'connected');
-
-						break;
-					}
-
-					case 'failed': {
-						this.emit('@connectionstatechange', 'failed');
-
-						break;
-					}
-
-					case 'disconnected': {
-						this.emit('@connectionstatechange', 'disconnected');
-
-						break;
-					}
-
-					case 'closed': {
-						this.emit('@connectionstatechange', 'closed');
-
-						break;
-					}
-				}
-			});
+			this._pc.addEventListener(
+				'iceconnectionstatechange',
+				this.onIceConnectionStateChange
+			);
 		}
 	}
 
@@ -236,7 +212,7 @@ export class ReactNative106 extends HandlerInterface {
 		return NAME;
 	}
 
-	close(): void {
+	override close(): void {
 		logger.debug('close()');
 
 		if (this._closed) {
@@ -251,13 +227,31 @@ export class ReactNative106 extends HandlerInterface {
 		this._sendStream.release(/* releaseTracks */ false);
 
 		// Close RTCPeerConnection.
-		if (this._pc) {
-			try {
-				this._pc.close();
-			} catch (error) {}
-		}
+		try {
+			this._pc.close();
+		} catch (error) {}
+
+		this._pc.removeEventListener(
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
+		);
+
+		this._pc.removeEventListener('icecandidateerror', this.onIceCandidateError);
+
+		this._pc.removeEventListener(
+			'connectionstatechange',
+			this.onConnectionStateChange
+		);
+
+		this._pc.removeEventListener(
+			'iceconnectionstatechange',
+			this.onIceConnectionStateChange
+		);
 
 		this.emit('@close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
 	}
 
 	async updateIceServers(iceServers: RTCIceServer[]): Promise<void> {
@@ -1250,6 +1244,55 @@ export class ReactNative106 extends HandlerInterface {
 
 		this._transportReady = true;
 	}
+
+	private onIceGatheringStateChange = (): void => {
+		this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+	};
+
+	private onIceCandidateError = (
+		event: RTCPeerConnectionIceErrorEvent
+	): void => {
+		this.emit('@icecandidateerror', event);
+	};
+
+	private onConnectionStateChange = (): void => {
+		this.emit('@connectionstatechange', this._pc.connectionState);
+	};
+
+	private onIceConnectionStateChange = (): void => {
+		switch (this._pc.iceConnectionState) {
+			case 'checking': {
+				this.emit('@connectionstatechange', 'connecting');
+
+				break;
+			}
+
+			case 'connected':
+			case 'completed': {
+				this.emit('@connectionstatechange', 'connected');
+
+				break;
+			}
+
+			case 'failed': {
+				this.emit('@connectionstatechange', 'failed');
+
+				break;
+			}
+
+			case 'disconnected': {
+				this.emit('@connectionstatechange', 'disconnected');
+
+				break;
+			}
+
+			case 'closed': {
+				this.emit('@connectionstatechange', 'closed');
+
+				break;
+			}
+		}
+	};
 
 	private assertNotClosed(): void {
 		if (this._closed) {

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -1,5 +1,6 @@
 import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
+import { EnhancedEventEmitter } from '../enhancedEvents';
 import { Logger } from '../Logger';
 import * as utils from '../utils';
 import * as ortc from '../ortc';
@@ -12,18 +13,19 @@ import type {
 	RtpParameters,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
-import {
-	type HandlerFactory,
+import type {
+	HandlerFactory,
 	HandlerInterface,
-	type HandlerOptions,
-	type HandlerSendOptions,
-	type HandlerSendResult,
-	type HandlerReceiveOptions,
-	type HandlerReceiveResult,
-	type HandlerSendDataChannelOptions,
-	type HandlerSendDataChannelResult,
-	type HandlerReceiveDataChannelOptions,
-	type HandlerReceiveDataChannelResult,
+	HandlerEvents,
+	HandlerOptions,
+	HandlerSendOptions,
+	HandlerSendResult,
+	HandlerReceiveOptions,
+	HandlerReceiveResult,
+	HandlerSendDataChannelOptions,
+	HandlerSendDataChannelResult,
+	HandlerReceiveDataChannelOptions,
+	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
 import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
@@ -35,7 +37,10 @@ const logger = new Logger('Safari12');
 const NAME = 'Safari12';
 const SCTP_NUM_STREAMS = { OS: 1024, MIS: 1024 };
 
-export class Safari12 extends HandlerInterface {
+export class Safari12
+	extends EnhancedEventEmitter<HandlerEvents>
+	implements HandlerInterface
+{
 	// Closed flag.
 	private _closed = false;
 	// Handler direction.
@@ -76,7 +81,7 @@ export class Safari12 extends HandlerInterface {
 			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
-				const pc = new RTCPeerConnection({
+				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
 					iceTransportPolicy: 'all',
 					bundlePolicy: 'max-bundle',
@@ -93,6 +98,8 @@ export class Safari12 extends HandlerInterface {
 						pc.close();
 					} catch (error) {}
 
+					pc = undefined;
+
 					const sdpObject = sdpTransform.parse(offer.sdp!);
 					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
 						sdpObject,
@@ -104,8 +111,10 @@ export class Safari12 extends HandlerInterface {
 					return nativeRtpCapabilities;
 				} catch (error) {
 					try {
-						pc.close();
+						pc?.close();
 					} catch (error2) {}
+
+					pc = undefined;
 
 					throw error;
 				}
@@ -184,49 +193,27 @@ export class Safari12 extends HandlerInterface {
 			}
 		);
 
+		this._pc.addEventListener(
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
+		);
+
+		this._pc.addEventListener('icecandidateerror', this.onIceCandidateError);
+
 		if (this._pc.connectionState) {
-			this._pc.addEventListener('connectionstatechange', () => {
-				this.emit('@connectionstatechange', this._pc.connectionState);
-			});
+			this._pc.addEventListener(
+				'connectionstatechange',
+				this.onConnectionStateChange
+			);
 		} else {
-			this._pc.addEventListener('iceconnectionstatechange', () => {
-				logger.warn(
-					'run() | pc.connectionState not supported, using pc.iceConnectionState'
-				);
+			logger.warn(
+				'run() | pc.connectionState not supported, using pc.iceConnectionState'
+			);
 
-				switch (this._pc.iceConnectionState) {
-					case 'checking': {
-						this.emit('@connectionstatechange', 'connecting');
-
-						break;
-					}
-
-					case 'connected':
-					case 'completed': {
-						this.emit('@connectionstatechange', 'connected');
-
-						break;
-					}
-
-					case 'failed': {
-						this.emit('@connectionstatechange', 'failed');
-
-						break;
-					}
-
-					case 'disconnected': {
-						this.emit('@connectionstatechange', 'disconnected');
-
-						break;
-					}
-
-					case 'closed': {
-						this.emit('@connectionstatechange', 'closed');
-
-						break;
-					}
-				}
-			});
+			this._pc.addEventListener(
+				'iceconnectionstatechange',
+				this.onIceConnectionStateChange
+			);
 		}
 	}
 
@@ -234,7 +221,7 @@ export class Safari12 extends HandlerInterface {
 		return NAME;
 	}
 
-	close(): void {
+	override close(): void {
 		logger.debug('close()');
 
 		if (this._closed) {
@@ -244,13 +231,31 @@ export class Safari12 extends HandlerInterface {
 		this._closed = true;
 
 		// Close RTCPeerConnection.
-		if (this._pc) {
-			try {
-				this._pc.close();
-			} catch (error) {}
-		}
+		try {
+			this._pc.close();
+		} catch (error) {}
+
+		this._pc.removeEventListener(
+			'icegatheringstatechange',
+			this.onIceGatheringStateChange
+		);
+
+		this._pc.removeEventListener('icecandidateerror', this.onIceCandidateError);
+
+		this._pc.removeEventListener(
+			'connectionstatechange',
+			this.onConnectionStateChange
+		);
+
+		this._pc.removeEventListener(
+			'iceconnectionstatechange',
+			this.onIceConnectionStateChange
+		);
 
 		this.emit('@close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
 	}
 
 	async updateIceServers(iceServers: RTCIceServer[]): Promise<void> {
@@ -1191,6 +1196,55 @@ export class Safari12 extends HandlerInterface {
 
 		this._transportReady = true;
 	}
+
+	private onIceGatheringStateChange = (): void => {
+		this.emit('@icegatheringstatechange', this._pc.iceGatheringState);
+	};
+
+	private onIceCandidateError = (
+		event: RTCPeerConnectionIceErrorEvent
+	): void => {
+		this.emit('@icecandidateerror', event);
+	};
+
+	private onConnectionStateChange = (): void => {
+		this.emit('@connectionstatechange', this._pc.connectionState);
+	};
+
+	private onIceConnectionStateChange = (): void => {
+		switch (this._pc.iceConnectionState) {
+			case 'checking': {
+				this.emit('@connectionstatechange', 'connecting');
+
+				break;
+			}
+
+			case 'connected':
+			case 'completed': {
+				this.emit('@connectionstatechange', 'connected');
+
+				break;
+			}
+
+			case 'failed': {
+				this.emit('@connectionstatechange', 'failed');
+
+				break;
+			}
+
+			case 'disconnected': {
+				this.emit('@connectionstatechange', 'disconnected');
+
+				break;
+			}
+
+			case 'closed': {
+				this.emit('@connectionstatechange', 'closed');
+
+				break;
+			}
+		}
+	};
 
 	private assertNotClosed(): void {
 		if (this._closed) {

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1567,13 +1567,16 @@ test('connection state change does not fire "connectionstatechange" in closed Tr
 		}
 	);
 
-	ctx.connectedSendTransport!.close();
-
 	// @ts-expect-error --- On purpose.
 	ctx.connectedSendTransport!.handler.setConnectionState('disconnected');
 
-	expect(connectionStateChangeEventNumTimesCalled).toBe(0);
+	expect(connectionStateChangeEventNumTimesCalled).toBe(1);
 	expect(ctx.connectedSendTransport!.connectionState).toBe('disconnected');
+
+	ctx.connectedSendTransport!.close();
+
+	expect(connectionStateChangeEventNumTimesCalled).toBe(1);
+	expect(ctx.connectedSendTransport!.connectionState).toBe('closed');
 });
 
 test('parseScalabilityMode() works', () => {


### PR DESCRIPTION
## Details

- This PR replaces PR #334.
- Here we remove event listeners in all event emitters and DOM event targets to allow GC to work on our closed objects.