### PR TITLE
Add custom DOM Event classes

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -133,6 +133,7 @@ const config = tsEslint.config(
 				2,
 				'type-annotation',
 			],
+			'@typescript-eslint/prefer-function-type': 0,
 			'@typescript-eslint/dot-notation': 0,
 			'@typescript-eslint/no-unused-vars': [
 				2,
@@ -149,6 +150,7 @@ const config = tsEslint.config(
 				2,
 				{ allowExpressions: true },
 			],
+			'@typescript-eslint/no-inferrable-types': 0,
 			'@typescript-eslint/no-unsafe-member-access': 0,
 			'@typescript-eslint/no-unsafe-assignment': 0,
 			'@typescript-eslint/no-unsafe-call': 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"awaitqueue": "^3.2.4",
 				"debug": "^4.4.1",
 				"events-alias": "npm:events@^3.3.0",
-				"fake-mediastreamtrack": "^2.1.3",
+				"fake-mediastreamtrack": "^2.1.4",
 				"h264-profile-level-id": "^2.2.3",
 				"sdp-transform": "^2.15.0",
 				"supports-color": "^10.2.0",
@@ -3399,9 +3399,9 @@
 			}
 		},
 		"node_modules/fake-mediastreamtrack": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-2.1.3.tgz",
-			"integrity": "sha512-oeUXj8MNfuNzvVngD984KTMy+t7P/89UWv4Iug/ENe+x3DN5o0COvOA/86pMYD1JE4rIQQRKdv1FQKHfjoz7GQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-2.1.4.tgz",
+			"integrity": "sha512-dvhHee735zKWp6RQ2YJW8dkwsT42br54tqMGDmsxzXbRPOsDv+0njbZW29B+ObS+AJlIPDIQFGEAJTr1OKh6pw==",
 			"license": "ISC",
 			"dependencies": {
 				"uuid": "^11.1.0"
@@ -9048,9 +9048,9 @@
 			}
 		},
 		"fake-mediastreamtrack": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-2.1.3.tgz",
-			"integrity": "sha512-oeUXj8MNfuNzvVngD984KTMy+t7P/89UWv4Iug/ENe+x3DN5o0COvOA/86pMYD1JE4rIQQRKdv1FQKHfjoz7GQ==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-2.1.4.tgz",
+			"integrity": "sha512-dvhHee735zKWp6RQ2YJW8dkwsT42br54tqMGDmsxzXbRPOsDv+0njbZW29B+ObS+AJlIPDIQFGEAJTr1OKh6pw==",
 			"requires": {
 				"uuid": "^11.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"awaitqueue": "^3.2.4",
 		"debug": "^4.4.1",
 		"events-alias": "npm:events@^3.3.0",
-		"fake-mediastreamtrack": "^2.1.3",
+		"fake-mediastreamtrack": "^2.1.4",
 		"h264-profile-level-id": "^2.2.3",
 		"sdp-transform": "^2.15.0",
 		"supports-color": "^10.2.0",

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -33,6 +33,13 @@ import type {
 	HandlerReceiveDataChannelOptions,
 	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
+import { FakeEventTarget } from './fakeEvents/FakeEventTarget';
+import {
+	FakeEventListener,
+	FakeAddEventListenerOptions,
+	FakeEventListenerOptions,
+} from './fakeEvents/FakeEventListener';
+import { FakeEvent } from './fakeEvents/FakeEvent';
 
 const logger = new Logger('FakeHandler');
 
@@ -480,8 +487,12 @@ type FakeRTCDataChannelOptions = {
 	protocol?: string;
 };
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
+/**
+ * @remarks
+ * - We use a custom FakeEventTarget class because Hermes JS engine in
+ *   React-Native doesn't implement EventListener.
+ */
+class FakeRTCDataChannel extends FakeEventTarget implements RTCDataChannel {
 	// Members for RTCDataChannel standard public getters/setters.
 	private readonly _id: number;
 	private readonly _negotiated = true; // mediasoup just uses negotiated DataChannels.
@@ -495,17 +506,18 @@ class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
 	private _bufferedAmountLowThreshold = 0;
 	private _binaryType: BinaryType = 'arraybuffer';
 	// Events.
-	private _onopen: ((this: FakeRTCDataChannel, ev: Event) => any) | null = null;
-	private _onclosing: ((this: FakeRTCDataChannel, ev: Event) => any) | null =
+	private _onopen: ((this: RTCDataChannel, ev: FakeEvent) => void) | null =
 		null;
-	private _onclose: ((this: FakeRTCDataChannel, ev: Event) => any) | null =
+	private _onclosing: ((this: RTCDataChannel, ev: FakeEvent) => void) | null =
 		null;
-	private _onmessage: ((this: FakeRTCDataChannel, ev: Event) => any) | null =
+	private _onclose: ((this: RTCDataChannel, ev: FakeEvent) => void) | null =
+		null;
+	private _onmessage: ((this: RTCDataChannel, ev: FakeEvent) => void) | null =
 		null;
 	private _onbufferedamountlow:
-		| ((this: FakeRTCDataChannel, ev: Event) => any)
+		| ((this: RTCDataChannel, ev: FakeEvent) => void)
 		| null = null;
-	private _onerror: ((this: FakeRTCDataChannel, ev: Event) => any) | null =
+	private _onerror: ((this: RTCDataChannel, ev: FakeEvent) => void) | null =
 		null;
 
 	constructor({
@@ -582,11 +594,11 @@ class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
 		this._binaryType = binaryType;
 	}
 
-	get onopen(): ((this: RTCDataChannel, ev: Event) => any) | null {
-		return this._onopen as ((this: RTCDataChannel, ev: Event) => any) | null;
+	get onopen(): ((this: RTCDataChannel, ev: FakeEvent) => void) | null {
+		return this._onopen;
 	}
 
-	set onopen(handler: ((this: FakeRTCDataChannel, ev: Event) => any) | null) {
+	set onopen(handler: ((this: RTCDataChannel, ev: FakeEvent) => void) | null) {
 		if (this._onopen) {
 			this.removeEventListener('open', this._onopen);
 		}
@@ -598,12 +610,12 @@ class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
 		}
 	}
 
-	get onclosing(): ((this: RTCDataChannel, ev: Event) => any) | null {
-		return this._onclosing as ((this: RTCDataChannel, ev: Event) => any) | null;
+	get onclosing(): ((this: RTCDataChannel, ev: FakeEvent) => void) | null {
+		return this._onclosing;
 	}
 
 	set onclosing(
-		handler: ((this: FakeRTCDataChannel, ev: Event) => any) | null
+		handler: ((this: RTCDataChannel, ev: FakeEvent) => void) | null
 	) {
 		if (this._onclosing) {
 			this.removeEventListener('closing', this._onclosing);
@@ -616,11 +628,11 @@ class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
 		}
 	}
 
-	get onclose(): ((this: RTCDataChannel, ev: Event) => any) | null {
-		return this._onclose as ((this: RTCDataChannel, ev: Event) => any) | null;
+	get onclose(): ((this: RTCDataChannel, ev: FakeEvent) => void) | null {
+		return this._onclose;
 	}
 
-	set onclose(handler: ((this: FakeRTCDataChannel, ev: Event) => any) | null) {
+	set onclose(handler: ((this: RTCDataChannel, ev: FakeEvent) => void) | null) {
 		if (this._onclose) {
 			this.removeEventListener('close', this._onclose);
 		}
@@ -632,12 +644,12 @@ class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
 		}
 	}
 
-	get onmessage(): ((this: RTCDataChannel, ev: Event) => any) | null {
-		return this._onmessage as ((this: RTCDataChannel, ev: Event) => any) | null;
+	get onmessage(): ((this: RTCDataChannel, ev: FakeEvent) => void) | null {
+		return this._onmessage;
 	}
 
 	set onmessage(
-		handler: ((this: FakeRTCDataChannel, ev: Event) => any) | null
+		handler: ((this: RTCDataChannel, ev: FakeEvent) => void) | null
 	) {
 		if (this._onmessage) {
 			this.removeEventListener('message', this._onmessage);
@@ -650,14 +662,14 @@ class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
 		}
 	}
 
-	get onbufferedamountlow(): ((this: RTCDataChannel, ev: Event) => any) | null {
-		return this._onbufferedamountlow as
-			| ((this: RTCDataChannel, ev: Event) => any)
-			| null;
+	get onbufferedamountlow():
+		| ((this: RTCDataChannel, ev: FakeEvent) => void)
+		| null {
+		return this._onbufferedamountlow;
 	}
 
 	set onbufferedamountlow(
-		handler: ((this: FakeRTCDataChannel, ev: Event) => any) | null
+		handler: ((this: RTCDataChannel, ev: FakeEvent) => void) | null
 	) {
 		if (this._onbufferedamountlow) {
 			this.removeEventListener('bufferedamountlow', this._onbufferedamountlow);
@@ -670,11 +682,11 @@ class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
 		}
 	}
 
-	get onerror(): ((this: RTCDataChannel, ev: Event) => any) | null {
-		return this._onerror as ((this: RTCDataChannel, ev: Event) => any) | null;
+	get onerror(): ((this: RTCDataChannel, ev: FakeEvent) => void) | null {
+		return this._onerror;
 	}
 
-	set onerror(handler: ((this: FakeRTCDataChannel, ev: Event) => any) | null) {
+	set onerror(handler: ((this: RTCDataChannel, ev: FakeEvent) => void) | null) {
 		if (this._onerror) {
 			this.removeEventListener('error', this._onerror);
 		}
@@ -688,18 +700,18 @@ class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
 
 	override addEventListener<K extends keyof RTCDataChannelEventMap>(
 		type: K,
-		listener: (this: FakeRTCDataChannel, ev: RTCDataChannelEventMap[K]) => any,
-		options?: boolean | AddEventListenerOptions
+		listener: (this: FakeRTCDataChannel, ev: RTCDataChannelEventMap[K]) => void,
+		options?: boolean | FakeAddEventListenerOptions
 	): void {
-		super.addEventListener(type, listener as EventListener, options);
+		super.addEventListener(type, listener as FakeEventListener, options);
 	}
 
 	override removeEventListener<K extends keyof RTCDataChannelEventMap>(
 		type: K,
-		listener: (this: FakeRTCDataChannel, ev: RTCDataChannelEventMap[K]) => any,
-		options?: boolean | EventListenerOptions
+		listener: (this: FakeRTCDataChannel, ev: RTCDataChannelEventMap[K]) => void,
+		options?: boolean | FakeEventListenerOptions
 	): void {
-		super.removeEventListener(type, listener as EventListener, options);
+		super.removeEventListener(type, listener as FakeEventListener, options);
 	}
 
 	close(): void {
@@ -721,4 +733,3 @@ class FakeRTCDataChannel extends EventTarget implements RTCDataChannel {
 		}
 	}
 }
-/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/handlers/fakeEvents/FakeEvent.ts
+++ b/src/handlers/fakeEvents/FakeEvent.ts
@@ -1,0 +1,71 @@
+// NOTE: Do not use our FakeEventTarget type inside this class, otherwise TS
+// will complain because "Property 'listeners' is missing in type 'EventTarget'
+// but required in type 'FakeEventTarget'".
+export class FakeEvent implements Event {
+	/**
+	 * Constants.
+	 */
+	readonly NONE = 0;
+	readonly CAPTURING_PHASE = 1;
+	readonly AT_TARGET = 2;
+	readonly BUBBLING_PHASE = 3;
+	/**
+	 * Members.
+	 */
+	readonly type: string;
+	readonly bubbles: boolean;
+	readonly cancelable: boolean;
+	defaultPrevented: boolean = false;
+	readonly composed: boolean = false;
+	readonly currentTarget: EventTarget | null = null;
+	// Not implemented.
+	readonly eventPhase: number = this.NONE;
+	readonly isTrusted: boolean = true;
+	readonly target: EventTarget | null = null;
+	readonly timeStamp: number = 0;
+	// Deprecated.
+	readonly cancelBubble: boolean = false;
+	readonly returnValue: boolean = true;
+	readonly srcElement: EventTarget | null = null;
+
+	constructor(
+		type: string,
+		options: { bubbles?: boolean; cancelable?: boolean } = {}
+	) {
+		this.type = type;
+		this.bubbles = options.bubbles ?? false;
+		this.cancelable = options.cancelable ?? false;
+	}
+
+	preventDefault(): void {
+		if (this.cancelable) {
+			this.defaultPrevented = true;
+		}
+	}
+
+	/**
+	 * Not implemented.
+	 */
+	stopPropagation(): void {}
+
+	/**
+	 * Not implemented.
+	 */
+	stopImmediatePropagation(): void {}
+
+	/**
+	 * Not implemented.
+	 */
+	composedPath(): EventTarget[] {
+		return [];
+	}
+
+	/**
+	 * Not implemented.
+	 * @deprecated
+	 */
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	initEvent(type: string, bubbles: boolean, cancelable: true): void {
+		// Not implemented.
+	}
+}

--- a/src/handlers/fakeEvents/FakeEventListener.ts
+++ b/src/handlers/fakeEvents/FakeEventListener.ts
@@ -1,0 +1,24 @@
+import { FakeEvent } from './FakeEvent';
+
+export type FakeEventListenerOrEventListenerObject =
+	| FakeEventListener
+	| FakeEventListenerObject;
+
+export interface FakeEventListener {
+	(evt: FakeEvent): void;
+}
+
+export interface FakeEventListenerObject {
+	handleEvent(object: FakeEvent): void;
+}
+
+export interface FakeAddEventListenerOptions {
+	capture?: boolean;
+	once?: boolean;
+	passive?: boolean;
+	signal?: AbortSignal;
+}
+
+export interface FakeEventListenerOptions {
+	capture?: boolean;
+}

--- a/src/handlers/fakeEvents/FakeEventTarget.ts
+++ b/src/handlers/fakeEvents/FakeEventTarget.ts
@@ -1,0 +1,84 @@
+import {
+	FakeEventListenerOrEventListenerObject,
+	FakeEventListener,
+	FakeAddEventListenerOptions,
+	FakeEventListenerOptions,
+} from './FakeEventListener';
+import { FakeEvent } from './FakeEvent';
+
+interface FakeListenerEntry {
+	callback: FakeEventListener;
+	once: boolean;
+}
+
+export class FakeEventTarget implements EventTarget {
+	private readonly listeners: Record<string, FakeListenerEntry[]> = {};
+
+	addEventListener(
+		type: string,
+		callback: FakeEventListenerOrEventListenerObject | null,
+		options?: FakeAddEventListenerOptions | boolean
+	): void {
+		if (!callback) {
+			return;
+		}
+
+		this.listeners[type] ??= [];
+
+		this.listeners[type].push({
+			callback:
+				typeof callback === 'function' ? callback : callback.handleEvent,
+			once: typeof options === 'object' && options.once === true,
+		});
+	}
+
+	removeEventListener(
+		type: string,
+		callback: FakeEventListenerOrEventListenerObject | null,
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		options?: boolean | FakeEventListenerOptions
+	): void {
+		if (!this.listeners[type]) {
+			return;
+		}
+
+		if (!callback) {
+			return;
+		}
+
+		this.listeners[type] = this.listeners[type].filter(
+			listener =>
+				listener.callback !==
+				(typeof callback === 'function' ? callback : callback.handleEvent)
+		);
+	}
+
+	dispatchEvent(event: FakeEvent): boolean {
+		if (!event || typeof event.type !== 'string') {
+			throw new Error('invalid event object');
+		}
+
+		const entries = this.listeners[event.type];
+
+		if (!entries) {
+			return true;
+		}
+
+		for (const listener of [...entries]) {
+			try {
+				listener.callback.call(this, event);
+			} catch (error) {
+				// Avoid that the error breaks the iteration.
+				setTimeout(() => {
+					throw error;
+				}, 0);
+			}
+
+			if (listener.once) {
+				this.removeEventListener(event.type, listener.callback);
+			}
+		}
+
+		return !event.defaultPrevented;
+	}
+}


### PR DESCRIPTION
## Details

- Fixes #337.
- Hermes JS engine of React-Native doesn't support DOM `EventTarget` and so on.
- We use those types and classes in our `FakeHandler` so it fails in runtime in React-Native.
- Solution is to create our own `EventTarget` and so on implementation.