### PR TITLE
Don't expect static codec payload types and RTP extension IDs

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -91,13 +91,18 @@ export class Device {
 	private readonly _handlerName: string;
 	// Loaded flag.
 	private _loaded = false;
-	// Extended RTP capabilities.
-	private _extendedRtpCapabilities?: ExtendedRtpCapabilities;
+	// Callback for sending Transports to request sending extended RTP capabilities
+	// on demand.
+	private _getSendExtendedRtpCapabilities?: (
+		nativeRtpCapabilities: RtpCapabilities
+	) => ExtendedRtpCapabilities;
 	// Local RTP capabilities for receiving media.
 	private _recvRtpCapabilities?: RtpCapabilities;
-	// Whether we can produce audio/video based on computed extended RTP
-	// capabilities.
-	private readonly _canProduceByKind: CanProduceByKind;
+	// Whether we can produce audio/video based on remote RTP capabilities.
+	private readonly _canProduceByKind: CanProduceByKind = {
+		audio: false,
+		video: false,
+	};
 	// Local SCTP capabilities.
 	private _sctpCapabilities?: SctpCapabilities;
 	// Observer instance.
@@ -200,13 +205,6 @@ export class Device {
 		}
 
 		this._handlerName = this._handlerFactory.name;
-		this._extendedRtpCapabilities = undefined;
-		this._recvRtpCapabilities = undefined;
-		this._canProduceByKind = {
-			audio: false,
-			video: false,
-		};
-		this._sctpCapabilities = undefined;
 	}
 
 	/**
@@ -280,46 +278,39 @@ export class Device {
 		const { getNativeRtpCapabilities, getNativeSctpCapabilities } =
 			this._handlerFactory;
 
-		const nativeRtpCapabilities = await getNativeRtpCapabilities();
-
-		logger.debug(
-			'load() | got native RTP capabilities:%o',
-			nativeRtpCapabilities
-		);
-
-		// Clone obtained native RTP capabilities to not modify input data.
 		const clonedNativeRtpCapabilities = utils.clone<RtpCapabilities>(
-			nativeRtpCapabilities
+			await getNativeRtpCapabilities()
 		);
 
 		// This may throw.
 		ortc.validateRtpCapabilities(clonedNativeRtpCapabilities);
 
-		// Get extended RTP capabilities.
-		this._extendedRtpCapabilities = ortc.getExtendedRtpCapabilities(
+		logger.debug(
+			'load() | got native RTP capabilities:%o',
+			clonedNativeRtpCapabilities
+		);
+
+		this._getSendExtendedRtpCapabilities = (
+			nativeRtpCapabilities: RtpCapabilities
+		) => {
+			return utils.clone<ExtendedRtpCapabilities>(
+				ortc.getExtendedRtpCapabilities(
+					nativeRtpCapabilities,
+					clonedRouterRtpCapabilities,
+					preferLocalCodecsOrder
+				)
+			);
+		};
+
+		const recvExtendedRtpCapabilities = ortc.getExtendedRtpCapabilities(
 			clonedNativeRtpCapabilities,
 			clonedRouterRtpCapabilities,
-			preferLocalCodecsOrder
-		);
-
-		logger.debug(
-			'load() | got extended RTP capabilities:%o',
-			this._extendedRtpCapabilities
-		);
-
-		// Check whether we can produce audio/video.
-		this._canProduceByKind.audio = ortc.canSend(
-			'audio',
-			this._extendedRtpCapabilities
-		);
-		this._canProduceByKind.video = ortc.canSend(
-			'video',
-			this._extendedRtpCapabilities
+			/* preferLocalCodecsOrder */ false
 		);
 
 		// Generate our receiving RTP capabilities for receiving media.
 		this._recvRtpCapabilities = ortc.getRecvRtpCapabilities(
-			this._extendedRtpCapabilities
+			recvExtendedRtpCapabilities
 		);
 
 		// This may throw.
@@ -330,16 +321,26 @@ export class Device {
 			this._recvRtpCapabilities
 		);
 
+		// Check whether we can produce audio/video.
+		this._canProduceByKind.audio = ortc.canSend(
+			'audio',
+			this._recvRtpCapabilities
+		);
+		this._canProduceByKind.video = ortc.canSend(
+			'video',
+			this._recvRtpCapabilities
+		);
+
 		// Generate our SCTP capabilities.
 		this._sctpCapabilities = await getNativeSctpCapabilities();
+
+		// This may throw.
+		ortc.validateSctpCapabilities(this._sctpCapabilities);
 
 		logger.debug(
 			'load() | got native SCTP capabilities:%o',
 			this._sctpCapabilities
 		);
-
-		// This may throw.
-		ortc.validateSctpCapabilities(this._sctpCapabilities);
 
 		logger.debug('load() succeeded');
 
@@ -471,7 +472,8 @@ export class Device {
 			additionalSettings,
 			appData,
 			handlerFactory: this._handlerFactory,
-			extendedRtpCapabilities: this._extendedRtpCapabilities!,
+			getSendExtendedRtpCapabilities: this._getSendExtendedRtpCapabilities!,
+			recvRtpCapabilities: this._recvRtpCapabilities!,
 			canProduceByKind: this._canProduceByKind,
 		});
 

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -14,6 +14,7 @@ import { Consumer, type ConsumerOptions } from './Consumer';
 import { DataProducer, type DataProducerOptions } from './DataProducer';
 import { DataConsumer, type DataConsumerOptions } from './DataConsumer';
 import type {
+	RtpCapabilities,
 	RtpParameters,
 	MediaKind,
 	RtpEncodingParameters,
@@ -209,8 +210,13 @@ export class Transport<
 	private _closed = false;
 	// Direction.
 	private readonly _direction: 'send' | 'recv';
-	// Extended RTP capabilities.
-	private readonly _extendedRtpCapabilities: ExtendedRtpCapabilities;
+	// Callback for sending Transports to request sending extended RTP capabilities
+	// on demand.
+	private _getSendExtendedRtpCapabilities: (
+		nativeRtpCapabilities: RtpCapabilities
+	) => ExtendedRtpCapabilities;
+	// Recv RTP capabilities.
+	private readonly _recvRtpCapabilities: RtpCapabilities;
 	// Whether we can produce audio/video based on computed extended RTP
 	// capabilities.
 	private readonly _canProduceByKind: CanProduceByKind;
@@ -268,12 +274,16 @@ export class Transport<
 		additionalSettings,
 		appData,
 		handlerFactory,
-		extendedRtpCapabilities,
+		getSendExtendedRtpCapabilities,
+		recvRtpCapabilities,
 		canProduceByKind,
 	}: {
 		direction: 'send' | 'recv';
 		handlerFactory: HandlerFactory;
-		extendedRtpCapabilities: ExtendedRtpCapabilities;
+		getSendExtendedRtpCapabilities: (
+			nativeRtpCapabilities: RtpCapabilities
+		) => ExtendedRtpCapabilities;
+		recvRtpCapabilities: RtpCapabilities;
 		canProduceByKind: CanProduceByKind;
 	} & TransportOptions<TransportAppData>) {
 		super();
@@ -282,7 +292,8 @@ export class Transport<
 
 		this._id = id;
 		this._direction = direction;
-		this._extendedRtpCapabilities = extendedRtpCapabilities;
+		this._getSendExtendedRtpCapabilities = getSendExtendedRtpCapabilities;
+		this._recvRtpCapabilities = recvRtpCapabilities;
 		this._canProduceByKind = canProduceByKind;
 		this._maxSctpMessageSize = sctpParameters
 			? sctpParameters.maxMessageSize
@@ -305,7 +316,7 @@ export class Transport<
 			iceServers,
 			iceTransportPolicy,
 			additionalSettings: clonedAdditionalSettings,
-			extendedRtpCapabilities,
+			getSendExtendedRtpCapabilities: this._getSendExtendedRtpCapabilities,
 		});
 
 		this._appData = appData ?? ({} as TransportAppData);
@@ -678,7 +689,7 @@ export class Transport<
 		// Ensure the device can consume it.
 		const canConsume = ortc.canReceive(
 			clonedRtpParameters,
-			this._extendedRtpCapabilities
+			this._recvRtpCapabilities
 		);
 
 		if (!canConsume) {

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -2,17 +2,13 @@ import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
 import { EnhancedEventEmitter } from '../enhancedEvents';
 import { Logger } from '../Logger';
-import * as utils from '../utils';
 import * as ortc from '../ortc';
 import { InvalidStateError } from '../errors';
 import { parse as parseScalabilityMode } from '../scalabilityModes';
 import type { IceParameters, DtlsRole } from '../Transport';
-import type {
-	RtpCapabilities,
-	MediaKind,
-	RtpParameters,
-} from '../RtpParameters';
+import type { RtpCapabilities, MediaKind } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { ExtendedRtpCapabilities } from '../privateTypes';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
 import * as ortcUtils from './ortc/utils';
@@ -47,13 +43,10 @@ export class Chrome111
 	private _direction: 'send' | 'recv';
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
-	// Generic sending RTP parameters for audio and video.
-	private _sendingRtpParametersByKind: { [K in MediaKind]: RtpParameters };
-	// Generic sending RTP parameters for audio and video suitable for the SDP
-	// remote answer.
-	private _sendingRemoteRtpParametersByKind: {
-		[K in MediaKind]: RtpParameters;
-	};
+	// Callback to request sending extended RTP capabilities on demand.
+	private _getSendExtendedRtpCapabilities: (
+		nativeRtpCapabilities: RtpCapabilities
+	) => ExtendedRtpCapabilities;
 	// Initial server side DTLS role. If not 'auto', it will force the opposite
 	// value in client side.
 	private _forcedLocalDtlsRole?: DtlsRole;
@@ -105,12 +98,8 @@ export class Chrome111
 					pc = undefined;
 
 					const sdpObject = sdpTransform.parse(offer.sdp!);
-					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
-						sdpObject,
-					});
-
-					// libwebrtc supports NACK for OPUS but doesn't announce it.
-					ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+					const nativeRtpCapabilities =
+						Chrome111.getLocalRtpCapabilities(sdpObject);
 
 					return nativeRtpCapabilities;
 				} catch (error) {
@@ -133,6 +122,19 @@ export class Chrome111
 		};
 	}
 
+	private static getLocalRtpCapabilities(
+		localSdpObject: SdpTransform.SessionDescription
+	): RtpCapabilities {
+		const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
+			sdpObject: localSdpObject,
+		});
+
+		// libwebrtc supports NACK for OPUS but doesn't announce it.
+		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+
+		return nativeRtpCapabilities;
+	}
+
 	private constructor({
 		direction,
 		iceParameters,
@@ -142,7 +144,7 @@ export class Chrome111
 		iceServers,
 		iceTransportPolicy,
 		additionalSettings,
-		extendedRtpCapabilities,
+		getSendExtendedRtpCapabilities,
 	}: HandlerOptions) {
 		super();
 
@@ -157,21 +159,7 @@ export class Chrome111
 			sctpParameters,
 		});
 
-		this._sendingRtpParametersByKind = {
-			audio: ortc.getSendingRtpParameters('audio', extendedRtpCapabilities),
-			video: ortc.getSendingRtpParameters('video', extendedRtpCapabilities),
-		};
-
-		this._sendingRemoteRtpParametersByKind = {
-			audio: ortc.getSendingRemoteRtpParameters(
-				'audio',
-				extendedRtpCapabilities
-			),
-			video: ortc.getSendingRemoteRtpParameters(
-				'video',
-				extendedRtpCapabilities
-			),
-		};
+		this._getSendExtendedRtpCapabilities = getSendExtendedRtpCapabilities;
 
 		if (dtlsParameters.role && dtlsParameters.role !== 'auto') {
 			this._forcedLocalDtlsRole =
@@ -362,27 +350,6 @@ export class Chrome111
 			});
 		}
 
-		const sendingRtpParameters: RtpParameters = utils.clone<RtpParameters>(
-			this._sendingRtpParametersByKind[track.kind as MediaKind]
-		);
-
-		// This may throw.
-		sendingRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRtpParameters.codecs,
-			codec
-		);
-
-		const sendingRemoteRtpParameters: RtpParameters =
-			utils.clone<RtpParameters>(
-				this._sendingRemoteRtpParametersByKind[track.kind as MediaKind]
-			);
-
-		// This may throw.
-		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRemoteRtpParameters.codecs,
-			codec
-		);
-
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
@@ -400,6 +367,36 @@ export class Chrome111
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp.setSessionExtmapAllowMixed();
 		}
+
+		const nativeRtpCapabilities =
+			Chrome111.getLocalRtpCapabilities(localSdpObject);
+		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
+			nativeRtpCapabilities
+		);
+
+		// Generic sending RTP parameters.
+		const sendingRtpParameters = ortc.getSendingRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRtpParameters.codecs,
+			codec
+		);
+
+		// Generic sending RTP parameters suitable for the SDP remote answer.
+		const sendingRemoteRtpParameters = ortc.getSendingRemoteRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRemoteRtpParameters.codecs,
+			codec
+		);
 
 		if (!this._transportReady) {
 			await this.setupTransport({

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -2,7 +2,6 @@ import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
 import { Logger } from '../Logger';
 import { EnhancedEventEmitter } from '../enhancedEvents';
-import * as utils from '../utils';
 import * as ortc from '../ortc';
 import { InvalidStateError } from '../errors';
 import { parse as parseScalabilityMode } from '../scalabilityModes';
@@ -10,10 +9,10 @@ import type { IceParameters, DtlsRole } from '../Transport';
 import type {
 	RtpCapabilities,
 	MediaKind,
-	RtpParameters,
 	RtpEncodingParameters,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { ExtendedRtpCapabilities } from '../privateTypes';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
 import * as ortcUtils from './ortc/utils';
@@ -48,13 +47,10 @@ export class Chrome74
 	private _direction: 'send' | 'recv';
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
-	// Generic sending RTP parameters for audio and video.
-	private _sendingRtpParametersByKind: { [K in MediaKind]: RtpParameters };
-	// Generic sending RTP parameters for audio and video suitable for the SDP
-	// remote answer.
-	private _sendingRemoteRtpParametersByKind: {
-		[K in MediaKind]: RtpParameters;
-	};
+	// Callback to request sending extended RTP capabilities on demand.
+	private _getSendExtendedRtpCapabilities: (
+		nativeRtpCapabilities: RtpCapabilities
+	) => ExtendedRtpCapabilities;
 	// Initial server side DTLS role. If not 'auto', it will force the opposite
 	// value in client side.
 	private _forcedLocalDtlsRole?: DtlsRole;
@@ -102,12 +98,8 @@ export class Chrome74
 					pc = undefined;
 
 					const sdpObject = sdpTransform.parse(offer.sdp!);
-					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
-						sdpObject,
-					});
-
-					// libwebrtc supports NACK for OPUS but doesn't announce it.
-					ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+					const nativeRtpCapabilities =
+						Chrome74.getLocalRtpCapabilities(sdpObject);
 
 					return nativeRtpCapabilities;
 				} catch (error) {
@@ -130,6 +122,19 @@ export class Chrome74
 		};
 	}
 
+	private static getLocalRtpCapabilities(
+		localSdpObject: SdpTransform.SessionDescription
+	): RtpCapabilities {
+		const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
+			sdpObject: localSdpObject,
+		});
+
+		// libwebrtc supports NACK for OPUS but doesn't announce it.
+		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+
+		return nativeRtpCapabilities;
+	}
+
 	private constructor({
 		direction,
 		iceParameters,
@@ -139,7 +144,7 @@ export class Chrome74
 		iceServers,
 		iceTransportPolicy,
 		additionalSettings,
-		extendedRtpCapabilities,
+		getSendExtendedRtpCapabilities,
 	}: HandlerOptions) {
 		super();
 
@@ -154,21 +159,7 @@ export class Chrome74
 			sctpParameters,
 		});
 
-		this._sendingRtpParametersByKind = {
-			audio: ortc.getSendingRtpParameters('audio', extendedRtpCapabilities),
-			video: ortc.getSendingRtpParameters('video', extendedRtpCapabilities),
-		};
-
-		this._sendingRemoteRtpParametersByKind = {
-			audio: ortc.getSendingRemoteRtpParameters(
-				'audio',
-				extendedRtpCapabilities
-			),
-			video: ortc.getSendingRemoteRtpParameters(
-				'video',
-				extendedRtpCapabilities
-			),
-		};
+		this._getSendExtendedRtpCapabilities = getSendExtendedRtpCapabilities;
 
 		if (dtlsParameters.role && dtlsParameters.role !== 'auto') {
 			this._forcedLocalDtlsRole =
@@ -340,26 +331,6 @@ export class Chrome74
 			});
 		}
 
-		const sendingRtpParameters = utils.clone<RtpParameters>(
-			this._sendingRtpParametersByKind[track.kind as MediaKind]
-		);
-
-		// This may throw.
-		sendingRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRtpParameters.codecs,
-			codec
-		);
-
-		const sendingRemoteRtpParameters = utils.clone<RtpParameters>(
-			this._sendingRemoteRtpParametersByKind[track.kind as MediaKind]
-		);
-
-		// This may throw.
-		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRemoteRtpParameters.codecs,
-			codec
-		);
-
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
@@ -373,7 +344,35 @@ export class Chrome74
 			this._remoteSdp.setSessionExtmapAllowMixed();
 		}
 
-		let offerMediaObject;
+		const nativeRtpCapabilities =
+			Chrome74.getLocalRtpCapabilities(localSdpObject);
+		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
+			nativeRtpCapabilities
+		);
+
+		// Generic sending RTP parameters.
+		const sendingRtpParameters = ortc.getSendingRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRtpParameters.codecs,
+			codec
+		);
+
+		// Generic sending RTP parameters suitable for the SDP remote answer.
+		const sendingRemoteRtpParameters = ortc.getSendingRemoteRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRemoteRtpParameters.codecs,
+			codec
+		);
 
 		if (!this._transportReady) {
 			await this.setupTransport({
@@ -388,6 +387,8 @@ export class Chrome74
 		const layers = parseScalabilityMode(
 			(encodings ?? [{}])[0]!.scalabilityMode
 		);
+
+		let offerMediaObject;
 
 		if (
 			encodings &&

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -18,6 +18,7 @@ import type {
 	RtpParameters,
 } from '../RtpParameters';
 import type { SctpCapabilities } from '../SctpParameters';
+import type { ExtendedRtpCapabilities } from '../privateTypes';
 import type {
 	HandlerFactory,
 	HandlerInterface,
@@ -51,8 +52,10 @@ export class FakeHandler
 	private _closed = false;
 	// Fake parameters source of RTP and SCTP parameters and capabilities.
 	private _fakeParameters: FakeParameters;
-	// Generic sending RTP parameters for audio and video.
-	private _rtpParametersByKind: { [K in MediaKind]: RtpParameters };
+	// Callback to request sending extended RTP capabilities on demand.
+	private _getSendExtendedRtpCapabilities: (
+		nativeRtpCapabilities: RtpCapabilities
+	) => ExtendedRtpCapabilities;
 	// Local RTCP CNAME.
 	private _cname = `CNAME-${utils.generateRandomNumber()}`;
 	// Got transport local and remote parameters.
@@ -75,7 +78,7 @@ export class FakeHandler
 			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
-				return fakeParameters.generateNativeRtpCapabilities();
+				return FakeHandler.getLocalRtpCapabilities(fakeParameters);
 			},
 			getNativeSctpCapabilities: async (): Promise<SctpCapabilities> => {
 				logger.debug('getNativeSctpCapabilities()');
@@ -83,6 +86,15 @@ export class FakeHandler
 				return fakeParameters.generateNativeSctpCapabilities();
 			},
 		};
+	}
+
+	private static getLocalRtpCapabilities(
+		fakeParameters: FakeParameters
+	): RtpCapabilities {
+		const nativeRtpCapabilities =
+			fakeParameters.generateNativeRtpCapabilities();
+
+		return nativeRtpCapabilities;
 	}
 
 	private constructor(
@@ -95,7 +107,7 @@ export class FakeHandler
 			// iceServers,
 			// iceTransportPolicy,
 			// additionalSettings,
-			extendedRtpCapabilities,
+			getSendExtendedRtpCapabilities,
 		}: HandlerOptions,
 		fakeParameters: FakeParameters
 	) {
@@ -103,12 +115,7 @@ export class FakeHandler
 
 		logger.debug('constructor()');
 
-		// Generic sending RTP parameters for audio and video.
-		// @type {Object}
-		this._rtpParametersByKind = {
-			audio: ortc.getSendingRtpParameters('audio', extendedRtpCapabilities),
-			video: ortc.getSendingRtpParameters('video', extendedRtpCapabilities),
-		};
+		this._getSendExtendedRtpCapabilities = getSendExtendedRtpCapabilities;
 
 		this._fakeParameters = fakeParameters;
 	}
@@ -172,14 +179,30 @@ export class FakeHandler
 			await this.setupTransport({ localDtlsRole: 'server' });
 		}
 
-		const rtpParameters = utils.clone<RtpParameters>(
-			this._rtpParametersByKind[track.kind as MediaKind]
+		const nativeRtpCapabilities = FakeHandler.getLocalRtpCapabilities(
+			this._fakeParameters
 		);
-		const useRtx = rtpParameters.codecs.some(_codec =>
+		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
+			nativeRtpCapabilities
+		);
+
+		// Generic sending RTP parameters.
+		const sendingRtpParameters: RtpParameters = ortc.getSendingRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRtpParameters.codecs,
+			codec
+		);
+
+		const useRtx = sendingRtpParameters.codecs.some(_codec =>
 			/.+\/rtx$/i.test(_codec.mimeType)
 		);
 
-		rtpParameters.mid = `mid-${utils.generateRandomNumber()}`;
+		sendingRtpParameters.mid = `mid-${utils.generateRandomNumber()}`;
 
 		if (!encodings) {
 			encodings = [{}];
@@ -193,10 +216,10 @@ export class FakeHandler
 			}
 		}
 
-		rtpParameters.encodings = encodings;
+		sendingRtpParameters.encodings = encodings;
 
 		// Fill RTCRtpParameters.rtcp.
-		rtpParameters.rtcp = {
+		sendingRtpParameters.rtcp = {
 			cname: this._cname,
 			reducedSize: true,
 			mux: true,
@@ -206,7 +229,7 @@ export class FakeHandler
 
 		this._tracks.set(localId, track);
 
-		return { localId: String(localId), rtpParameters };
+		return { localId: String(localId), rtpParameters: sendingRtpParameters };
 	}
 
 	async stopSending(localId: string): Promise<void> {

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -3,17 +3,16 @@ import type * as SdpTransform from 'sdp-transform';
 import { EnhancedEventEmitter } from '../enhancedEvents';
 import { Logger } from '../Logger';
 import { UnsupportedError, InvalidStateError } from '../errors';
-import * as utils from '../utils';
 import * as ortc from '../ortc';
 import { parse as parseScalabilityMode } from '../scalabilityModes';
 import type { IceParameters, DtlsRole } from '../Transport';
 import type {
 	RtpCapabilities,
 	MediaKind,
-	RtpParameters,
 	RtpEncodingParameters,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { ExtendedRtpCapabilities } from '../privateTypes';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
 import type {
@@ -47,13 +46,10 @@ export class Firefox120
 	private _direction: 'send' | 'recv';
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
-	// Generic sending RTP parameters for audio and video.
-	private _sendingRtpParametersByKind: { [K in MediaKind]: RtpParameters };
-	// Generic sending RTP parameters for audio and video suitable for the SDP
-	// remote answer.
-	private _sendingRemoteRtpParametersByKind: {
-		[K in MediaKind]: RtpParameters;
-	};
+	// Callback to request sending extended RTP capabilities on demand.
+	private _getSendExtendedRtpCapabilities: (
+		nativeRtpCapabilities: RtpCapabilities
+	) => ExtendedRtpCapabilities;
 	// RTCPeerConnection instance.
 	private _pc: RTCPeerConnection;
 	// Map of RTCTransceivers indexed by MID.
@@ -123,9 +119,8 @@ export class Firefox120
 					pc = undefined;
 
 					const sdpObject = sdpTransform.parse(offer.sdp!);
-					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
-						sdpObject,
-					});
+					const nativeRtpCapabilities =
+						Firefox120.getLocalRtpCapabilities(sdpObject);
 
 					return nativeRtpCapabilities;
 				} catch (error) {
@@ -156,6 +151,16 @@ export class Firefox120
 		};
 	}
 
+	private static getLocalRtpCapabilities(
+		localSdpObject: SdpTransform.SessionDescription
+	): RtpCapabilities {
+		const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
+			sdpObject: localSdpObject,
+		});
+
+		return nativeRtpCapabilities;
+	}
+
 	private constructor({
 		direction,
 		iceParameters,
@@ -165,7 +170,7 @@ export class Firefox120
 		iceServers,
 		iceTransportPolicy,
 		additionalSettings,
-		extendedRtpCapabilities,
+		getSendExtendedRtpCapabilities,
 	}: HandlerOptions) {
 		super();
 
@@ -180,21 +185,7 @@ export class Firefox120
 			sctpParameters,
 		});
 
-		this._sendingRtpParametersByKind = {
-			audio: ortc.getSendingRtpParameters('audio', extendedRtpCapabilities),
-			video: ortc.getSendingRtpParameters('video', extendedRtpCapabilities),
-		};
-
-		this._sendingRemoteRtpParametersByKind = {
-			audio: ortc.getSendingRemoteRtpParameters(
-				'audio',
-				extendedRtpCapabilities
-			),
-			video: ortc.getSendingRemoteRtpParameters(
-				'video',
-				extendedRtpCapabilities
-			),
-		};
+		this._getSendExtendedRtpCapabilities = getSendExtendedRtpCapabilities;
 
 		this._pc = new RTCPeerConnection({
 			iceServers: iceServers ?? [],
@@ -358,27 +349,6 @@ export class Firefox120
 			});
 		}
 
-		const sendingRtpParameters: RtpParameters = utils.clone<RtpParameters>(
-			this._sendingRtpParametersByKind[track.kind as MediaKind]
-		);
-
-		// This may throw.
-		sendingRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRtpParameters.codecs,
-			codec
-		);
-
-		const sendingRemoteRtpParameters: RtpParameters =
-			utils.clone<RtpParameters>(
-				this._sendingRemoteRtpParametersByKind[track.kind as MediaKind]
-			);
-
-		// This may throw.
-		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRemoteRtpParameters.codecs,
-			codec
-		);
-
 		// NOTE: Firefox fails sometimes to properly anticipate the closed media
 		// section that it should use, so don't reuse closed media sections.
 		//   https://github.com/versatica/mediasoup-client/issues/104
@@ -401,6 +371,36 @@ export class Firefox120
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp.setSessionExtmapAllowMixed();
 		}
+
+		const nativeRtpCapabilities =
+			Firefox120.getLocalRtpCapabilities(localSdpObject);
+		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
+			nativeRtpCapabilities
+		);
+
+		// Generic sending RTP parameters.
+		const sendingRtpParameters = ortc.getSendingRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRtpParameters.codecs,
+			codec
+		);
+
+		// Generic sending RTP parameters suitable for the SDP remote answer.
+		const sendingRemoteRtpParameters = ortc.getSendingRemoteRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRemoteRtpParameters.codecs,
+			codec
+		);
 
 		// In Firefox use DTLS role client even if we are the "offerer" since
 		// Firefox does not respect ICE-Lite.

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -30,7 +30,9 @@ export type HandlerOptions = {
 	iceServers?: RTCIceServer[];
 	iceTransportPolicy?: RTCIceTransportPolicy;
 	additionalSettings?: Partial<RTCConfiguration>;
-	extendedRtpCapabilities: ExtendedRtpCapabilities;
+	getSendExtendedRtpCapabilities: (
+		nativeRtpCapabilities: RtpCapabilities
+	) => ExtendedRtpCapabilities;
 };
 
 export type HandlerFactory = {

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -2,7 +2,6 @@ import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
 import { EnhancedEventEmitter } from '../enhancedEvents';
 import { Logger } from '../Logger';
-import * as utils from '../utils';
 import * as ortc from '../ortc';
 import { InvalidStateError } from '../errors';
 import { parse as parseScalabilityMode } from '../scalabilityModes';
@@ -10,10 +9,10 @@ import type { IceParameters, DtlsRole } from '../Transport';
 import type {
 	RtpCapabilities,
 	MediaKind,
-	RtpParameters,
 	RtpEncodingParameters,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { ExtendedRtpCapabilities } from '../privateTypes';
 import type {
 	HandlerFactory,
 	HandlerInterface,
@@ -48,13 +47,10 @@ export class ReactNative106
 	private _direction: 'send' | 'recv';
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
-	// Generic sending RTP parameters for audio and video.
-	private _sendingRtpParametersByKind: { [K in MediaKind]: RtpParameters };
-	// Generic sending RTP parameters for audio and video suitable for the SDP
-	// remote answer.
-	private _sendingRemoteRtpParametersByKind: {
-		[K in MediaKind]: RtpParameters;
-	};
+	// Callback to request sending extended RTP capabilities on demand.
+	private _getSendExtendedRtpCapabilities: (
+		nativeRtpCapabilities: RtpCapabilities
+	) => ExtendedRtpCapabilities;
 	// Initial server side DTLS role. If not 'auto', it will force the opposite
 	// value in client side.
 	private _forcedLocalDtlsRole?: DtlsRole;
@@ -103,12 +99,8 @@ export class ReactNative106
 					pc = undefined;
 
 					const sdpObject = sdpTransform.parse(offer.sdp!);
-					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
-						sdpObject,
-					});
-
-					// libwebrtc supports NACK for OPUS but doesn't announce it.
-					ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+					const nativeRtpCapabilities =
+						ReactNative106.getLocalRtpCapabilities(sdpObject);
 
 					return nativeRtpCapabilities;
 				} catch (error) {
@@ -131,6 +123,19 @@ export class ReactNative106
 		};
 	}
 
+	private static getLocalRtpCapabilities(
+		localSdpObject: SdpTransform.SessionDescription
+	): RtpCapabilities {
+		const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
+			sdpObject: localSdpObject,
+		});
+
+		// libwebrtc supports NACK for OPUS but doesn't announce it.
+		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+
+		return nativeRtpCapabilities;
+	}
+
 	private constructor({
 		direction,
 		iceParameters,
@@ -140,7 +145,7 @@ export class ReactNative106
 		iceServers,
 		iceTransportPolicy,
 		additionalSettings,
-		extendedRtpCapabilities,
+		getSendExtendedRtpCapabilities,
 	}: HandlerOptions) {
 		super();
 
@@ -155,21 +160,7 @@ export class ReactNative106
 			sctpParameters,
 		});
 
-		this._sendingRtpParametersByKind = {
-			audio: ortc.getSendingRtpParameters('audio', extendedRtpCapabilities),
-			video: ortc.getSendingRtpParameters('video', extendedRtpCapabilities),
-		};
-
-		this._sendingRemoteRtpParametersByKind = {
-			audio: ortc.getSendingRemoteRtpParameters(
-				'audio',
-				extendedRtpCapabilities
-			),
-			video: ortc.getSendingRemoteRtpParameters(
-				'video',
-				extendedRtpCapabilities
-			),
-		};
+		this._getSendExtendedRtpCapabilities = getSendExtendedRtpCapabilities;
 
 		if (dtlsParameters.role && dtlsParameters.role !== 'auto') {
 			this._forcedLocalDtlsRole =
@@ -347,26 +338,6 @@ export class ReactNative106
 			});
 		}
 
-		const sendingRtpParameters = utils.clone<RtpParameters>(
-			this._sendingRtpParametersByKind[track.kind as MediaKind]
-		);
-
-		// This may throw.
-		sendingRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRtpParameters.codecs,
-			codec
-		);
-
-		const sendingRemoteRtpParameters = utils.clone<RtpParameters>(
-			this._sendingRemoteRtpParametersByKind[track.kind as MediaKind]
-		);
-
-		// This may throw.
-		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRemoteRtpParameters.codecs,
-			codec
-		);
-
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
@@ -385,7 +356,35 @@ export class ReactNative106
 			this._remoteSdp.setSessionExtmapAllowMixed();
 		}
 
-		let offerMediaObject;
+		const nativeRtpCapabilities =
+			ReactNative106.getLocalRtpCapabilities(localSdpObject);
+		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
+			nativeRtpCapabilities
+		);
+
+		// Generic sending RTP parameters.
+		const sendingRtpParameters = ortc.getSendingRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRtpParameters.codecs,
+			codec
+		);
+
+		// Generic sending RTP parameters suitable for the SDP remote answer.
+		const sendingRemoteRtpParameters = ortc.getSendingRemoteRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRemoteRtpParameters.codecs,
+			codec
+		);
 
 		if (!this._transportReady) {
 			await this.setupTransport({
@@ -400,6 +399,8 @@ export class ReactNative106
 		const layers = parseScalabilityMode(
 			(encodings ?? [{}])[0]!.scalabilityMode
 		);
+
+		let offerMediaObject;
 
 		if (
 			encodings &&

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -2,17 +2,13 @@ import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
 import { EnhancedEventEmitter } from '../enhancedEvents';
 import { Logger } from '../Logger';
-import * as utils from '../utils';
 import * as ortc from '../ortc';
 import { InvalidStateError } from '../errors';
 import { parse as parseScalabilityMode } from '../scalabilityModes';
 import type { IceParameters, DtlsRole } from '../Transport';
-import type {
-	RtpCapabilities,
-	MediaKind,
-	RtpParameters,
-} from '../RtpParameters';
+import type { RtpCapabilities, MediaKind } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { ExtendedRtpCapabilities } from '../privateTypes';
 import type {
 	HandlerFactory,
 	HandlerInterface,
@@ -47,13 +43,10 @@ export class Safari12
 	private _direction: 'send' | 'recv';
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
-	// Generic sending RTP parameters for audio and video.
-	private _sendingRtpParametersByKind: { [K in MediaKind]: RtpParameters };
-	// Generic sending RTP parameters for audio and video suitable for the SDP
-	// remote answer.
-	private _sendingRemoteRtpParametersByKind: {
-		[K in MediaKind]: RtpParameters;
-	};
+	// Callback to request sending extended RTP capabilities on demand.
+	private _getSendExtendedRtpCapabilities: (
+		nativeRtpCapabilities: RtpCapabilities
+	) => ExtendedRtpCapabilities;
 	// Initial server side DTLS role. If not 'auto', it will force the opposite
 	// value in client side.
 	private _forcedLocalDtlsRole?: DtlsRole;
@@ -101,12 +94,8 @@ export class Safari12
 					pc = undefined;
 
 					const sdpObject = sdpTransform.parse(offer.sdp!);
-					const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
-						sdpObject,
-					});
-
-					// libwebrtc supports NACK for OPUS but doesn't announce it.
-					ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+					const nativeRtpCapabilities =
+						Safari12.getLocalRtpCapabilities(sdpObject);
 
 					return nativeRtpCapabilities;
 				} catch (error) {
@@ -129,6 +118,19 @@ export class Safari12
 		};
 	}
 
+	private static getLocalRtpCapabilities(
+		localSdpObject: SdpTransform.SessionDescription
+	): RtpCapabilities {
+		const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
+			sdpObject: localSdpObject,
+		});
+
+		// libwebrtc supports NACK for OPUS but doesn't announce it.
+		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+
+		return nativeRtpCapabilities;
+	}
+
 	constructor({
 		direction,
 		iceParameters,
@@ -138,7 +140,7 @@ export class Safari12
 		iceServers,
 		iceTransportPolicy,
 		additionalSettings,
-		extendedRtpCapabilities,
+		getSendExtendedRtpCapabilities,
 	}: HandlerOptions) {
 		super();
 
@@ -153,21 +155,7 @@ export class Safari12
 			sctpParameters,
 		});
 
-		this._sendingRtpParametersByKind = {
-			audio: ortc.getSendingRtpParameters('audio', extendedRtpCapabilities),
-			video: ortc.getSendingRtpParameters('video', extendedRtpCapabilities),
-		};
-
-		this._sendingRemoteRtpParametersByKind = {
-			audio: ortc.getSendingRemoteRtpParameters(
-				'audio',
-				extendedRtpCapabilities
-			),
-			video: ortc.getSendingRemoteRtpParameters(
-				'video',
-				extendedRtpCapabilities
-			),
-		};
+		this._getSendExtendedRtpCapabilities = getSendExtendedRtpCapabilities;
 
 		if (dtlsParameters.role && dtlsParameters.role !== 'auto') {
 			this._forcedLocalDtlsRole =
@@ -345,26 +333,6 @@ export class Safari12
 
 		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
 
-		const sendingRtpParameters = utils.clone<RtpParameters>(
-			this._sendingRtpParametersByKind[track.kind as MediaKind]
-		);
-
-		// This may throw.
-		sendingRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRtpParameters.codecs,
-			codec
-		);
-
-		const sendingRemoteRtpParameters = utils.clone<RtpParameters>(
-			this._sendingRemoteRtpParametersByKind[track.kind as MediaKind]
-		);
-
-		// This may throw.
-		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
-			sendingRemoteRtpParameters.codecs,
-			codec
-		);
-
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
@@ -381,6 +349,36 @@ export class Safari12
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp.setSessionExtmapAllowMixed();
 		}
+
+		const nativeRtpCapabilities =
+			Safari12.getLocalRtpCapabilities(localSdpObject);
+		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
+			nativeRtpCapabilities
+		);
+
+		// Generic sending RTP parameters.
+		const sendingRtpParameters = ortc.getSendingRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRtpParameters.codecs,
+			codec
+		);
+
+		// Generic sending RTP parameters suitable for the SDP remote answer.
+		const sendingRemoteRtpParameters = ortc.getSendingRemoteRtpParameters(
+			track.kind as MediaKind,
+			sendExtendedRtpCapabilities
+		);
+
+		// This may throw.
+		sendingRemoteRtpParameters.codecs = ortc.reduceCodecs(
+			sendingRemoteRtpParameters.codecs,
+			codec
+		);
 
 		let offerMediaObject;
 

--- a/src/handlers/sdp/commonUtils.ts
+++ b/src/handlers/sdp/commonUtils.ts
@@ -15,8 +15,10 @@ import type {
 } from '../../RtpParameters';
 
 /**
- * This function must be called with an SDP with 1 m=audio and 1 m=video
- * sections.
+ * This function extracs RTP capabilities from the given SDP.
+ *
+ * BUNDLE is assumed so, as per spec, all media sections in the SDP must share
+ * same ids for codecs and RTP extensions.
  */
 export function extractRtpCapabilities({
 	sdpObject,
@@ -25,33 +27,15 @@ export function extractRtpCapabilities({
 }): RtpCapabilities {
 	// Map of RtpCodecParameters indexed by payload type.
 	const codecsMap: Map<number, RtpCodecCapability> = new Map();
-	// Array of RtpHeaderExtensions.
-	const headerExtensions: RtpHeaderExtension[] = [];
-	// Whether a m=audio/video section has been already found.
-	let gotAudio = false;
-	let gotVideo = false;
+	// Map of RtpHeaderExtensions indexed by preferred id.
+	const headerExtensionMap: Map<number, RtpHeaderExtension> = new Map();
 
 	for (const m of sdpObject.media) {
 		const kind = m.type;
 
 		switch (kind) {
-			case 'audio': {
-				if (gotAudio) {
-					continue;
-				}
-
-				gotAudio = true;
-
-				break;
-			}
-
+			case 'audio':
 			case 'video': {
-				if (gotVideo) {
-					continue;
-				}
-
-				gotVideo = true;
-
 				break;
 			}
 
@@ -84,9 +68,13 @@ export function extractRtpCapabilities({
 				continue;
 			}
 
-			// Specials case to convert parameter value to string.
+			// Specials cases to convert parameter value to string.
 			if (parameters?.hasOwnProperty('profile-level-id')) {
 				parameters['profile-level-id'] = String(parameters['profile-level-id']);
+			}
+
+			if (parameters?.hasOwnProperty('profile-id')) {
+				parameters['profile-id'] = String(parameters['profile-id']);
 			}
 
 			codec.parameters = parameters;
@@ -138,13 +126,13 @@ export function extractRtpCapabilities({
 				preferredId: ext.value,
 			};
 
-			headerExtensions.push(headerExtension);
+			headerExtensionMap.set(headerExtension.preferredId, headerExtension);
 		}
 	}
 
 	const rtpCapabilities: RtpCapabilities = {
 		codecs: Array.from(codecsMap.values()),
-		headerExtensions: headerExtensions,
+		headerExtensions: Array.from(headerExtensionMap.values()),
 	};
 
 	return rtpCapabilities;

--- a/src/ortc.ts
+++ b/src/ortc.ts
@@ -188,8 +188,7 @@ export function validateSctpStreamParameters(
 }
 
 /**
- * Validates SctpCapabilities. It may modify given data by adding missing
- * fields with default values.
+ * Validates SctpCapabilities.
  * It throws if invalid.
  */
 export function validateSctpCapabilities(caps: SctpCapabilities): void {
@@ -208,7 +207,7 @@ export function validateSctpCapabilities(caps: SctpCapabilities): void {
 /**
  * Generate extended RTP capabilities for sending and receiving.
  *
- * Resulting codecs keep order preferrred by local or remote capabilities
+ * Resulting codecs keep order preferred by local or remote capabilities
  * depending on `preferLocalCodecsOrder`.
  */
 export function getExtendedRtpCapabilities(
@@ -376,8 +375,8 @@ export function getRecvRtpCapabilities(
 
 	for (const extendedCodec of extendedRtpCapabilities.codecs) {
 		const codec = {
-			mimeType: extendedCodec.mimeType,
 			kind: extendedCodec.kind,
+			mimeType: extendedCodec.mimeType,
 			preferredPayloadType: extendedCodec.remotePayloadType,
 			clockRate: extendedCodec.clockRate,
 			channels: extendedCodec.channels,
@@ -393,8 +392,8 @@ export function getRecvRtpCapabilities(
 		}
 
 		const rtxCodec: RtpCodecCapability = {
-			mimeType: `${extendedCodec.kind}/rtx`,
 			kind: extendedCodec.kind,
+			mimeType: `${extendedCodec.kind}/rtx`,
 			preferredPayloadType: extendedCodec.remoteRtxPayloadType,
 			clockRate: extendedCodec.clockRate,
 			parameters: {
@@ -683,9 +682,9 @@ export function generateProbatorRtpParameters(
  */
 export function canSend(
 	kind: MediaKind,
-	extendedRtpCapabilities: ExtendedRtpCapabilities
+	rtpCapabilities: RtpCapabilities
 ): boolean {
-	return extendedRtpCapabilities.codecs.some(codec => codec.kind === kind);
+	return (rtpCapabilities.codecs ?? []).some(codec => codec.kind === kind);
 }
 
 /**
@@ -694,7 +693,7 @@ export function canSend(
  */
 export function canReceive(
 	rtpParameters: RtpParameters,
-	extendedRtpCapabilities: ExtendedRtpCapabilities
+	rtpCapabilities: RtpCapabilities
 ): boolean {
 	// This may throw.
 	validateRtpParameters(rtpParameters);
@@ -705,8 +704,8 @@ export function canReceive(
 
 	const firstMediaCodec = rtpParameters.codecs[0]!;
 
-	return extendedRtpCapabilities.codecs.some(
-		codec => codec.remotePayloadType === firstMediaCodec.payloadType
+	return (rtpCapabilities.codecs ?? []).some(
+		codec => codec.preferredPayloadType === firstMediaCodec.payloadType
 	);
 }
 
@@ -1048,8 +1047,7 @@ function validateRtcpParameters(rtcp: RtcpParameters): void {
 }
 
 /**
- * Validates NumSctpStreams. It may modify given data by adding missing
- * fields with default values.
+ * Validates NumSctpStreams.
  * It throws if invalid.
  */
 function validateNumSctpStreams(numStreams: NumSctpStreams): void {

--- a/src/privateTypes.ts
+++ b/src/privateTypes.ts
@@ -5,6 +5,15 @@ import type {
 	RtpHeaderExtensionDirection,
 } from './RtpParameters';
 
+/**
+ * Extended RTP capabilities are a superset of RTP capabilities that include
+ * information about sending and receiving ids.
+ *
+ * @remarks
+ * - Only intended for internal purposes.
+ *
+ * @private
+ */
 export type ExtendedRtpCapabilities = {
 	codecs: ExtendedRtpCodecCapability[];
 	headerExtensions: ExtendedRtpHeaderExtension[];

--- a/src/test/fakeParameters.ts
+++ b/src/test/fakeParameters.ts
@@ -218,6 +218,43 @@ export function generateNativeRtpCapabilities(): mediasoupClient.types.RtpCapabi
 				parameters: {},
 			},
 			{
+				mimeType: 'audio/foo',
+				kind: 'audio',
+				preferredPayloadType: 107,
+				clockRate: 90000,
+				channels: 4,
+				rtcpFeedback: [{ type: 'foo-qwe-qwe' }],
+				parameters: {
+					foo: 'lalala',
+				},
+			},
+			{
+				mimeType: 'video/BAZCODEC',
+				kind: 'video',
+				preferredPayloadType: 100,
+				clockRate: 90000,
+				rtcpFeedback: [
+					{ type: 'foo' },
+					{ type: 'transport-cc' },
+					{ type: 'ccm', parameter: 'fir' },
+					{ type: 'nack' },
+					{ type: 'nack', parameter: 'pli' },
+				],
+				parameters: {
+					baz: '1234abcd',
+				},
+			},
+			{
+				mimeType: 'video/rtx',
+				kind: 'video',
+				preferredPayloadType: 101,
+				clockRate: 90000,
+				rtcpFeedback: [],
+				parameters: {
+					apt: 100,
+				},
+			},
+			{
 				mimeType: 'video/VP8',
 				kind: 'video',
 				preferredPayloadType: 96,

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -491,6 +491,9 @@ test('transport.produce() succeeds', async () => {
 	// Use disableTrackOnPause: false and zeroRtpOnPause: true
 	const videoProducer = await ctx.connectedSendTransport!.produce({
 		track: videoTrack,
+		codec: ctx.loadedDevice!.rtpCapabilities.codecs!.find(
+			codec => codec.mimeType.toLowerCase() === 'video/vp9'
+		),
 		encodings: videoEncodings,
 		disableTrackOnPause: false,
 		zeroRtpOnPause: true,
@@ -505,37 +508,11 @@ test('transport.produce() succeeds', async () => {
 	expect(videoProducer.track).toBe(videoTrack);
 	expect(typeof videoProducer.rtpParameters).toBe('object');
 	expect(typeof videoProducer.rtpParameters.mid).toBe('string');
-	expect(videoProducer.rtpParameters.codecs.length).toBe(4);
+	expect(videoProducer.rtpParameters.codecs.length).toBe(2);
 
 	codecs = videoProducer.rtpParameters.codecs;
 
 	expect(codecs[0]).toEqual({
-		mimeType: 'video/VP8',
-		payloadType: 96,
-		clockRate: 90000,
-		rtcpFeedback: [
-			{ type: 'goog-remb', parameter: '' },
-			{ type: 'transport-cc', parameter: '' },
-			{ type: 'ccm', parameter: 'fir' },
-			{ type: 'nack', parameter: '' },
-			{ type: 'nack', parameter: 'pli' },
-		],
-		parameters: {
-			baz: '1234abcd',
-		},
-	});
-
-	expect(codecs[1]).toEqual({
-		mimeType: 'video/rtx',
-		payloadType: 97,
-		clockRate: 90000,
-		rtcpFeedback: [],
-		parameters: {
-			apt: 96,
-		},
-	});
-
-	expect(codecs[2]).toEqual({
 		mimeType: 'video/VP9',
 		payloadType: 98,
 		clockRate: 90000,
@@ -551,7 +528,7 @@ test('transport.produce() succeeds', async () => {
 		},
 	});
 
-	expect(codecs[3]).toEqual({
+	expect(codecs[1]).toEqual({
 		mimeType: 'video/rtx',
 		payloadType: 99,
 		clockRate: 90000,


### PR DESCRIPTION
## Details

- Fixes #330
- In Chrome M140 the way codec payload types and RTP extension IDs are assigned in the SDP will change and will break assumptions we do in mediasoup-client.
- Before this PR, mediasoup-client obtains local RTP capabilities when `device.load()` is called and assumes that the codec payload types and RTP extension IDs will be later the same ones when sending `Transports` are created and `Producers` are created on them. So for example, in Chrome M140, if we start with video and then we add audio to a sending `Transport`, those numeric payload types and extension local IDs will be different than the ones in our discovered RTP capabilities, and hence our sending `RtpParameters` will have wrong values that won't match what the browser will really send into the RTP packets, so everything will fail.
- In this PR, mediasoup-client computes local capabilities every time `transport.produce()` is called and obtains the codec payload types and RTP extension IDs dynamically from the latest SDP offer generated by the browser.
- Thanks a lot to @ramesh-kv-rc for properly reporting the issue.

## Important

- **Upgrading to next mediasoup-client version will be urgently needed, otherwise many apps will stop working with errors like this:**
  ```
  failed:InvalidAccessError: Failed to execute 'setRemoteDescription' on 'RTCPeerConnection': Failed to set remote answer sdp: Failed to set recv parameters for m-section with mid='0'
  ```
- The new dynamic RTP extension ID assign logic in libwebrtc has already landed in latest Chrome Canary 141.0.7354.0 and indeed mediasoup-client `v3` branch **fails** on it. However by using the branch in this PR it works fine.
