### PR TITLE
Replace `ua-parser-js`dependency with `browser-dtector`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
 				"@types/debug": "^4.1.12",
 				"@types/events-alias": "npm:@types/events@^3.0.3",
 				"awaitqueue": "^3.2.4",
+				"browser-dtector": "^4.1.0",
 				"debug": "^4.4.1",
 				"events-alias": "npm:events@^3.3.0",
 				"fake-mediastreamtrack": "^2.1.4",
 				"h264-profile-level-id": "^2.2.3",
 				"sdp-transform": "^2.15.0",
-				"supports-color": "^10.2.0",
-				"ua-parser-js": "^2.0.4"
+				"supports-color": "^10.2.0"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.34.0",
@@ -1590,19 +1590,10 @@
 			"version": "24.3.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
 			"integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.10.0"
-			}
-		},
-		"node_modules/@types/node-fetch": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-			"integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/node": "*",
-				"form-data": "^4.0.0"
 			}
 		},
 		"node_modules/@types/sdp-transform": {
@@ -2303,12 +2294,6 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"license": "MIT"
-		},
 		"node_modules/awaitqueue": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.2.4.tgz",
@@ -2451,6 +2436,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/browser-dtector": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/browser-dtector/-/browser-dtector-4.1.0.tgz",
+			"integrity": "sha512-ZnLAE4aknz8f7UWJ9/QJ9rNlHjBi59aVu6a73WGnUUAIXak6+2AbY/I1fnRPJhuqn94Lce63u9ecKNP+D9f71w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/browserslist": {
 			"version": "4.25.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
@@ -2526,19 +2526,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/callsites": {
@@ -2752,18 +2739,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"license": "MIT",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"dev": true,
@@ -2903,35 +2878,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/detect-europe-js": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-			"integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/faisalman"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/ua-parser-js"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/faisalman"
-				}
-			],
-			"license": "MIT"
-		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2940,20 +2886,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/dunder-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/eastasianwidth": {
@@ -2998,51 +2930,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"is-arrayish": "^0.2.1"
-			}
-		},
-		"node_modules/es-define-property": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-set-tostringtag": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/escalade": {
@@ -3574,22 +3461,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3611,15 +3482,6 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",
 			"dev": true,
@@ -3638,30 +3500,6 @@
 				"node": "6.* || 8.* || >= 10.*"
 			}
 		},
-		"node_modules/get-intrinsic": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3670,19 +3508,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/get-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"license": "MIT",
-			"dependencies": {
-				"dunder-proto": "^1.0.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stdin": {
@@ -3780,18 +3605,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/gopd": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3850,45 +3663,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"license": "MIT",
-			"dependencies": {
-				"has-symbols": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -4086,26 +3860,6 @@
 			"engines": {
 				"node": ">=0.12.0"
 			}
-		},
-		"node_modules/is-standalone-pwa": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-			"integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/faisalman"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/ua-parser-js"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/faisalman"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
@@ -5004,15 +4758,6 @@
 				"tmpl": "1.0.5"
 			}
 		},
-		"node_modules/math-intrinsics": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/meow": {
 			"version": "12.1.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -5051,27 +4796,6 @@
 			},
 			"engines": {
 				"node": ">=8.6"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/mimic-fn": {
@@ -5147,26 +4871,6 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"license": "MIT",
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
 		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
@@ -6240,12 +5944,6 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
-		"node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"license": "MIT"
-		},
 		"node_modules/ts-api-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6392,59 +6090,6 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
-		"node_modules/ua-is-frozen": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-			"integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/faisalman"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/ua-parser-js"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/faisalman"
-				}
-			],
-			"license": "MIT"
-		},
-		"node_modules/ua-parser-js": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.4.tgz",
-			"integrity": "sha512-XiBOnM/UpUq21ZZ91q2AVDOnGROE6UQd37WrO9WBgw4u2eGvUCNOheMmZ3EfEUj7DLHr8tre+Um/436Of/Vwzg==",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/ua-parser-js"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/faisalman"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/faisalman"
-				}
-			],
-			"license": "AGPL-3.0-or-later",
-			"dependencies": {
-				"@types/node-fetch": "^2.6.12",
-				"detect-europe-js": "^0.1.2",
-				"is-standalone-pwa": "^0.1.1",
-				"node-fetch": "^2.7.0",
-				"ua-is-frozen": "^0.1.2"
-			},
-			"bin": {
-				"ua-parser-js": "script/cli.js"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/uglify-js": {
 			"version": "3.19.3",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -6463,6 +6108,7 @@
 			"version": "7.10.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
 			"integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unique-string": {
@@ -6597,22 +6243,6 @@
 			"dev": true,
 			"dependencies": {
 				"makeerror": "1.0.12"
-			}
-		},
-		"node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"license": "MIT",
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -7958,17 +7588,9 @@
 			"version": "24.3.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
 			"integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+			"dev": true,
 			"requires": {
 				"undici-types": "~7.10.0"
-			}
-		},
-		"@types/node-fetch": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-			"integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
-			"requires": {
-				"@types/node": "*",
-				"form-data": "^4.0.0"
 			}
 		},
 		"@types/sdp-transform": {
@@ -8368,11 +7990,6 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
-		"asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-		},
 		"awaitqueue": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.2.4.tgz",
@@ -8476,6 +8093,11 @@
 				"fill-range": "^7.1.1"
 			}
 		},
+		"browser-dtector": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/browser-dtector/-/browser-dtector-4.1.0.tgz",
+			"integrity": "sha512-ZnLAE4aknz8f7UWJ9/QJ9rNlHjBi59aVu6a73WGnUUAIXak6+2AbY/I1fnRPJhuqn94Lce63u9ecKNP+D9f71w=="
+		},
 		"browserslist": {
 			"version": "4.25.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
@@ -8519,15 +8141,6 @@
 			"dev": true,
 			"requires": {
 				"run-applescript": "^7.0.0"
-			}
-		},
-		"call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"requires": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
 			}
 		},
 		"callsites": {
@@ -8662,14 +8275,6 @@
 			"version": "1.1.4",
 			"dev": true
 		},
-		"combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"requires": {
-				"delayed-stream": "~1.0.0"
-			}
-		},
 		"concat-map": {
 			"version": "0.0.1",
 			"dev": true
@@ -8753,31 +8358,11 @@
 			"integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
 			"dev": true
 		},
-		"delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-		},
-		"detect-europe-js": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-			"integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow=="
-		},
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
 			"dev": true
-		},
-		"dunder-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"requires": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.2.0"
-			}
 		},
 		"eastasianwidth": {
 			"version": "0.2.0",
@@ -8810,35 +8395,6 @@
 			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
-			}
-		},
-		"es-define-property": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
-		},
-		"es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-		},
-		"es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-			"requires": {
-				"es-errors": "^1.3.0"
-			}
-		},
-		"es-set-tostringtag": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"requires": {
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
 			}
 		},
 		"escalade": {
@@ -9180,18 +8736,6 @@
 				"signal-exit": "^4.0.1"
 			}
 		},
-		"form-data": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			}
-		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9205,11 +8749,6 @@
 			"dev": true,
 			"optional": true
 		},
-		"function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"dev": true
@@ -9220,37 +8759,11 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
-		"get-intrinsic": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"requires": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.1.0"
-			}
-		},
 		"get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
 			"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
 			"dev": true
-		},
-		"get-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"requires": {
-				"dunder-proto": "^1.0.1",
-				"es-object-atoms": "^1.0.0"
-			}
 		},
 		"get-stdin": {
 			"version": "9.0.0",
@@ -9309,11 +8822,6 @@
 			"integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
 			"dev": true
 		},
-		"gopd": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
-		},
 		"graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -9350,27 +8858,6 @@
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true
-		},
-		"has-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-		},
-		"has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"requires": {
-				"has-symbols": "^1.0.3"
-			}
-		},
-		"hasown": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"requires": {
-				"function-bind": "^1.1.2"
-			}
 		},
 		"html-escaper": {
 			"version": "2.0.2",
@@ -9483,11 +8970,6 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true
-		},
-		"is-standalone-pwa": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-			"integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g=="
 		},
 		"is-stream": {
 			"version": "2.0.1",
@@ -10133,11 +9615,6 @@
 				"tmpl": "1.0.5"
 			}
 		},
-		"math-intrinsics": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
-		},
 		"meow": {
 			"version": "12.1.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -10162,19 +9639,6 @@
 			"requires": {
 				"braces": "^3.0.3",
 				"picomatch": "^2.3.1"
-			}
-		},
-		"mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-		},
-		"mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"requires": {
-				"mime-db": "1.52.0"
 			}
 		},
 		"mimic-fn": {
@@ -10222,14 +9686,6 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
-		},
-		"node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"requires": {
-				"whatwg-url": "^5.0.0"
-			}
 		},
 		"node-int64": {
 			"version": "0.4.0",
@@ -10900,11 +10356,6 @@
 				"ieee754": "^1.2.1"
 			}
 		},
-		"tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-		},
 		"ts-api-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -10973,23 +10424,6 @@
 				"@typescript-eslint/utils": "8.41.0"
 			}
 		},
-		"ua-is-frozen": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-			"integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw=="
-		},
-		"ua-parser-js": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.4.tgz",
-			"integrity": "sha512-XiBOnM/UpUq21ZZ91q2AVDOnGROE6UQd37WrO9WBgw4u2eGvUCNOheMmZ3EfEUj7DLHr8tre+Um/436Of/Vwzg==",
-			"requires": {
-				"@types/node-fetch": "^2.6.12",
-				"detect-europe-js": "^0.1.2",
-				"is-standalone-pwa": "^0.1.1",
-				"node-fetch": "^2.7.0",
-				"ua-is-frozen": "^0.1.2"
-			}
-		},
 		"uglify-js": {
 			"version": "3.19.3",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -11000,7 +10434,8 @@
 		"undici-types": {
 			"version": "7.10.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-			"integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag=="
+			"integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+			"dev": true
 		},
 		"unique-string": {
 			"version": "3.0.0",
@@ -11087,20 +10522,6 @@
 			"dev": true,
 			"requires": {
 				"makeerror": "1.0.12"
-			}
-		},
-		"webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-		},
-		"whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"requires": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
 			}
 		},
 		"which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
 				"eslint-plugin-jest": "^29.0.1",
 				"eslint-plugin-prettier": "^5.5.4",
 				"globals": "^16.3.0",
-				"jest": "^30.1.0",
+				"jest": "^30.1.1",
 				"open-cli": "^8.0.0",
 				"prettier": "^3.6.2",
 				"ts-jest": "^29.4.1",
@@ -597,21 +597,21 @@
 			"license": "MIT"
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
-			"integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+			"integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.0.4",
+				"@emnapi/wasi-threads": "1.1.0",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-			"integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+			"integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -620,9 +620,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
-			"integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -969,9 +969,9 @@
 			}
 		},
 		"node_modules/@jest/console": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.0.tgz",
-			"integrity": "sha512-qCEJKC53Z/mpRcxuK8wg0rnkUKoAeN+pet1T7Da/l8WPGzSWdE+RIUQM+LN5bQkNH5PBUab+ua9BiFTW0hKXSQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.1.tgz",
+			"integrity": "sha512-f7TGqR1k4GtN5pyFrKmq+ZVndesiwLU33yDpJIGMS9aW+j6hKjue7ljeAdznBsH9kAnxUWe2Y+Y3fLV/FJt3gA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -987,17 +987,17 @@
 			}
 		},
 		"node_modules/@jest/core": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.0.tgz",
-			"integrity": "sha512-pxSGVBndJFgHS8IuW6gT39kmbZwPvBZfnqJG4lN9xS++0hxuINsitpTswq8hiaZo+R/OYjVbuw0ee+UDsrK4aw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.1.tgz",
+			"integrity": "sha512-3ncU9peZ3D2VdgRkdZtUceTrDgX5yiDRwAFjtxNfU22IiZrpVWlv/FogzDLYSJQptQGfFo3PcHK86a2oG6WUGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.1.0",
+				"@jest/console": "30.1.1",
 				"@jest/pattern": "30.0.1",
-				"@jest/reporters": "30.1.0",
-				"@jest/test-result": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/reporters": "30.1.1",
+				"@jest/test-result": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
@@ -1006,18 +1006,18 @@
 				"exit-x": "^0.2.2",
 				"graceful-fs": "^4.2.11",
 				"jest-changed-files": "30.0.5",
-				"jest-config": "30.1.0",
+				"jest-config": "30.1.1",
 				"jest-haste-map": "30.1.0",
 				"jest-message-util": "30.1.0",
 				"jest-regex-util": "30.0.1",
 				"jest-resolve": "30.1.0",
-				"jest-resolve-dependencies": "30.1.0",
-				"jest-runner": "30.1.0",
-				"jest-runtime": "30.1.0",
-				"jest-snapshot": "30.1.0",
+				"jest-resolve-dependencies": "30.1.1",
+				"jest-runner": "30.1.1",
+				"jest-runtime": "30.1.1",
+				"jest-snapshot": "30.1.1",
 				"jest-util": "30.0.5",
 				"jest-validate": "30.1.0",
-				"jest-watcher": "30.1.0",
+				"jest-watcher": "30.1.1",
 				"micromatch": "^4.0.8",
 				"pretty-format": "30.0.5",
 				"slash": "^3.0.0"
@@ -1045,13 +1045,13 @@
 			}
 		},
 		"node_modules/@jest/environment": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.0.tgz",
-			"integrity": "sha512-a9yjDya5j/6jFFCbuF3wBlxHzaFNRpZBpO52VP80BzgEfLFY7ZlZnS8K3qZGlKYiA02tLCJL3R6+66l1lY05zQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.1.tgz",
+			"integrity": "sha512-yWHbU+3j7ehQE+NRpnxRvHvpUhoohIjMePBbIr8lfe0cWVb0WeTf80DNux1GPJa18CDHiIU5DtksGUfxcDE+Rw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "30.1.0",
+				"@jest/fake-timers": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"jest-mock": "30.0.5"
@@ -1061,23 +1061,23 @@
 			}
 		},
 		"node_modules/@jest/expect": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.0.tgz",
-			"integrity": "sha512-Mnl7ZZ0NurliixNfFGTJ1aC+RBi2p9fFj+0RCsrXJDouaYZbQ7IZbmI9OWsf8f3BsBS/0UWCBztyXmHTn0Q8dQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.1.tgz",
+			"integrity": "sha512-3vHIHsF+qd3D8FU2c7U5l3rg1fhDwAYcGyHyZAi94YIlTwcJ+boNhRyJf373cl4wxbOX+0Q7dF40RTrTFTSuig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"expect": "30.1.0",
-				"jest-snapshot": "30.1.0"
+				"expect": "30.1.1",
+				"jest-snapshot": "30.1.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/expect-utils": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.0.tgz",
-			"integrity": "sha512-3anLWpBieOCIvDYkEoHTK3351znRkmtAiOyURPRwn3IIT2TLlwqkgl6P7wk5mxwW04MZvHHx/gw1qGb3VPDmLA==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.1.tgz",
+			"integrity": "sha512-5YUHr27fpJ64dnvtu+tt11ewATynrHkGYD+uSFgRr8V2eFJis/vEXgToyLwccIwqBihVfz9jwio+Zr1ab1Zihw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1088,9 +1088,9 @@
 			}
 		},
 		"node_modules/@jest/fake-timers": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.0.tgz",
-			"integrity": "sha512-Yei5/jGS0OZbPaLOUMrWVjAlwrlQWPkrBx2lp9M1kx79q2O4JJnrXRCEGgag06zN+a4M3FKatw7g1GYcNATPMg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.1.tgz",
+			"integrity": "sha512-fK/25dNgBNYPw3eLi2CRs57g1H04qBAFNMsUY3IRzkfx/m4THe0E1zF+yGQBOMKKc2XQVdc9EYbJ4hEm7/2UtA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1116,14 +1116,14 @@
 			}
 		},
 		"node_modules/@jest/globals": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.0.tgz",
-			"integrity": "sha512-zZEscSJnh/yNA+7Rw0aNtIy6DZ9EQGWK2PD7Ig934Y/5xJOOGnLBgGKG4YNkORhkR4UZo33CKwaazSy1+Rfosw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.1.tgz",
+			"integrity": "sha512-NNUUkHT2TU/xztZl6r1UXvJL+zvCwmZsQDmK69fVHHcB9fBtlu3FInnzOve/ZoyKnWY8JXWJNT+Lkmu1+ubXUA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.1.0",
-				"@jest/expect": "30.1.0",
+				"@jest/environment": "30.1.1",
+				"@jest/expect": "30.1.1",
 				"@jest/types": "30.0.5",
 				"jest-mock": "30.0.5"
 			},
@@ -1146,16 +1146,16 @@
 			}
 		},
 		"node_modules/@jest/reporters": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.0.tgz",
-			"integrity": "sha512-BJg8JUaJrX9Q01DUFs4+/P9XMsYivfoafXr/vjxy43rRebkd8ZC+NrxEh2tBdOBS5ow89dSL2mIcAFqASQCU3w==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.1.tgz",
+			"integrity": "sha512-Hb2Bq80kahOC6Sv2waEaH1rEU6VdFcM6WHaRBWQF9tf30+nJHxhl/Upbgo9+25f0mOgbphxvbwSMjSgy9gW/FA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "30.1.0",
-				"@jest/test-result": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/console": "30.1.1",
+				"@jest/test-result": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"@types/node": "*",
@@ -1202,9 +1202,9 @@
 			}
 		},
 		"node_modules/@jest/snapshot-utils": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.0.tgz",
-			"integrity": "sha512-8Hc0WVaquUqVQ9J3inaJtV3EvkLzep81qtuS0l/gD7huGPEZCf6TZWugvaF6LpZARw6oLF291E5Y3e+eKcZe1w==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.1.tgz",
+			"integrity": "sha512-TkVBc9wuN22TT8hESRFmjjg/xIMu7z0J3UDYtIRydzCqlLPTB7jK1DDBKdnTUZ4zL3z3rnPpzV6rL1Uzh87sXg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1233,13 +1233,13 @@
 			}
 		},
 		"node_modules/@jest/test-result": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.0.tgz",
-			"integrity": "sha512-ByBm3rucBDAeYUsArrOq6dnYIRsQ0dogs0DqOWaYjPvO4McVQYb/6dVNz9vIqz3hJbhb7b/XF5ZBLoTxUNJwbQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.1.tgz",
+			"integrity": "sha512-bMdj7fNu8iZuBPSnbVir5ezvWmVo4jrw7xDE+A33Yb3ENCoiJK9XgOLgal+rJ9XSKjsL7aPUMIo87zhN7I5o2w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.1.0",
+				"@jest/console": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/istanbul-lib-coverage": "^2.0.6",
 				"collect-v8-coverage": "^1.0.2"
@@ -1249,13 +1249,13 @@
 			}
 		},
 		"node_modules/@jest/test-sequencer": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.0.tgz",
-			"integrity": "sha512-qKfPCHMEHP+vLdGOVkoxbR42deneEdlAtJkn5z/h0HSfd8LJyUbTysO5esd1hJu9pXmeK6yA9ug1ccV+OJKFPg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.1.tgz",
+			"integrity": "sha512-yruRdLXSA3HYD/MTNykgJ6VYEacNcXDFRMqKVAwlYegmxICUiT/B++CNuhJnYJzKYks61iYnjVsMwbUqmmAYJg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.1.0",
+				"@jest/test-result": "30.1.1",
 				"graceful-fs": "^4.2.11",
 				"jest-haste-map": "30.1.0",
 				"slash": "^3.0.0"
@@ -1265,9 +1265,9 @@
 			}
 		},
 		"node_modules/@jest/transform": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.0.tgz",
-			"integrity": "sha512-OvzganIbExZDS2jl37re14XSJXK3sREyGP641RL+Ek1galupCMLWHlxop+4wQnVX7e3fxF6C3W16VzWdl2ducQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.1.tgz",
+			"integrity": "sha512-PHIA2AbAASBfk6evkNifvmx9lkOSkmvaQoO6VSpuL8+kQqDMHeDoJ7RU3YP1wWAMD7AyQn9UL5iheuFYCC4lqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2326,13 +2326,13 @@
 			}
 		},
 		"node_modules/babel-jest": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.0.tgz",
-			"integrity": "sha512-xoF2zwb3po3dOJMahde//mE284gcxp9WH8TTbo3Y102fas7Ga1mjGUwrw137RmvUkuA2liISRlg2BFQhmTfeHg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.1.tgz",
+			"integrity": "sha512-1bZfC/V03qBCzASvZpNFhx3Ouj6LgOd4KFJm4br/fYOS+tSSvVCE61QmcAVbMTwq/GoB7KN4pzGMoyr9cMxSvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/transform": "30.1.0",
+				"@jest/transform": "30.1.1",
 				"@types/babel__core": "^7.20.5",
 				"babel-plugin-istanbul": "^7.0.0",
 				"babel-preset-jest": "30.0.1",
@@ -3381,15 +3381,15 @@
 			}
 		},
 		"node_modules/expect": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.1.0.tgz",
-			"integrity": "sha512-BjTOhEHlQVAXJqkgmxRt33ZbA8H+NLKpZ+Ff0qsFEOhPMNNcdJ160TocOSyiQS8ZNEUHXozg2ykBDboySPTSKQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.1.1.tgz",
+			"integrity": "sha512-OKe7cdic4qbfWd/CcgwJvvCrNX2KWfuMZee9AfJHL1gTYmvqjBjZG1a2NwfhspBzxzlXwsN75WWpKTYfsJpBxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/expect-utils": "30.1.0",
+				"@jest/expect-utils": "30.1.1",
 				"@jest/get-type": "30.1.0",
-				"jest-matcher-utils": "30.1.0",
+				"jest-matcher-utils": "30.1.1",
 				"jest-message-util": "30.1.0",
 				"jest-mock": "30.0.5",
 				"jest-util": "30.0.5"
@@ -4239,16 +4239,16 @@
 			}
 		},
 		"node_modules/jest": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-30.1.0.tgz",
-			"integrity": "sha512-4/QcV9Yw4+O3Hsjj/71s4fz2WHdJuXd11bbEJYeK7kxF/bZ1Kx1aCjBaXQ5eTeSLSLv3/XwhAhFQaX/KnTF/yw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.1.1.tgz",
+			"integrity": "sha512-yC3JvpP/ZcAZX5rYCtXO/g9k6VTCQz0VFE2v1FpxytWzUqfDtu0XL/pwnNvptzYItvGwomh1ehomRNMOyhCJKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.1.0",
+				"@jest/core": "30.1.1",
 				"@jest/types": "30.0.5",
 				"import-local": "^3.2.0",
-				"jest-cli": "30.1.0"
+				"jest-cli": "30.1.1"
 			},
 			"bin": {
 				"jest": "bin/jest.js"
@@ -4281,15 +4281,15 @@
 			}
 		},
 		"node_modules/jest-circus": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.0.tgz",
-			"integrity": "sha512-+59Jn7UmRwWiC9GV2mKdf6ei2SGE2/QwO3fn+G7gm3XprNCJsbn+8VFdkI7vKsyRH8yzzPXMnF88XCBcYy8+PQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.1.tgz",
+			"integrity": "sha512-M3Vd4x5wD7eSJspuTvRF55AkOOBndRxgW3gqQBDlFvbH3X+ASdi8jc+EqXEeAFd/UHulVYIlC4XKJABOhLw6UA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.1.0",
-				"@jest/expect": "30.1.0",
-				"@jest/test-result": "30.1.0",
+				"@jest/environment": "30.1.1",
+				"@jest/expect": "30.1.1",
+				"@jest/test-result": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
@@ -4297,10 +4297,10 @@
 				"dedent": "^1.6.0",
 				"is-generator-fn": "^2.1.0",
 				"jest-each": "30.1.0",
-				"jest-matcher-utils": "30.1.0",
+				"jest-matcher-utils": "30.1.1",
 				"jest-message-util": "30.1.0",
-				"jest-runtime": "30.1.0",
-				"jest-snapshot": "30.1.0",
+				"jest-runtime": "30.1.1",
+				"jest-snapshot": "30.1.1",
 				"jest-util": "30.0.5",
 				"p-limit": "^3.1.0",
 				"pretty-format": "30.0.5",
@@ -4313,19 +4313,19 @@
 			}
 		},
 		"node_modules/jest-cli": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.0.tgz",
-			"integrity": "sha512-H18qsWNR73XNzHbafx+UrP8L4EcziiG41S192You2tfellKSj5BERpAovjh+RMHtuCId4F50VC/JuwPVNaFkRg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.1.tgz",
+			"integrity": "sha512-xm9llxuh5OoI5KZaYzlMhklryHBwg9LZy/gEaaMlXlxb+cZekGNzukU0iblbDo3XOBuN6N0CgK4ykgNRYSEb6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/core": "30.1.0",
-				"@jest/test-result": "30.1.0",
+				"@jest/core": "30.1.1",
+				"@jest/test-result": "30.1.1",
 				"@jest/types": "30.0.5",
 				"chalk": "^4.1.2",
 				"exit-x": "^0.2.2",
 				"import-local": "^3.2.0",
-				"jest-config": "30.1.0",
+				"jest-config": "30.1.1",
 				"jest-util": "30.0.5",
 				"jest-validate": "30.1.0",
 				"yargs": "^17.7.2"
@@ -4346,29 +4346,29 @@
 			}
 		},
 		"node_modules/jest-config": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.0.tgz",
-			"integrity": "sha512-XqpN5l/DkQQJIFig+eZL2KiBTXrhV9MUXQtstX0ES3XhgIujQppUagF79CI86ES3pp/UVVJVwQyCBt89I9nsJA==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.1.tgz",
+			"integrity": "sha512-xuPGUGDw+9fPPnGmddnLnHS/mhKUiJOW7K65vErYmglEPKq65NKwSRchkQ7iv6gqjs2l+YNEsAtbsplxozdOWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/core": "^7.27.4",
 				"@jest/get-type": "30.1.0",
 				"@jest/pattern": "30.0.1",
-				"@jest/test-sequencer": "30.1.0",
+				"@jest/test-sequencer": "30.1.1",
 				"@jest/types": "30.0.5",
-				"babel-jest": "30.1.0",
+				"babel-jest": "30.1.1",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"deepmerge": "^4.3.1",
 				"glob": "^10.3.10",
 				"graceful-fs": "^4.2.11",
-				"jest-circus": "30.1.0",
+				"jest-circus": "30.1.1",
 				"jest-docblock": "30.0.1",
-				"jest-environment-node": "30.1.0",
+				"jest-environment-node": "30.1.1",
 				"jest-regex-util": "30.0.1",
 				"jest-resolve": "30.1.0",
-				"jest-runner": "30.1.0",
+				"jest-runner": "30.1.1",
 				"jest-util": "30.0.5",
 				"jest-validate": "30.1.0",
 				"micromatch": "^4.0.8",
@@ -4398,9 +4398,9 @@
 			}
 		},
 		"node_modules/jest-diff": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.0.tgz",
-			"integrity": "sha512-DHkvlHONjXknCIzYqFCIqH9uT0G6ZMN0U9Brb64BbQnCmVNcILa3FLTHh21h+E1oNRpaTvupTQTCiOhz2hx7hw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.1.tgz",
+			"integrity": "sha512-LUU2Gx8EhYxpdzTR6BmjL1ifgOAQJQELTHOiPv9KITaKjZvJ9Jmgigx01tuZ49id37LorpGc9dPBPlXTboXScw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4444,14 +4444,14 @@
 			}
 		},
 		"node_modules/jest-environment-node": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.0.tgz",
-			"integrity": "sha512-PoHcBVniqBcJubrLbMSrDIzD3RONpnqPeuNB1dOvU4aWzuV5vwViAtZtvAPtcZJW6i4n2YAAM+r8AvKWgUegmA==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.1.tgz",
+			"integrity": "sha512-IaMoaA6saxnJimqCppUDqKck+LKM0Jg+OxyMUIvs1yGd2neiC22o8zXo90k04+tO+49OmgMR4jTgM5e4B0S62Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.1.0",
-				"@jest/fake-timers": "30.1.0",
+				"@jest/environment": "30.1.1",
+				"@jest/fake-timers": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"jest-mock": "30.0.5",
@@ -4502,15 +4502,15 @@
 			}
 		},
 		"node_modules/jest-matcher-utils": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.0.tgz",
-			"integrity": "sha512-A0/O5+WzSmeBrsm1PMOLyKkKUekbCbAtgyViRvJagjMnOsuKQbukiHJy7y+7cTST9pvoi81NyHXz5Fc96UoKUQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.1.tgz",
+			"integrity": "sha512-SuH2QVemK48BNTqReti6FtjsMPFsSOD/ZzRxU1TttR7RiRsRSe78d03bb4Cx6D4bQC/80Q8U4VnaaAH9FlbZ9w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jest/get-type": "30.1.0",
 				"chalk": "^4.1.2",
-				"jest-diff": "30.1.0",
+				"jest-diff": "30.1.1",
 				"pretty-format": "30.0.5"
 			},
 			"engines": {
@@ -4602,30 +4602,30 @@
 			}
 		},
 		"node_modules/jest-resolve-dependencies": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.0.tgz",
-			"integrity": "sha512-pNWAfnzoqPWPYNaHwWmR34+5ib9DcUr5E+GLyIxjGxZEwdfgYnXLjPP3WfSW0VaTUnYes1Tl0cQNyBPr5plZmg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.1.tgz",
+			"integrity": "sha512-tRtaaoH8Ws1Gn1o/9pedt19dvVgr81WwdmvJSP9Ow3amOUOP2nN9j94u5jC9XlIfa2Q1FQKIWWQwL4ajqsjCGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"jest-regex-util": "30.0.1",
-				"jest-snapshot": "30.1.0"
+				"jest-snapshot": "30.1.1"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-runner": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.0.tgz",
-			"integrity": "sha512-Qd8JLWBooJQZBbstY9sdzt3B3Euj4cjDB0X+CeExURm1+BqZcXA5pSPb4XwbgPlBhTXkUva3bb0B94CFy9ZnZw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.1.tgz",
+			"integrity": "sha512-ATe6372SOfJvCRExtCAr06I4rGujwFdKg44b6i7/aOgFnULwjxzugJ0Y4AnG+jeSeQi8dU7R6oqLGmsxRUbErQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/console": "30.1.0",
-				"@jest/environment": "30.1.0",
-				"@jest/test-result": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/console": "30.1.1",
+				"@jest/environment": "30.1.1",
+				"@jest/test-result": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
@@ -4633,14 +4633,14 @@
 				"exit-x": "^0.2.2",
 				"graceful-fs": "^4.2.11",
 				"jest-docblock": "30.0.1",
-				"jest-environment-node": "30.1.0",
+				"jest-environment-node": "30.1.1",
 				"jest-haste-map": "30.1.0",
 				"jest-leak-detector": "30.1.0",
 				"jest-message-util": "30.1.0",
 				"jest-resolve": "30.1.0",
-				"jest-runtime": "30.1.0",
+				"jest-runtime": "30.1.1",
 				"jest-util": "30.0.5",
-				"jest-watcher": "30.1.0",
+				"jest-watcher": "30.1.1",
 				"jest-worker": "30.1.0",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
@@ -4650,18 +4650,18 @@
 			}
 		},
 		"node_modules/jest-runtime": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.0.tgz",
-			"integrity": "sha512-tPKb7oCj1D0CffhJrP+yheK/lHx2PrMaK21BmBD3YUirr4E4gxXa6jNb9r9yhiD0LRv9J5AoTmzJVYeyWPgt6A==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.1.tgz",
+			"integrity": "sha512-7sOyR0Oekw4OesQqqBHuYJRB52QtXiq0NNgLRzVogiMSxKCMiliUd6RrXHCnG5f12Age/ggidCBiQftzcA9XKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.1.0",
-				"@jest/fake-timers": "30.1.0",
-				"@jest/globals": "30.1.0",
+				"@jest/environment": "30.1.1",
+				"@jest/fake-timers": "30.1.1",
+				"@jest/globals": "30.1.1",
 				"@jest/source-map": "30.0.1",
-				"@jest/test-result": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/test-result": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
@@ -4674,7 +4674,7 @@
 				"jest-mock": "30.0.5",
 				"jest-regex-util": "30.0.1",
 				"jest-resolve": "30.1.0",
-				"jest-snapshot": "30.1.0",
+				"jest-snapshot": "30.1.1",
 				"jest-util": "30.0.5",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
@@ -4684,9 +4684,9 @@
 			}
 		},
 		"node_modules/jest-snapshot": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.0.tgz",
-			"integrity": "sha512-rBR/lTOi4ANpoqMhehPcGX/KGVXBEwe4V6HH27B3J1VZoXHXLk4nbMVGusbPc2y+of9/sU5uH2E998IlO7sLlQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.1.tgz",
+			"integrity": "sha512-7/iBEzoJqEt2TjkQY+mPLHP8cbPhLReZVkkxjTMzIzoTC4cZufg7HzKo/n9cIkXKj2LG0x3mmBHsZto+7TOmFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4695,17 +4695,17 @@
 				"@babel/plugin-syntax-jsx": "^7.27.1",
 				"@babel/plugin-syntax-typescript": "^7.27.1",
 				"@babel/types": "^7.27.3",
-				"@jest/expect-utils": "30.1.0",
+				"@jest/expect-utils": "30.1.1",
 				"@jest/get-type": "30.1.0",
-				"@jest/snapshot-utils": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/snapshot-utils": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"babel-preset-current-node-syntax": "^1.1.0",
 				"chalk": "^4.1.2",
-				"expect": "30.1.0",
+				"expect": "30.1.1",
 				"graceful-fs": "^4.2.11",
-				"jest-diff": "30.1.0",
-				"jest-matcher-utils": "30.1.0",
+				"jest-diff": "30.1.1",
+				"jest-matcher-utils": "30.1.1",
 				"jest-message-util": "30.1.0",
 				"jest-util": "30.0.5",
 				"pretty-format": "30.0.5",
@@ -4779,13 +4779,13 @@
 			}
 		},
 		"node_modules/jest-watcher": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.0.tgz",
-			"integrity": "sha512-aXSHgnDY2XhHt7zo8MkdN0ovl/DbmPEw2KTEZRtH+4MeLZ+eYwnO+RIUk4nVlIx1wwH+7FZk+wPOYSDWDW3F4w==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.1.tgz",
+			"integrity": "sha512-CrAQ73LlaS6KGQQw6NBi71g7qvP7scy+4+2c0jKX6+CWaYg85lZiig5nQQVTsS5a5sffNPL3uxXnaE9d7v9eQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/test-result": "30.1.0",
+				"@jest/test-result": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
@@ -7229,20 +7229,20 @@
 			"dev": true
 		},
 		"@emnapi/core": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
-			"integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
+			"integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"@emnapi/wasi-threads": "1.0.4",
+				"@emnapi/wasi-threads": "1.1.0",
 				"tslib": "^2.4.0"
 			}
 		},
 		"@emnapi/runtime": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
-			"integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+			"integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -7250,9 +7250,9 @@
 			}
 		},
 		"@emnapi/wasi-threads": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
-			"integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
+			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -7477,9 +7477,9 @@
 			"dev": true
 		},
 		"@jest/console": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.0.tgz",
-			"integrity": "sha512-qCEJKC53Z/mpRcxuK8wg0rnkUKoAeN+pet1T7Da/l8WPGzSWdE+RIUQM+LN5bQkNH5PBUab+ua9BiFTW0hKXSQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/console/-/console-30.1.1.tgz",
+			"integrity": "sha512-f7TGqR1k4GtN5pyFrKmq+ZVndesiwLU33yDpJIGMS9aW+j6hKjue7ljeAdznBsH9kAnxUWe2Y+Y3fLV/FJt3gA==",
 			"dev": true,
 			"requires": {
 				"@jest/types": "30.0.5",
@@ -7491,16 +7491,16 @@
 			}
 		},
 		"@jest/core": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.0.tgz",
-			"integrity": "sha512-pxSGVBndJFgHS8IuW6gT39kmbZwPvBZfnqJG4lN9xS++0hxuINsitpTswq8hiaZo+R/OYjVbuw0ee+UDsrK4aw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/core/-/core-30.1.1.tgz",
+			"integrity": "sha512-3ncU9peZ3D2VdgRkdZtUceTrDgX5yiDRwAFjtxNfU22IiZrpVWlv/FogzDLYSJQptQGfFo3PcHK86a2oG6WUGg==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "30.1.0",
+				"@jest/console": "30.1.1",
 				"@jest/pattern": "30.0.1",
-				"@jest/reporters": "30.1.0",
-				"@jest/test-result": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/reporters": "30.1.1",
+				"@jest/test-result": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",
@@ -7509,18 +7509,18 @@
 				"exit-x": "^0.2.2",
 				"graceful-fs": "^4.2.11",
 				"jest-changed-files": "30.0.5",
-				"jest-config": "30.1.0",
+				"jest-config": "30.1.1",
 				"jest-haste-map": "30.1.0",
 				"jest-message-util": "30.1.0",
 				"jest-regex-util": "30.0.1",
 				"jest-resolve": "30.1.0",
-				"jest-resolve-dependencies": "30.1.0",
-				"jest-runner": "30.1.0",
-				"jest-runtime": "30.1.0",
-				"jest-snapshot": "30.1.0",
+				"jest-resolve-dependencies": "30.1.1",
+				"jest-runner": "30.1.1",
+				"jest-runtime": "30.1.1",
+				"jest-snapshot": "30.1.1",
 				"jest-util": "30.0.5",
 				"jest-validate": "30.1.0",
-				"jest-watcher": "30.1.0",
+				"jest-watcher": "30.1.1",
 				"micromatch": "^4.0.8",
 				"pretty-format": "30.0.5",
 				"slash": "^3.0.0"
@@ -7533,40 +7533,40 @@
 			"dev": true
 		},
 		"@jest/environment": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.0.tgz",
-			"integrity": "sha512-a9yjDya5j/6jFFCbuF3wBlxHzaFNRpZBpO52VP80BzgEfLFY7ZlZnS8K3qZGlKYiA02tLCJL3R6+66l1lY05zQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.1.1.tgz",
+			"integrity": "sha512-yWHbU+3j7ehQE+NRpnxRvHvpUhoohIjMePBbIr8lfe0cWVb0WeTf80DNux1GPJa18CDHiIU5DtksGUfxcDE+Rw==",
 			"dev": true,
 			"requires": {
-				"@jest/fake-timers": "30.1.0",
+				"@jest/fake-timers": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"jest-mock": "30.0.5"
 			}
 		},
 		"@jest/expect": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.0.tgz",
-			"integrity": "sha512-Mnl7ZZ0NurliixNfFGTJ1aC+RBi2p9fFj+0RCsrXJDouaYZbQ7IZbmI9OWsf8f3BsBS/0UWCBztyXmHTn0Q8dQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.1.1.tgz",
+			"integrity": "sha512-3vHIHsF+qd3D8FU2c7U5l3rg1fhDwAYcGyHyZAi94YIlTwcJ+boNhRyJf373cl4wxbOX+0Q7dF40RTrTFTSuig==",
 			"dev": true,
 			"requires": {
-				"expect": "30.1.0",
-				"jest-snapshot": "30.1.0"
+				"expect": "30.1.1",
+				"jest-snapshot": "30.1.1"
 			}
 		},
 		"@jest/expect-utils": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.0.tgz",
-			"integrity": "sha512-3anLWpBieOCIvDYkEoHTK3351znRkmtAiOyURPRwn3IIT2TLlwqkgl6P7wk5mxwW04MZvHHx/gw1qGb3VPDmLA==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.1.tgz",
+			"integrity": "sha512-5YUHr27fpJ64dnvtu+tt11ewATynrHkGYD+uSFgRr8V2eFJis/vEXgToyLwccIwqBihVfz9jwio+Zr1ab1Zihw==",
 			"dev": true,
 			"requires": {
 				"@jest/get-type": "30.1.0"
 			}
 		},
 		"@jest/fake-timers": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.0.tgz",
-			"integrity": "sha512-Yei5/jGS0OZbPaLOUMrWVjAlwrlQWPkrBx2lp9M1kx79q2O4JJnrXRCEGgag06zN+a4M3FKatw7g1GYcNATPMg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.1.1.tgz",
+			"integrity": "sha512-fK/25dNgBNYPw3eLi2CRs57g1H04qBAFNMsUY3IRzkfx/m4THe0E1zF+yGQBOMKKc2XQVdc9EYbJ4hEm7/2UtA==",
 			"dev": true,
 			"requires": {
 				"@jest/types": "30.0.5",
@@ -7584,13 +7584,13 @@
 			"dev": true
 		},
 		"@jest/globals": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.0.tgz",
-			"integrity": "sha512-zZEscSJnh/yNA+7Rw0aNtIy6DZ9EQGWK2PD7Ig934Y/5xJOOGnLBgGKG4YNkORhkR4UZo33CKwaazSy1+Rfosw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.1.1.tgz",
+			"integrity": "sha512-NNUUkHT2TU/xztZl6r1UXvJL+zvCwmZsQDmK69fVHHcB9fBtlu3FInnzOve/ZoyKnWY8JXWJNT+Lkmu1+ubXUA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "30.1.0",
-				"@jest/expect": "30.1.0",
+				"@jest/environment": "30.1.1",
+				"@jest/expect": "30.1.1",
 				"@jest/types": "30.0.5",
 				"jest-mock": "30.0.5"
 			}
@@ -7606,15 +7606,15 @@
 			}
 		},
 		"@jest/reporters": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.0.tgz",
-			"integrity": "sha512-BJg8JUaJrX9Q01DUFs4+/P9XMsYivfoafXr/vjxy43rRebkd8ZC+NrxEh2tBdOBS5ow89dSL2mIcAFqASQCU3w==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.1.1.tgz",
+			"integrity": "sha512-Hb2Bq80kahOC6Sv2waEaH1rEU6VdFcM6WHaRBWQF9tf30+nJHxhl/Upbgo9+25f0mOgbphxvbwSMjSgy9gW/FA==",
 			"dev": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^0.2.3",
-				"@jest/console": "30.1.0",
-				"@jest/test-result": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/console": "30.1.1",
+				"@jest/test-result": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"@types/node": "*",
@@ -7646,9 +7646,9 @@
 			}
 		},
 		"@jest/snapshot-utils": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.0.tgz",
-			"integrity": "sha512-8Hc0WVaquUqVQ9J3inaJtV3EvkLzep81qtuS0l/gD7huGPEZCf6TZWugvaF6LpZARw6oLF291E5Y3e+eKcZe1w==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.1.1.tgz",
+			"integrity": "sha512-TkVBc9wuN22TT8hESRFmjjg/xIMu7z0J3UDYtIRydzCqlLPTB7jK1DDBKdnTUZ4zL3z3rnPpzV6rL1Uzh87sXg==",
 			"dev": true,
 			"requires": {
 				"@jest/types": "30.0.5",
@@ -7669,33 +7669,33 @@
 			}
 		},
 		"@jest/test-result": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.0.tgz",
-			"integrity": "sha512-ByBm3rucBDAeYUsArrOq6dnYIRsQ0dogs0DqOWaYjPvO4McVQYb/6dVNz9vIqz3hJbhb7b/XF5ZBLoTxUNJwbQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.1.1.tgz",
+			"integrity": "sha512-bMdj7fNu8iZuBPSnbVir5ezvWmVo4jrw7xDE+A33Yb3ENCoiJK9XgOLgal+rJ9XSKjsL7aPUMIo87zhN7I5o2w==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "30.1.0",
+				"@jest/console": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/istanbul-lib-coverage": "^2.0.6",
 				"collect-v8-coverage": "^1.0.2"
 			}
 		},
 		"@jest/test-sequencer": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.0.tgz",
-			"integrity": "sha512-qKfPCHMEHP+vLdGOVkoxbR42deneEdlAtJkn5z/h0HSfd8LJyUbTysO5esd1hJu9pXmeK6yA9ug1ccV+OJKFPg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.1.1.tgz",
+			"integrity": "sha512-yruRdLXSA3HYD/MTNykgJ6VYEacNcXDFRMqKVAwlYegmxICUiT/B++CNuhJnYJzKYks61iYnjVsMwbUqmmAYJg==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "30.1.0",
+				"@jest/test-result": "30.1.1",
 				"graceful-fs": "^4.2.11",
 				"jest-haste-map": "30.1.0",
 				"slash": "^3.0.0"
 			}
 		},
 		"@jest/transform": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.0.tgz",
-			"integrity": "sha512-OvzganIbExZDS2jl37re14XSJXK3sREyGP641RL+Ek1galupCMLWHlxop+4wQnVX7e3fxF6C3W16VzWdl2ducQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.1.1.tgz",
+			"integrity": "sha512-PHIA2AbAASBfk6evkNifvmx9lkOSkmvaQoO6VSpuL8+kQqDMHeDoJ7RU3YP1wWAMD7AyQn9UL5iheuFYCC4lqQ==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.27.4",
@@ -8382,12 +8382,12 @@
 			}
 		},
 		"babel-jest": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.0.tgz",
-			"integrity": "sha512-xoF2zwb3po3dOJMahde//mE284gcxp9WH8TTbo3Y102fas7Ga1mjGUwrw137RmvUkuA2liISRlg2BFQhmTfeHg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.1.1.tgz",
+			"integrity": "sha512-1bZfC/V03qBCzASvZpNFhx3Ouj6LgOd4KFJm4br/fYOS+tSSvVCE61QmcAVbMTwq/GoB7KN4pzGMoyr9cMxSvQ==",
 			"dev": true,
 			"requires": {
-				"@jest/transform": "30.1.0",
+				"@jest/transform": "30.1.1",
 				"@types/babel__core": "^7.20.5",
 				"babel-plugin-istanbul": "^7.0.0",
 				"babel-preset-jest": "30.0.1",
@@ -9034,14 +9034,14 @@
 			"dev": true
 		},
 		"expect": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-30.1.0.tgz",
-			"integrity": "sha512-BjTOhEHlQVAXJqkgmxRt33ZbA8H+NLKpZ+Ff0qsFEOhPMNNcdJ160TocOSyiQS8ZNEUHXozg2ykBDboySPTSKQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-30.1.1.tgz",
+			"integrity": "sha512-OKe7cdic4qbfWd/CcgwJvvCrNX2KWfuMZee9AfJHL1gTYmvqjBjZG1a2NwfhspBzxzlXwsN75WWpKTYfsJpBxg==",
 			"dev": true,
 			"requires": {
-				"@jest/expect-utils": "30.1.0",
+				"@jest/expect-utils": "30.1.1",
 				"@jest/get-type": "30.1.0",
-				"jest-matcher-utils": "30.1.0",
+				"jest-matcher-utils": "30.1.1",
 				"jest-message-util": "30.1.0",
 				"jest-mock": "30.0.5",
 				"jest-util": "30.0.5"
@@ -9579,15 +9579,15 @@
 			}
 		},
 		"jest": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-30.1.0.tgz",
-			"integrity": "sha512-4/QcV9Yw4+O3Hsjj/71s4fz2WHdJuXd11bbEJYeK7kxF/bZ1Kx1aCjBaXQ5eTeSLSLv3/XwhAhFQaX/KnTF/yw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-30.1.1.tgz",
+			"integrity": "sha512-yC3JvpP/ZcAZX5rYCtXO/g9k6VTCQz0VFE2v1FpxytWzUqfDtu0XL/pwnNvptzYItvGwomh1ehomRNMOyhCJKw==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "30.1.0",
+				"@jest/core": "30.1.1",
 				"@jest/types": "30.0.5",
 				"import-local": "^3.2.0",
-				"jest-cli": "30.1.0"
+				"jest-cli": "30.1.1"
 			}
 		},
 		"jest-changed-files": {
@@ -9602,14 +9602,14 @@
 			}
 		},
 		"jest-circus": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.0.tgz",
-			"integrity": "sha512-+59Jn7UmRwWiC9GV2mKdf6ei2SGE2/QwO3fn+G7gm3XprNCJsbn+8VFdkI7vKsyRH8yzzPXMnF88XCBcYy8+PQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.1.1.tgz",
+			"integrity": "sha512-M3Vd4x5wD7eSJspuTvRF55AkOOBndRxgW3gqQBDlFvbH3X+ASdi8jc+EqXEeAFd/UHulVYIlC4XKJABOhLw6UA==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "30.1.0",
-				"@jest/expect": "30.1.0",
-				"@jest/test-result": "30.1.0",
+				"@jest/environment": "30.1.1",
+				"@jest/expect": "30.1.1",
+				"@jest/test-result": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
@@ -9617,10 +9617,10 @@
 				"dedent": "^1.6.0",
 				"is-generator-fn": "^2.1.0",
 				"jest-each": "30.1.0",
-				"jest-matcher-utils": "30.1.0",
+				"jest-matcher-utils": "30.1.1",
 				"jest-message-util": "30.1.0",
-				"jest-runtime": "30.1.0",
-				"jest-snapshot": "30.1.0",
+				"jest-runtime": "30.1.1",
+				"jest-snapshot": "30.1.1",
 				"jest-util": "30.0.5",
 				"p-limit": "^3.1.0",
 				"pretty-format": "30.0.5",
@@ -9630,46 +9630,46 @@
 			}
 		},
 		"jest-cli": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.0.tgz",
-			"integrity": "sha512-H18qsWNR73XNzHbafx+UrP8L4EcziiG41S192You2tfellKSj5BERpAovjh+RMHtuCId4F50VC/JuwPVNaFkRg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.1.1.tgz",
+			"integrity": "sha512-xm9llxuh5OoI5KZaYzlMhklryHBwg9LZy/gEaaMlXlxb+cZekGNzukU0iblbDo3XOBuN6N0CgK4ykgNRYSEb6g==",
 			"dev": true,
 			"requires": {
-				"@jest/core": "30.1.0",
-				"@jest/test-result": "30.1.0",
+				"@jest/core": "30.1.1",
+				"@jest/test-result": "30.1.1",
 				"@jest/types": "30.0.5",
 				"chalk": "^4.1.2",
 				"exit-x": "^0.2.2",
 				"import-local": "^3.2.0",
-				"jest-config": "30.1.0",
+				"jest-config": "30.1.1",
 				"jest-util": "30.0.5",
 				"jest-validate": "30.1.0",
 				"yargs": "^17.7.2"
 			}
 		},
 		"jest-config": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.0.tgz",
-			"integrity": "sha512-XqpN5l/DkQQJIFig+eZL2KiBTXrhV9MUXQtstX0ES3XhgIujQppUagF79CI86ES3pp/UVVJVwQyCBt89I9nsJA==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.1.1.tgz",
+			"integrity": "sha512-xuPGUGDw+9fPPnGmddnLnHS/mhKUiJOW7K65vErYmglEPKq65NKwSRchkQ7iv6gqjs2l+YNEsAtbsplxozdOWg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.27.4",
 				"@jest/get-type": "30.1.0",
 				"@jest/pattern": "30.0.1",
-				"@jest/test-sequencer": "30.1.0",
+				"@jest/test-sequencer": "30.1.1",
 				"@jest/types": "30.0.5",
-				"babel-jest": "30.1.0",
+				"babel-jest": "30.1.1",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"deepmerge": "^4.3.1",
 				"glob": "^10.3.10",
 				"graceful-fs": "^4.2.11",
-				"jest-circus": "30.1.0",
+				"jest-circus": "30.1.1",
 				"jest-docblock": "30.0.1",
-				"jest-environment-node": "30.1.0",
+				"jest-environment-node": "30.1.1",
 				"jest-regex-util": "30.0.1",
 				"jest-resolve": "30.1.0",
-				"jest-runner": "30.1.0",
+				"jest-runner": "30.1.1",
 				"jest-util": "30.0.5",
 				"jest-validate": "30.1.0",
 				"micromatch": "^4.0.8",
@@ -9680,9 +9680,9 @@
 			}
 		},
 		"jest-diff": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.0.tgz",
-			"integrity": "sha512-DHkvlHONjXknCIzYqFCIqH9uT0G6ZMN0U9Brb64BbQnCmVNcILa3FLTHh21h+E1oNRpaTvupTQTCiOhz2hx7hw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.1.tgz",
+			"integrity": "sha512-LUU2Gx8EhYxpdzTR6BmjL1ifgOAQJQELTHOiPv9KITaKjZvJ9Jmgigx01tuZ49id37LorpGc9dPBPlXTboXScw==",
 			"dev": true,
 			"requires": {
 				"@jest/diff-sequences": "30.0.1",
@@ -9714,13 +9714,13 @@
 			}
 		},
 		"jest-environment-node": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.0.tgz",
-			"integrity": "sha512-PoHcBVniqBcJubrLbMSrDIzD3RONpnqPeuNB1dOvU4aWzuV5vwViAtZtvAPtcZJW6i4n2YAAM+r8AvKWgUegmA==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.1.1.tgz",
+			"integrity": "sha512-IaMoaA6saxnJimqCppUDqKck+LKM0Jg+OxyMUIvs1yGd2neiC22o8zXo90k04+tO+49OmgMR4jTgM5e4B0S62Q==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "30.1.0",
-				"@jest/fake-timers": "30.1.0",
+				"@jest/environment": "30.1.1",
+				"@jest/fake-timers": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"jest-mock": "30.0.5",
@@ -9758,14 +9758,14 @@
 			}
 		},
 		"jest-matcher-utils": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.0.tgz",
-			"integrity": "sha512-A0/O5+WzSmeBrsm1PMOLyKkKUekbCbAtgyViRvJagjMnOsuKQbukiHJy7y+7cTST9pvoi81NyHXz5Fc96UoKUQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.1.tgz",
+			"integrity": "sha512-SuH2QVemK48BNTqReti6FtjsMPFsSOD/ZzRxU1TttR7RiRsRSe78d03bb4Cx6D4bQC/80Q8U4VnaaAH9FlbZ9w==",
 			"dev": true,
 			"requires": {
 				"@jest/get-type": "30.1.0",
 				"chalk": "^4.1.2",
-				"jest-diff": "30.1.0",
+				"jest-diff": "30.1.1",
 				"pretty-format": "30.0.5"
 			}
 		},
@@ -9827,25 +9827,25 @@
 			}
 		},
 		"jest-resolve-dependencies": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.0.tgz",
-			"integrity": "sha512-pNWAfnzoqPWPYNaHwWmR34+5ib9DcUr5E+GLyIxjGxZEwdfgYnXLjPP3WfSW0VaTUnYes1Tl0cQNyBPr5plZmg==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.1.1.tgz",
+			"integrity": "sha512-tRtaaoH8Ws1Gn1o/9pedt19dvVgr81WwdmvJSP9Ow3amOUOP2nN9j94u5jC9XlIfa2Q1FQKIWWQwL4ajqsjCGQ==",
 			"dev": true,
 			"requires": {
 				"jest-regex-util": "30.0.1",
-				"jest-snapshot": "30.1.0"
+				"jest-snapshot": "30.1.1"
 			}
 		},
 		"jest-runner": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.0.tgz",
-			"integrity": "sha512-Qd8JLWBooJQZBbstY9sdzt3B3Euj4cjDB0X+CeExURm1+BqZcXA5pSPb4XwbgPlBhTXkUva3bb0B94CFy9ZnZw==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.1.1.tgz",
+			"integrity": "sha512-ATe6372SOfJvCRExtCAr06I4rGujwFdKg44b6i7/aOgFnULwjxzugJ0Y4AnG+jeSeQi8dU7R6oqLGmsxRUbErQ==",
 			"dev": true,
 			"requires": {
-				"@jest/console": "30.1.0",
-				"@jest/environment": "30.1.0",
-				"@jest/test-result": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/console": "30.1.1",
+				"@jest/environment": "30.1.1",
+				"@jest/test-result": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
@@ -9853,31 +9853,31 @@
 				"exit-x": "^0.2.2",
 				"graceful-fs": "^4.2.11",
 				"jest-docblock": "30.0.1",
-				"jest-environment-node": "30.1.0",
+				"jest-environment-node": "30.1.1",
 				"jest-haste-map": "30.1.0",
 				"jest-leak-detector": "30.1.0",
 				"jest-message-util": "30.1.0",
 				"jest-resolve": "30.1.0",
-				"jest-runtime": "30.1.0",
+				"jest-runtime": "30.1.1",
 				"jest-util": "30.0.5",
-				"jest-watcher": "30.1.0",
+				"jest-watcher": "30.1.1",
 				"jest-worker": "30.1.0",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
 			}
 		},
 		"jest-runtime": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.0.tgz",
-			"integrity": "sha512-tPKb7oCj1D0CffhJrP+yheK/lHx2PrMaK21BmBD3YUirr4E4gxXa6jNb9r9yhiD0LRv9J5AoTmzJVYeyWPgt6A==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.1.1.tgz",
+			"integrity": "sha512-7sOyR0Oekw4OesQqqBHuYJRB52QtXiq0NNgLRzVogiMSxKCMiliUd6RrXHCnG5f12Age/ggidCBiQftzcA9XKw==",
 			"dev": true,
 			"requires": {
-				"@jest/environment": "30.1.0",
-				"@jest/fake-timers": "30.1.0",
-				"@jest/globals": "30.1.0",
+				"@jest/environment": "30.1.1",
+				"@jest/fake-timers": "30.1.1",
+				"@jest/globals": "30.1.1",
 				"@jest/source-map": "30.0.1",
-				"@jest/test-result": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/test-result": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
@@ -9890,16 +9890,16 @@
 				"jest-mock": "30.0.5",
 				"jest-regex-util": "30.0.1",
 				"jest-resolve": "30.1.0",
-				"jest-snapshot": "30.1.0",
+				"jest-snapshot": "30.1.1",
 				"jest-util": "30.0.5",
 				"slash": "^3.0.0",
 				"strip-bom": "^4.0.0"
 			}
 		},
 		"jest-snapshot": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.0.tgz",
-			"integrity": "sha512-rBR/lTOi4ANpoqMhehPcGX/KGVXBEwe4V6HH27B3J1VZoXHXLk4nbMVGusbPc2y+of9/sU5uH2E998IlO7sLlQ==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.1.1.tgz",
+			"integrity": "sha512-7/iBEzoJqEt2TjkQY+mPLHP8cbPhLReZVkkxjTMzIzoTC4cZufg7HzKo/n9cIkXKj2LG0x3mmBHsZto+7TOmFg==",
 			"dev": true,
 			"requires": {
 				"@babel/core": "^7.27.4",
@@ -9907,17 +9907,17 @@
 				"@babel/plugin-syntax-jsx": "^7.27.1",
 				"@babel/plugin-syntax-typescript": "^7.27.1",
 				"@babel/types": "^7.27.3",
-				"@jest/expect-utils": "30.1.0",
+				"@jest/expect-utils": "30.1.1",
 				"@jest/get-type": "30.1.0",
-				"@jest/snapshot-utils": "30.1.0",
-				"@jest/transform": "30.1.0",
+				"@jest/snapshot-utils": "30.1.1",
+				"@jest/transform": "30.1.1",
 				"@jest/types": "30.0.5",
 				"babel-preset-current-node-syntax": "^1.1.0",
 				"chalk": "^4.1.2",
-				"expect": "30.1.0",
+				"expect": "30.1.1",
 				"graceful-fs": "^4.2.11",
-				"jest-diff": "30.1.0",
-				"jest-matcher-utils": "30.1.0",
+				"jest-diff": "30.1.1",
+				"jest-matcher-utils": "30.1.1",
 				"jest-message-util": "30.1.0",
 				"jest-util": "30.0.5",
 				"pretty-format": "30.0.5",
@@ -9970,12 +9970,12 @@
 			}
 		},
 		"jest-watcher": {
-			"version": "30.1.0",
-			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.0.tgz",
-			"integrity": "sha512-aXSHgnDY2XhHt7zo8MkdN0ovl/DbmPEw2KTEZRtH+4MeLZ+eYwnO+RIUk4nVlIx1wwH+7FZk+wPOYSDWDW3F4w==",
+			"version": "30.1.1",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.1.1.tgz",
+			"integrity": "sha512-CrAQ73LlaS6KGQQw6NBi71g7qvP7scy+4+2c0jKX6+CWaYg85lZiig5nQQVTsS5a5sffNPL3uxXnaE9d7v9eQg==",
 			"dev": true,
 			"requires": {
-				"@jest/test-result": "30.1.0",
+				"@jest/test-result": "30.1.1",
 				"@jest/types": "30.0.5",
 				"@types/node": "*",
 				"ansi-escapes": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
 		"eslint-plugin-jest": "^29.0.1",
 		"eslint-plugin-prettier": "^5.5.4",
 		"globals": "^16.3.0",
-		"jest": "^30.1.0",
+		"jest": "^30.1.1",
 		"open-cli": "^8.0.0",
 		"prettier": "^3.6.2",
 		"ts-jest": "^29.4.1",

--- a/package.json
+++ b/package.json
@@ -74,13 +74,13 @@
 		"@types/debug": "^4.1.12",
 		"@types/events-alias": "npm:@types/events@^3.0.3",
 		"awaitqueue": "^3.2.4",
+		"browser-dtector": "^4.1.0",
 		"debug": "^4.4.1",
 		"events-alias": "npm:events@^3.3.0",
 		"fake-mediastreamtrack": "^2.1.4",
 		"h264-profile-level-id": "^2.2.3",
 		"sdp-transform": "^2.15.0",
-		"supports-color": "^10.2.0",
-		"ua-parser-js": "^2.0.4"
+		"supports-color": "^10.2.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.34.0",

--- a/src/Device.ts
+++ b/src/Device.ts
@@ -1,4 +1,7 @@
-import { UAParser } from 'ua-parser-js';
+import BrowserDetector, {
+	KnownBrowsers,
+	KnownPlatforms,
+} from 'browser-dtector';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './enhancedEvents';
 import { UnsupportedError, InvalidStateError } from './errors';
@@ -44,28 +47,7 @@ export type DeviceOptions = {
 };
 
 /**
- * Async mediasoup-client Handler detection. More powerful than
- * `detectDevice()`.
- */
-export async function detectDeviceAsync(
-	userAgent?: string
-): Promise<BuiltinHandlerName | undefined> {
-	logger.debug('detectDeviceAsync() [userAgent:%s]', userAgent);
-
-	if (!userAgent && typeof navigator === 'object') {
-		userAgent = navigator.userAgent;
-	}
-
-	const uaParserResult = await UAParser(userAgent).withFeatureCheck();
-
-	return detectDeviceImpl(uaParserResult);
-}
-
-/**
  * Sync mediasoup-client Handler detection.
- *
- * @deprecated It only relies on navigator.userAgent. Use `detectDeviceAsync()`
- * instead.
  */
 export function detectDevice(
 	userAgent?: string
@@ -76,9 +58,30 @@ export function detectDevice(
 		userAgent = navigator.userAgent;
 	}
 
-	const uaParserResult = UAParser(userAgent);
+	const browserDetector = new BrowserDetector(userAgent);
 
-	return detectDeviceImpl(uaParserResult);
+	return detectDeviceImpl(browserDetector);
+}
+
+/**
+ * Async mediasoup-client Handler detection.
+ *
+ * @remarks
+ * - Currently it runs same logic than `detectDevice()`.
+ * - In the future this function could give better results than `detectDevice()`.
+ */
+export async function detectDeviceAsync(
+	userAgent?: string
+): Promise<BuiltinHandlerName | undefined> {
+	logger.debug('detectDeviceAsync() [userAgent:%s]', userAgent);
+
+	if (!userAgent && typeof navigator === 'object') {
+		userAgent = navigator.userAgent;
+	}
+
+	const browserDetector = new BrowserDetector(userAgent);
+
+	return detectDeviceImpl(browserDetector);
 }
 
 export type DeviceObserver = EnhancedEventEmitter<DeviceObserverEvents>;
@@ -488,7 +491,7 @@ export class Device {
 }
 
 function detectDeviceImpl(
-	uaParserResult: UAParser.IResult
+	browserDetector: BrowserDetector
 ): BuiltinHandlerName | undefined {
 	// React-Native.
 	if (typeof navigator === 'object' && navigator.product === 'ReactNative') {
@@ -509,65 +512,67 @@ function detectDeviceImpl(
 	}
 	// Browser.
 	else {
-		logger.debug(
-			'detectDeviceImpl() | browser detected [userAgent:%s, parsed:%o]',
-			uaParserResult.ua,
-			uaParserResult
+		const parsed = browserDetector.parseUserAgent();
+
+		const browserMajorVersionMatch = /^\d+/.exec(parsed?.shortVersion ?? '0');
+		const browserMajorVersion = parseInt(
+			browserMajorVersionMatch?.[0] ?? '0',
+			10
 		);
 
-		const browser = uaParserResult.browser;
-		const browserName = browser.name?.toLowerCase();
-		const browserVersion = parseInt(browser.major ?? '0');
-		const engine = uaParserResult.engine;
-		const engineName = engine.name?.toLowerCase();
-		const os = uaParserResult.os;
-		const osName = os.name?.toLowerCase();
-		const osVersion = parseFloat(os.version ?? '0');
-		const device = uaParserResult.device;
-		const deviceModel = device.model?.toLowerCase();
+		const isIOS =
+			parsed.platform === KnownPlatforms.iphone ||
+			parsed.platform === KnownPlatforms.ipad ||
+			(parsed.platform === KnownPlatforms.mac &&
+				(parsed.isMobile || parsed.isTablet || navigator?.maxTouchPoints >= 2));
 
-		const isIOS = osName === 'ios' || deviceModel === 'ipad';
+		const isChrome = parsed.isChrome;
+		const isFirefox = parsed.isFireFox;
+		const isSafari = parsed.isSafari;
+		const isEdge = parsed.isEdge;
+		const isElectron =
+			parsed.isDesktop && parsed.name === KnownBrowsers.electron;
+		const isWebkit = parsed.isWebkit;
 
-		const isChrome =
-			browserName &&
-			[
-				'chrome',
-				'chromium',
-				'mobile chrome',
-				'chrome webview',
-				'chrome headless',
-			].includes(browserName);
+		// For logging purposes.
+		const result = {
+			browserMajorVersion,
+			isIOS,
+			isChrome,
+			isFirefox,
+			isSafari,
+			isElectron,
+			isWebkit,
+		};
 
-		const isFirefox =
-			browserName &&
-			['firefox', 'mobile firefox', 'mobile focus'].includes(browserName);
-
-		const isSafari =
-			browserName && ['safari', 'mobile safari'].includes(browserName);
-
-		const isEdge = browserName && ['edge'].includes(browserName);
+		logger.debug(
+			'detectDeviceImpl() | detected browser [userAgent:%s, parsed:%o, result:%o]',
+			parsed.userAgent,
+			parsed,
+			result
+		);
 
 		// Chrome, Chromium, and Edge.
-		if ((isChrome || isEdge) && !isIOS && browserVersion >= 111) {
+		if ((isChrome || isEdge) && !isIOS && browserMajorVersion >= 111) {
 			return 'Chrome111';
 		} else if (
-			(isChrome && !isIOS && browserVersion >= 74) ||
-			(isEdge && !isIOS && browserVersion >= 88)
+			(isChrome && !isIOS && browserMajorVersion >= 74) ||
+			(isEdge && !isIOS && browserMajorVersion >= 88)
 		) {
 			return 'Chrome74';
 		}
+		// Electron.
+		else if (isElectron) {
+			return 'Chrome111';
+		}
 		// Firefox.
-		else if (isFirefox && !isIOS && browserVersion >= 120) {
+		else if (isFirefox && !isIOS && browserMajorVersion >= 120) {
 			return 'Firefox120';
 		}
-		// Firefox on iOS (so Safari).
-		else if (isFirefox && isIOS && osVersion >= 14.3) {
-			return 'Safari12';
-		}
-		// Safari with Unified-Plan support enabled.
+		// Safari.
 		else if (
 			isSafari &&
-			browserVersion >= 12 &&
+			browserMajorVersion >= 12 &&
 			typeof RTCRtpTransceiver !== 'undefined' &&
 			RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection')
 		) {
@@ -575,7 +580,6 @@ function detectDeviceImpl(
 		}
 		// Best effort for WebKit based browsers in iOS.
 		else if (
-			engineName === 'webkit' &&
 			isIOS &&
 			typeof RTCRtpTransceiver !== 'undefined' &&
 			RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection')
@@ -583,9 +587,8 @@ function detectDeviceImpl(
 			return 'Safari12';
 		}
 		// Best effort for Chromium based browsers.
-		else if (engineName === 'blink') {
-			// eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
-			const match = uaParserResult.ua.match(
+		else if (isWebkit) {
+			const match = browserDetector.userAgent?.match(
 				/(?:(?:Chrome|Chromium))[ /](\w+)/i
 			);
 
@@ -604,9 +607,10 @@ function detectDeviceImpl(
 		// Unsupported browser.
 		else {
 			logger.warn(
-				'detectDeviceImpl() | browser not supported [name:%s, version:%s]',
-				browserName,
-				browserVersion
+				'detectDeviceImpl() | browser not supported [userAgent:%s, parsed:%o, result:%o]',
+				parsed.userAgent,
+				parsed,
+				result
 			);
 
 			return undefined;

--- a/src/Device.ts
+++ b/src/Device.ts
@@ -524,7 +524,9 @@ function detectDeviceImpl(
 			parsed.platform === KnownPlatforms.iphone ||
 			parsed.platform === KnownPlatforms.ipad ||
 			(parsed.platform === KnownPlatforms.mac &&
-				(parsed.isMobile || parsed.isTablet || navigator?.maxTouchPoints >= 2));
+				(parsed.isMobile ||
+					parsed.isTablet ||
+					(typeof navigator === 'object' && navigator?.maxTouchPoints >= 2)));
 
 		const isChrome = parsed.isChrome;
 		const isFirefox = parsed.isFireFox;

--- a/src/test/uaTestCases.ts
+++ b/src/test/uaTestCases.ts
@@ -48,9 +48,9 @@ export const uaTestCases: UATestCase[] = [
 		expect: 'Chrome74',
 	},
 	{
-		desc: 'Firefox (iOS) - Unsupported',
-		ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/114.0 Mobile/15E148 Safari/605.1.15',
-		expect: undefined,
+		desc: 'Firefox (iOS)',
+		ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/142.0.1 Mobile/15E148 Safari/605.1.15',
+		expect: 'Safari12',
 	},
 	{
 		desc: 'In-app WKWebView (iOS) (TikTok)',

--- a/src/test/uaTestCases.ts
+++ b/src/test/uaTestCases.ts
@@ -18,6 +18,11 @@ export const uaTestCases: UATestCase[] = [
 		expect: 'Chrome111',
 	},
 	{
+		desc: 'iPhone iOS 16',
+		ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Mobile/15E148 Safari/604.1',
+		expect: 'Safari12',
+	},
+	{
 		desc: 'Generic Android Chrome 112',
 		ua: 'Mozilla/5.0 (Linux; Android 13; M2012K11AG) AppleWebKit/537.36 (KHTML, like Gecko) Soul/4.0 Chrome/112.0.5615.135 Mobile Safari/537.36',
 		expect: 'Chrome111',

--- a/src/test/uaTestCases.ts
+++ b/src/test/uaTestCases.ts
@@ -63,6 +63,11 @@ export const uaTestCases: UATestCase[] = [
 		expect: 'Safari12',
 	},
 	{
+		desc: 'Custom Webview in iPad',
+		ua: 'Mozilla/5.0 (iPad; CPU iPadOS 16_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Mobile/15E148 Safari/604.1 MyApp/1.0',
+		expect: 'Safari12',
+	},
+	{
 		desc: 'Chrome Mobile (iOS)',
 		ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/114.0.5735.124 Mobile/15E148 Safari/604.1',
 		expect: 'Safari12',
@@ -77,5 +82,10 @@ export const uaTestCases: UATestCase[] = [
 		desc: 'Zoom App Marketplace browser - Unsupported',
 		ua: 'Mozilla/5.0 ZoomWebKit/537.36 (KHTML, like Gecko) ZoomApps/1.0',
 		expect: undefined,
+	},
+	{
+		desc: 'Electron in Windows',
+		ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Electron/37.4.0 Chrome/138.0.7204.243 Safari/537.36',
+		expect: 'Chrome111',
 	},
 ];

--- a/src/test/uaTestCases.ts
+++ b/src/test/uaTestCases.ts
@@ -68,13 +68,13 @@ export const uaTestCases: UATestCase[] = [
 		expect: 'Safari12',
 	},
 	{
-		desc: 'Fake Foo Invalid Browser',
+		desc: 'Fake Foo Invalid Browser - Unsupported',
 		ua: 'Fake/5.0 (Foo; Bar Lalala OS_19.5) Foo/22.2',
 		expect: undefined,
 	},
 	{
 		// Zoom App Marketplace browser.
-		desc: 'Zoom App Marketplace browser',
+		desc: 'Zoom App Marketplace browser - Unsupported',
 		ua: 'Mozilla/5.0 ZoomWebKit/537.36 (KHTML, like Gecko) ZoomApps/1.0',
 		expect: undefined,
 	},


### PR DESCRIPTION
## Details

- Fixes https://github.com/versatica/mediasoup-client/issues/284.
- Remove [ua-parser-js](https://github.com/faisalman/ua-parser-js) library because its license is AGPL. More details about this in issue https://github.com/versatica/mediasoup-client/issues/284.
- Use [browser-dtector](https://github.com/sibiraj-s/browser-dtector) library which has MIT license.
- `browser-dtector` is definitively not as advanced as `ua-parser-js`, but hopefully no major regressions will happen in existing apps.