### PR TITLE
Fix native RTP capabilities not being normalized

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -276,7 +276,7 @@ export class Device {
 		);
 
 		// This may throw.
-		ortc.validateRtpCapabilities(clonedRouterRtpCapabilities);
+		ortc.validateAndNormalizeRtpCapabilities(clonedRouterRtpCapabilities);
 
 		const { getNativeRtpCapabilities, getNativeSctpCapabilities } =
 			this._handlerFactory;
@@ -286,7 +286,7 @@ export class Device {
 		);
 
 		// This may throw.
-		ortc.validateRtpCapabilities(clonedNativeRtpCapabilities);
+		ortc.validateAndNormalizeRtpCapabilities(clonedNativeRtpCapabilities);
 
 		logger.debug(
 			'load() | got native RTP capabilities:%o',
@@ -317,7 +317,7 @@ export class Device {
 		);
 
 		// This may throw.
-		ortc.validateRtpCapabilities(this._recvRtpCapabilities);
+		ortc.validateAndNormalizeRtpCapabilities(this._recvRtpCapabilities);
 
 		logger.debug(
 			'load() | got receiving RTP capabilities:%o',

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -594,7 +594,7 @@ export class Transport<
 
 					try {
 						// This will fill rtpParameters's missing fields with default values.
-						ortc.validateRtpParameters(rtpParameters);
+						ortc.validateAndNormalizeRtpParameters(rtpParameters);
 
 						const { id } = await new Promise<{ id: string }>(
 							(resolve, reject) => {
@@ -771,7 +771,7 @@ export class Transport<
 				});
 
 			// This will fill sctpStreamParameters's missing fields with default values.
-			ortc.validateSctpStreamParameters(sctpStreamParameters);
+			ortc.validateAndNormalizeSctpStreamParameters(sctpStreamParameters);
 
 			const { id } = await new Promise<{ id: string }>((resolve, reject) => {
 				this.safeEmit(
@@ -842,7 +842,7 @@ export class Transport<
 		const clonedSctpStreamParameters = utils.clone(sctpStreamParameters);
 
 		// This may throw.
-		ortc.validateSctpStreamParameters(clonedSctpStreamParameters);
+		ortc.validateAndNormalizeSctpStreamParameters(clonedSctpStreamParameters);
 
 		// Enqueue command.
 		return this._awaitQueue.push(async () => {

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -132,6 +132,9 @@ export class Chrome111
 			sdpObject: localSdpObject,
 		});
 
+		// Need to validate and normalize native RTP capabilities.
+		ortc.validateAndNormalizeRtpCapabilities(nativeRtpCapabilities);
+
 		// libwebrtc supports NACK for OPUS but doesn't announce it.
 		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
 

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -129,6 +129,9 @@ export class Chrome74
 			sdpObject: localSdpObject,
 		});
 
+		// Need to validate and normalize native RTP capabilities.
+		ortc.validateAndNormalizeRtpCapabilities(nativeRtpCapabilities);
+
 		// libwebrtc supports NACK for OPUS but doesn't announce it.
 		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
 

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -101,6 +101,9 @@ export class FakeHandler
 		const nativeRtpCapabilities =
 			fakeParameters.generateNativeRtpCapabilities();
 
+		// Need to validate and normalize native RTP capabilities.
+		ortc.validateAndNormalizeRtpCapabilities(nativeRtpCapabilities);
+
 		return nativeRtpCapabilities;
 	}
 

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -158,6 +158,9 @@ export class Firefox120
 			sdpObject: localSdpObject,
 		});
 
+		// Need to validate and normalize native RTP capabilities.
+		ortc.validateAndNormalizeRtpCapabilities(nativeRtpCapabilities);
+
 		return nativeRtpCapabilities;
 	}
 

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -130,6 +130,9 @@ export class ReactNative106
 			sdpObject: localSdpObject,
 		});
 
+		// Need to validate and normalize native RTP capabilities.
+		ortc.validateAndNormalizeRtpCapabilities(nativeRtpCapabilities);
+
 		// libwebrtc supports NACK for OPUS but doesn't announce it.
 		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
 

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -128,6 +128,9 @@ export class Safari12
 			sdpObject: localSdpObject,
 		});
 
+		// Need to validate and normalize native RTP capabilities.
+		ortc.validateAndNormalizeRtpCapabilities(nativeRtpCapabilities);
+
 		// libwebrtc supports NACK for OPUS but doesn't announce it.
 		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
 

--- a/src/ortc.ts
+++ b/src/ortc.ts
@@ -30,7 +30,9 @@ const RTP_PROBATOR_CODEC_PAYLOAD_TYPE = 127;
  * fields with default values.
  * It throws if invalid.
  */
-export function validateRtpCapabilities(caps: RtpCapabilities): void {
+export function validateAndNormalizeRtpCapabilities(
+	caps: RtpCapabilities
+): void {
 	if (typeof caps !== 'object') {
 		throw new TypeError('caps is not an object');
 	}
@@ -43,7 +45,7 @@ export function validateRtpCapabilities(caps: RtpCapabilities): void {
 	}
 
 	for (const codec of caps.codecs) {
-		validateRtpCodecCapability(codec);
+		validateAndNormalizeRtpCodecCapability(codec);
 	}
 
 	// headerExtensions is optional. If unset, fill with an empty array.
@@ -54,7 +56,7 @@ export function validateRtpCapabilities(caps: RtpCapabilities): void {
 	}
 
 	for (const ext of caps.headerExtensions) {
-		validateRtpHeaderExtension(ext);
+		validateAndNormalizeRtpHeaderExtension(ext);
 	}
 }
 
@@ -63,7 +65,7 @@ export function validateRtpCapabilities(caps: RtpCapabilities): void {
  * fields with default values.
  * It throws if invalid.
  */
-export function validateRtpParameters(params: RtpParameters): void {
+export function validateAndNormalizeRtpParameters(params: RtpParameters): void {
 	if (typeof params !== 'object') {
 		throw new TypeError('params is not an object');
 	}
@@ -79,7 +81,7 @@ export function validateRtpParameters(params: RtpParameters): void {
 	}
 
 	for (const codec of params.codecs) {
-		validateRtpCodecParameters(codec);
+		validateAndNormalizeRtpCodecParameters(codec);
 	}
 
 	// headerExtensions is optional. If unset, fill with an empty array.
@@ -101,7 +103,7 @@ export function validateRtpParameters(params: RtpParameters): void {
 	}
 
 	for (const encoding of params.encodings) {
-		validateRtpEncodingParameters(encoding);
+		validateAndNormalizeRtpEncodingParameters(encoding);
 	}
 
 	// rtcp is optional. If unset, fill with an empty object.
@@ -111,7 +113,7 @@ export function validateRtpParameters(params: RtpParameters): void {
 		params.rtcp = {};
 	}
 
-	validateRtcpParameters(params.rtcp);
+	validateAndNormalizeRtcpParameters(params.rtcp);
 }
 
 /**
@@ -119,7 +121,7 @@ export function validateRtpParameters(params: RtpParameters): void {
  * fields with default values.
  * It throws if invalid.
  */
-export function validateSctpStreamParameters(
+export function validateAndNormalizeSctpStreamParameters(
 	params: SctpStreamParameters
 ): void {
 	if (typeof params !== 'object') {
@@ -658,7 +660,7 @@ export function generateProbatorRtpParameters(
 	videoRtpParameters = utils.clone<RtpParameters>(videoRtpParameters);
 
 	// This may throw.
-	validateRtpParameters(videoRtpParameters);
+	validateAndNormalizeRtpParameters(videoRtpParameters);
 
 	const rtpParameters: RtpParameters = {
 		mid: RTP_PROBATOR_MID,
@@ -694,7 +696,7 @@ export function canReceive(
 	rtpCapabilities: RtpCapabilities
 ): boolean {
 	// This may throw.
-	validateRtpParameters(rtpParameters);
+	validateAndNormalizeRtpParameters(rtpParameters);
 
 	if (rtpParameters.codecs.length === 0) {
 		return false;
@@ -712,7 +714,9 @@ export function canReceive(
  * fields with default values.
  * It throws if invalid.
  */
-function validateRtpCodecCapability(codec: RtpCodecCapability): void {
+function validateAndNormalizeRtpCodecCapability(
+	codec: RtpCodecCapability
+): void {
 	const MimeTypeRegex = new RegExp('^(audio|video)/(.+)', 'i');
 
 	if (typeof codec !== 'object') {
@@ -785,7 +789,7 @@ function validateRtpCodecCapability(codec: RtpCodecCapability): void {
 	}
 
 	for (const fb of codec.rtcpFeedback) {
-		validateRtcpFeedback(fb);
+		validateAndNormalizeRtcpFeedback(fb);
 	}
 }
 
@@ -794,7 +798,7 @@ function validateRtpCodecCapability(codec: RtpCodecCapability): void {
  * fields with default values.
  * It throws if invalid.
  */
-function validateRtcpFeedback(fb: RtcpFeedback): void {
+function validateAndNormalizeRtcpFeedback(fb: RtcpFeedback): void {
 	if (typeof fb !== 'object') {
 		throw new TypeError('fb is not an object');
 	}
@@ -815,7 +819,7 @@ function validateRtcpFeedback(fb: RtcpFeedback): void {
  * fields with default values.
  * It throws if invalid.
  */
-function validateRtpHeaderExtension(ext: RtpHeaderExtension): void {
+function validateAndNormalizeRtpHeaderExtension(ext: RtpHeaderExtension): void {
 	if (typeof ext !== 'object') {
 		throw new TypeError('ext is not an object');
 	}
@@ -855,7 +859,9 @@ function validateRtpHeaderExtension(ext: RtpHeaderExtension): void {
  * fields with default values.
  * It throws if invalid.
  */
-function validateRtpCodecParameters(codec: RtpCodecParameters): void {
+function validateAndNormalizeRtpCodecParameters(
+	codec: RtpCodecParameters
+): void {
 	const MimeTypeRegex = new RegExp('^(audio|video)/(.+)', 'i');
 
 	if (typeof codec !== 'object') {
@@ -927,7 +933,7 @@ function validateRtpCodecParameters(codec: RtpCodecParameters): void {
 	}
 
 	for (const fb of codec.rtcpFeedback) {
-		validateRtcpFeedback(fb);
+		validateAndNormalizeRtcpFeedback(fb);
 	}
 }
 
@@ -984,7 +990,9 @@ function validateRtpHeaderExtensionParameters(
  * fields with default values.
  * It throws if invalid.
  */
-function validateRtpEncodingParameters(encoding: RtpEncodingParameters): void {
+function validateAndNormalizeRtpEncodingParameters(
+	encoding: RtpEncodingParameters
+): void {
 	if (typeof encoding !== 'object') {
 		throw new TypeError('encoding is not an object');
 	}
@@ -1028,7 +1036,7 @@ function validateRtpEncodingParameters(encoding: RtpEncodingParameters): void {
  * fields with default values.
  * It throws if invalid.
  */
-function validateRtcpParameters(rtcp: RtcpParameters): void {
+function validateAndNormalizeRtcpParameters(rtcp: RtcpParameters): void {
 	if (typeof rtcp !== 'object') {
 		throw new TypeError('rtcp is not an object');
 	}

--- a/src/test/fakeParameters.ts
+++ b/src/test/fakeParameters.ts
@@ -184,8 +184,11 @@ export function generateRouterRtpCapabilities(): mediasoupClient.types.RtpCapabi
 	});
 }
 
+// NOTE: We don't freeze these RTP capabilities because we do need to normalize
+// them as we do in real browser handlers (this is an object supposed to be
+// generated internally so it's ok).
 export function generateNativeRtpCapabilities(): mediasoupClient.types.RtpCapabilities {
-	return utils.deepFreeze<mediasoupClient.types.RtpCapabilities>({
+	return {
 		codecs: [
 			{
 				mimeType: 'audio/opus',
@@ -361,7 +364,7 @@ export function generateNativeRtpCapabilities(): mediasoupClient.types.RtpCapabi
 				preferredId: 10,
 			},
 		],
-	});
+	};
 }
 
 export function generateNativeSctpCapabilities(): mediasoupClient.types.SctpCapabilities {


### PR DESCRIPTION
## Details

- Fixes #340
- We need to normalize locally generated native RTP capabilities to be able to compare them properly with Router's RTP capabilities.
- This was a regression introduced in PR #336.
- Thanks @gnauhtt for reporting it and including the solution in the report.