### PR TITLE
New browser/device detection

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -159,6 +159,7 @@ const config = tsEslint.config(
 			'@typescript-eslint/consistent-indexed-object-style': 0,
 			'@typescript-eslint/no-empty-function': 0,
 			'@typescript-eslint/prefer-nullish-coalescing': 0,
+			'@typescript-eslint/prefer-regexp-exec': 0,
 			'@typescript-eslint/require-await': 0,
 			'@typescript-eslint/restrict-template-expressions': 0,
 			'@typescript-eslint/unbound-method': 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
 				"@types/debug": "^4.1.12",
 				"@types/events-alias": "npm:@types/events@^3.0.3",
 				"awaitqueue": "^3.2.4",
-				"browser-dtector": "^4.1.0",
 				"debug": "^4.4.3",
 				"events-alias": "npm:events@^3.3.0",
 				"fake-mediastreamtrack": "^2.1.4",
@@ -2434,21 +2433,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/browser-dtector": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/browser-dtector/-/browser-dtector-4.1.0.tgz",
-			"integrity": "sha512-ZnLAE4aknz8f7UWJ9/QJ9rNlHjBi59aVu6a73WGnUUAIXak6+2AbY/I1fnRPJhuqn94Lce63u9ecKNP+D9f71w==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/sibiraj-s"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=16"
 			}
 		},
 		"node_modules/browserslist": {
@@ -8092,11 +8076,6 @@
 			"requires": {
 				"fill-range": "^7.1.1"
 			}
-		},
-		"browser-dtector": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/browser-dtector/-/browser-dtector-4.1.0.tgz",
-			"integrity": "sha512-ZnLAE4aknz8f7UWJ9/QJ9rNlHjBi59aVu6a73WGnUUAIXak6+2AbY/I1fnRPJhuqn94Lce63u9ecKNP+D9f71w=="
 		},
 		"browserslist": {
 			"version": "4.25.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
 		"@types/debug": "^4.1.12",
 		"@types/events-alias": "npm:@types/events@^3.0.3",
 		"awaitqueue": "^3.2.4",
-		"browser-dtector": "^4.1.0",
 		"debug": "^4.4.3",
 		"events-alias": "npm:events@^3.3.0",
 		"fake-mediastreamtrack": "^2.1.4",

--- a/src/3rdTypes/user-agent-data.d.ts
+++ b/src/3rdTypes/user-agent-data.d.ts
@@ -1,0 +1,29 @@
+/**
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Navigator/userAgentData
+ *
+ * @remarks TypeScript DOM library doesn't define this type yet.
+ */
+interface NavigatorUAData {
+	brands: { brand: string; version: string }[];
+	platform: Platform;
+	mobile: boolean;
+	getHighEntropyValues?(hints: string[]): Promise<Record<string, string>>;
+}
+
+type Platform =
+	| 'Android'
+	| 'Chrome OS'
+	| 'Chromium OS'
+	| 'iOS'
+	| 'Linux'
+	| 'macOS'
+	| 'Windows'
+	| 'Unknown';
+
+/**
+ * @remarks No need to extend from anywhere since by default TypeScript
+ * automatically merges interfaces with the same name.
+ */
+interface Navigator {
+	readonly userAgentData?: NavigatorUAData;
+}

--- a/src/3rdTypes/webrtc-extensions.d.ts
+++ b/src/3rdTypes/webrtc-extensions.d.ts
@@ -4,7 +4,7 @@
  *
  * @see https://www.w3.org/TR/webrtc-svc/
  *
- * @note No need to extend from anywhere since by default TypeScript
+ * @remarks No need to extend from anywhere since by default TypeScript
  * automatically merges interfaces with the same name.
  */
 interface RTCRtpEncodingParameters {

--- a/src/Device.ts
+++ b/src/Device.ts
@@ -1,7 +1,3 @@
-import BrowserDetector, {
-	KnownBrowsers,
-	KnownPlatforms,
-} from 'browser-dtector';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './enhancedEvents';
 import { UnsupportedError, InvalidStateError } from './errors';
@@ -50,17 +46,20 @@ export type DeviceOptions = {
  * Sync mediasoup-client Handler detection.
  */
 export function detectDevice(
-	userAgent?: string
+	userAgent?: string,
+	userAgentData?: NavigatorUAData
 ): BuiltinHandlerName | undefined {
-	logger.debug('detectDevice() [userAgent:%s]', userAgent);
+	logger.debug('detectDevice()');
 
 	if (!userAgent && typeof navigator === 'object') {
 		userAgent = navigator.userAgent;
 	}
 
-	const browserDetector = new BrowserDetector(userAgent);
+	if (!userAgentData && typeof navigator === 'object') {
+		userAgentData = navigator.userAgentData;
+	}
 
-	return detectDeviceImpl(browserDetector);
+	return detectDeviceImpl(userAgent, userAgentData);
 }
 
 /**
@@ -68,20 +67,24 @@ export function detectDevice(
  *
  * @remarks
  * - Currently it runs same logic than `detectDevice()`.
- * - In the future this function could give better results than `detectDevice()`.
+ * - In the future this function could give better results than
+ *   `detectDevice()`.
  */
 export async function detectDeviceAsync(
-	userAgent?: string
+	userAgent?: string,
+	userAgentData?: NavigatorUAData
 ): Promise<BuiltinHandlerName | undefined> {
-	logger.debug('detectDeviceAsync() [userAgent:%s]', userAgent);
+	logger.debug('detectDeviceAsync()');
 
 	if (!userAgent && typeof navigator === 'object') {
 		userAgent = navigator.userAgent;
 	}
 
-	const browserDetector = new BrowserDetector(userAgent);
+	if (!userAgentData && typeof navigator === 'object') {
+		userAgentData = navigator.userAgentData;
+	}
 
-	return detectDeviceImpl(browserDetector);
+	return detectDeviceImpl(userAgent, userAgentData);
 }
 
 export type DeviceObserver = EnhancedEventEmitter<DeviceObserverEvents>;
@@ -491,127 +494,294 @@ export class Device {
 }
 
 function detectDeviceImpl(
-	browserDetector: BrowserDetector
+	userAgent?: string,
+	userAgentData?: NavigatorUAData
 ): BuiltinHandlerName | undefined {
-	// React-Native.
-	if (typeof navigator === 'object' && navigator.product === 'ReactNative') {
-		logger.debug('detectDeviceImpl() | React-Native detected');
+	logger.debug(
+		'detectDeviceImpl() [userAgent:%s, userAgentData:%o]',
+		userAgent,
+		userAgentData
+	);
 
+	const chromiumMajorVersion = getChromiumMajorVersion(
+		userAgent,
+		userAgentData
+	);
+
+	if (chromiumMajorVersion && chromiumMajorVersion >= 111) {
+		logger.debug('detectDeviceImpl() | using Chrome111 handler');
+
+		return 'Chrome111';
+	} else if (chromiumMajorVersion && chromiumMajorVersion >= 74) {
+		logger.debug('detectDeviceImpl() | using Chrome74 handler');
+
+		return 'Chrome74';
+	}
+
+	const firefoxMajorVersion = getFirefoxMajorVersion(userAgent);
+
+	if (firefoxMajorVersion && firefoxMajorVersion >= 120) {
+		logger.debug('detectDeviceImpl() | using Firefox120 handler');
+
+		return 'Firefox120';
+	}
+
+	const macOSWebKitMajorVersion = getMacOSWebKitMajorVersion(userAgent);
+
+	if (macOSWebKitMajorVersion && macOSWebKitMajorVersion >= 605) {
+		logger.debug('detectDeviceImpl() | using Safari12 handler');
+
+		return 'Safari12';
+	}
+
+	const iOSWebKitMajorVersion = getIOSWebKitMajorVersion(userAgent);
+
+	if (iOSWebKitMajorVersion && iOSWebKitMajorVersion >= 605) {
+		logger.debug('detectDeviceImpl() | using Safari12 handler');
+
+		return 'Safari12';
+	}
+
+	if (isReactNative()) {
 		if (
 			typeof RTCPeerConnection === 'undefined' ||
 			typeof RTCRtpTransceiver === 'undefined'
 		) {
 			logger.warn(
-				'detectDeviceImpl() | unsupported react-native-webrtc without RTCPeerConnection or RTCRtpTransceiver, forgot to call registerGlobals() on it?'
+				'detectDeviceImpl() | unsupported react-native-webrtc version without RTCPeerConnection or RTCRtpTransceiver, forgot to call registerGlobals() on it?'
 			);
 
 			return undefined;
 		}
 
+		logger.debug('detectDeviceImpl() | using ReactNative106 handler');
+
 		return 'ReactNative106';
 	}
-	// Browser.
-	else {
-		const parsed = browserDetector.parseUserAgent();
 
-		const browserMajorVersionMatch = /^\d+/.exec(parsed?.shortVersion ?? '0');
-		const browserMajorVersion = parseInt(
-			browserMajorVersionMatch?.[0] ?? '0',
-			10
-		);
+	logger.warn(
+		'detectDeviceImpl() | device not supported [userAgent:%s, userAgentData:%o]',
+		userAgent,
+		userAgentData
+	);
 
-		const isIOS =
-			parsed.platform === KnownPlatforms.iphone ||
-			parsed.platform === KnownPlatforms.ipad ||
-			(parsed.platform === KnownPlatforms.mac &&
-				(parsed.isMobile ||
-					parsed.isTablet ||
-					(typeof navigator === 'object' && navigator?.maxTouchPoints >= 2)));
+	return undefined;
+}
 
-		const isChrome = parsed.isChrome;
-		const isFirefox = parsed.isFireFox;
-		const isSafari = parsed.isSafari;
-		const isEdge = parsed.isEdge;
-		const isElectron =
-			parsed.isDesktop && parsed.name === KnownBrowsers.electron;
+function getChromiumMajorVersion(
+	userAgent?: string,
+	userAgentData?: NavigatorUAData
+): number | undefined {
+	if (isIOS(userAgent, userAgentData)) {
+		logger.debug('getChromiumMajorVersion() | this is iOS => undefined');
 
-		// For logging purposes.
-		const result = {
-			browserMajorVersion,
-			isIOS,
-			isChrome,
-			isFirefox,
-			isSafari,
-			isElectron,
-		};
+		return undefined;
+	}
 
+	if (isReactNative()) {
 		logger.debug(
-			'detectDeviceImpl() | detected browser [userAgent:%s, parsed:%o, result:%o]',
-			parsed.userAgent,
-			parsed,
-			result
+			'getChromiumMajorVersion() | this is React-Native => undefined'
 		);
 
-		// Chrome, Chromium, and Edge.
-		if ((isChrome || isEdge) && !isIOS && browserMajorVersion >= 111) {
-			return 'Chrome111';
-		} else if (
-			(isChrome && !isIOS && browserMajorVersion >= 74) ||
-			(isEdge && !isIOS && browserMajorVersion >= 88)
-		) {
-			return 'Chrome74';
-		}
-		// Electron.
-		else if (isElectron) {
-			return 'Chrome111';
-		}
-		// Firefox.
-		else if (isFirefox && !isIOS && browserMajorVersion >= 120) {
-			return 'Firefox120';
-		}
-		// Safari.
-		else if (
-			isSafari &&
-			browserMajorVersion >= 12 &&
-			typeof RTCRtpTransceiver !== 'undefined' &&
-			RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection')
-		) {
-			return 'Safari12';
-		}
-		// Best effort for WebKit based browsers in iOS.
-		else if (
-			isIOS &&
-			typeof RTCRtpTransceiver !== 'undefined' &&
-			RTCRtpTransceiver.prototype.hasOwnProperty('currentDirection')
-		) {
-			return 'Safari12';
-		}
-		// Best effort for Chromium based browsers.
-		else {
-			const match = browserDetector.userAgent?.match(
-				/(?:(?:Chrome|Chromium))[ /](\w+)/i
+		return undefined;
+	}
+
+	if (userAgentData) {
+		const chromiumBrand = userAgentData.brands.find(
+			b => b.brand === 'Chromium'
+		);
+
+		if (chromiumBrand) {
+			const majorVersion = Number(chromiumBrand.version);
+
+			logger.debug(
+				`getChromiumMajorVersion() | Chromium major version based on NavigatorUAData => ${majorVersion}`
 			);
 
-			if (match) {
-				const version = Number(match[1]);
-
-				if (version >= 111) {
-					return 'Chrome111';
-				} else {
-					return 'Chrome74';
-				}
-			}
-			// Unsupported browser.
-			else {
-				logger.warn(
-					'detectDeviceImpl() | browser not supported [userAgent:%s, parsed:%o, result:%o]',
-					parsed.userAgent,
-					parsed,
-					result
-				);
-
-				return undefined;
-			}
+			return majorVersion;
 		}
 	}
+
+	const match = userAgent?.match(/\b(?:Chrome|Chromium)\/(\w+)/i);
+
+	if (match?.[1]) {
+		const majorVersion = Number(match[1]);
+
+		logger.debug(
+			`getChromiumMajorVersion() | Chromium major version based on User-Agent => ${majorVersion}`
+		);
+
+		return majorVersion;
+	}
+
+	logger.debug('getChromiumMajorVersion() | this is not Chromium => undefined');
+
+	return undefined;
+}
+
+function getFirefoxMajorVersion(userAgent?: string): number | undefined {
+	if (isIOS(userAgent)) {
+		logger.debug('getFirefoxMajorVersion() | this is iOS => undefined');
+
+		return undefined;
+	}
+
+	if (isReactNative()) {
+		logger.debug(
+			'getFirefoxMajorVersion() | this is React-Native => undefined'
+		);
+
+		return undefined;
+	}
+
+	const match = userAgent?.match(/\bFirefox\/(\w+)/i);
+
+	if (match?.[1]) {
+		const majorVersion = Number(match[1]);
+
+		logger.debug(
+			`getFirefoxMajorVersion() | Firefox major version based on User-Agent => ${majorVersion}`
+		);
+
+		return majorVersion;
+	}
+
+	logger.debug('getFirefoxMajorVersion() | this is not Firefox => undefined');
+
+	return undefined;
+}
+
+function getMacOSWebKitMajorVersion(userAgent?: string): number | undefined {
+	if (isIOS(userAgent)) {
+		logger.debug('getMacOSWebKitMajorVersion() | this is iOS => undefined');
+
+		return undefined;
+	}
+
+	if (isReactNative()) {
+		logger.debug(
+			'getMacOSWebKitMajorVersion() | this is React-Native => undefined'
+		);
+
+		return undefined;
+	}
+
+	const isSafari =
+		userAgent &&
+		/\bSafari\b/i.test(userAgent) &&
+		!/\bChrome\b/i.test(userAgent) &&
+		!/\bChromium\b/i.test(userAgent) &&
+		!/\bFirefox\b/i.test(userAgent);
+
+	if (!isSafari) {
+		logger.debug(
+			'getMacOSWebKitMajorVersion() | this is not Safari => undefined'
+		);
+
+		return undefined;
+	}
+
+	const match = userAgent.match(/AppleWebKit\/(\w+)/i);
+
+	if (match?.[1]) {
+		const majorVersion = Number(match[1]);
+
+		logger.debug(
+			`getMacOSWebKitMajorVersion() | WebKit major version based on User-Agent => ${majorVersion}`
+		);
+
+		return majorVersion;
+	}
+
+	logger.debug(
+		'getMacOSWebKitMajorVersion() | this is not WebKit => undefined'
+	);
+
+	return undefined;
+}
+
+function getIOSWebKitMajorVersion(userAgent?: string): number | undefined {
+	if (!isIOS(userAgent)) {
+		logger.debug('getIOSWebKitMajorVersion() | this is not iOS => undefined');
+
+		return undefined;
+	}
+
+	if (isReactNative()) {
+		logger.debug(
+			'getIOSWebKitMajorVersion() | this is React-Native => undefined'
+		);
+
+		return undefined;
+	}
+
+	const match = userAgent?.match(/AppleWebKit\/(\w+)/i);
+
+	if (match?.[1]) {
+		const majorVersion = Number(match[1]);
+
+		logger.debug(
+			`getIOSWebKitMajorVersion() | WebKit major version based on User-Agent => ${majorVersion}`
+		);
+
+		return majorVersion;
+	}
+
+	logger.debug('getIOSWebKitMajorVersion() | this is not WebKit => undefined');
+
+	return undefined;
+}
+
+function isIOS(userAgent?: string, userAgentData?: NavigatorUAData): boolean {
+	if (userAgentData?.platform === 'iOS') {
+		logger.debug(
+			'isIOS() | this is iOS based on NavigatorUAData.platform => true'
+		);
+
+		return true;
+	}
+
+	if (userAgentData?.platform) {
+		logger.debug(
+			'isIOS() | this is not iOS based on NavigatorUAData.platform => false'
+		);
+
+		return false;
+	}
+
+	if (userAgent && /iPad|iPhone|iPod/.test(userAgent)) {
+		logger.debug('isIOS() | this is iOS based on User-Agent => true');
+
+		return true;
+	}
+
+	// iPadOS 13+ identifies itself as Mac (to force desktop view mode in some
+	// websites) but we know it's iOS if it has touch screen.
+	if (
+		typeof navigator === 'object' &&
+		navigator.platform === 'MacIntel' &&
+		navigator.maxTouchPoints > 1
+	) {
+		logger.debug('isIOS() | this is iPadOS 13+ based on User-Agent => true');
+
+		return true;
+	}
+
+	logger.debug('isIOS() | this is not iOS => false');
+
+	return false;
+}
+
+function isReactNative(): boolean {
+	if (typeof navigator === 'object' && navigator.product === 'ReactNative') {
+		logger.debug(
+			'isReactNative() | this is React-Native based on navigator.product'
+		);
+
+		return true;
+	}
+
+	logger.debug('isReactNative() | this is not React-Native => false');
+
+	return false;
 }

--- a/src/Device.ts
+++ b/src/Device.ts
@@ -498,7 +498,7 @@ function detectDeviceImpl(
 	userAgentData?: NavigatorUAData
 ): BuiltinHandlerName | undefined {
 	logger.debug(
-		'detectDeviceImpl() [userAgent:%s, userAgentData:%o]',
+		'detectDeviceImpl() [userAgent:"%s", userAgentData:%o]',
 		userAgent,
 		userAgentData
 	);
@@ -508,59 +508,89 @@ function detectDeviceImpl(
 		userAgentData
 	);
 
-	if (chromiumMajorVersion && chromiumMajorVersion >= 111) {
-		logger.debug('detectDeviceImpl() | using Chrome111 handler');
+	if (chromiumMajorVersion) {
+		if (chromiumMajorVersion >= 111) {
+			logger.debug('detectDeviceImpl() | using Chrome111 handler');
 
-		return 'Chrome111';
-	} else if (chromiumMajorVersion && chromiumMajorVersion >= 74) {
-		logger.debug('detectDeviceImpl() | using Chrome74 handler');
+			return 'Chrome111';
+		} else if (chromiumMajorVersion >= 74) {
+			logger.debug('detectDeviceImpl() | using Chrome74 handler');
 
-		return 'Chrome74';
+			return 'Chrome74';
+		} else {
+			logger.warn(
+				'detectDeviceImpl() | unsupported Chromium based browser/version'
+			);
+
+			return undefined;
+		}
 	}
 
 	const firefoxMajorVersion = getFirefoxMajorVersion(userAgent);
 
-	if (firefoxMajorVersion && firefoxMajorVersion >= 120) {
-		logger.debug('detectDeviceImpl() | using Firefox120 handler');
+	if (firefoxMajorVersion) {
+		if (firefoxMajorVersion >= 120) {
+			logger.debug('detectDeviceImpl() | using Firefox120 handler');
 
-		return 'Firefox120';
+			return 'Firefox120';
+		} else {
+			logger.warn('detectDeviceImpl() | unsupported Firefox browser/version');
+
+			return undefined;
+		}
 	}
 
 	const macOSWebKitMajorVersion = getMacOSWebKitMajorVersion(userAgent);
 
-	if (macOSWebKitMajorVersion && macOSWebKitMajorVersion >= 605) {
-		logger.debug('detectDeviceImpl() | using Safari12 handler');
+	if (macOSWebKitMajorVersion) {
+		if (macOSWebKitMajorVersion >= 605) {
+			logger.debug('detectDeviceImpl() | using Safari12 handler');
 
-		return 'Safari12';
+			return 'Safari12';
+		} else {
+			logger.warn(
+				'detectDeviceImpl() | unsupported desktop Safari browser/version'
+			);
+
+			return undefined;
+		}
 	}
 
 	const iOSWebKitMajorVersion = getIOSWebKitMajorVersion(userAgent);
 
-	if (iOSWebKitMajorVersion && iOSWebKitMajorVersion >= 605) {
-		logger.debug('detectDeviceImpl() | using Safari12 handler');
+	if (iOSWebKitMajorVersion) {
+		if (iOSWebKitMajorVersion >= 605) {
+			logger.debug('detectDeviceImpl() | using Safari12 handler');
 
-		return 'Safari12';
+			return 'Safari12';
+		} else {
+			logger.warn(
+				'detectDeviceImpl() | unsupported iOS Safari based browser/version'
+			);
+
+			return undefined;
+		}
 	}
 
 	if (isReactNative()) {
 		if (
-			typeof RTCPeerConnection === 'undefined' ||
-			typeof RTCRtpTransceiver === 'undefined'
+			typeof RTCPeerConnection !== 'undefined' &&
+			typeof RTCRtpTransceiver !== 'undefined'
 		) {
+			logger.debug('detectDeviceImpl() | using ReactNative106 handler');
+
+			return 'ReactNative106';
+		} else {
 			logger.warn(
 				'detectDeviceImpl() | unsupported react-native-webrtc version without RTCPeerConnection or RTCRtpTransceiver, forgot to call registerGlobals() on it?'
 			);
 
 			return undefined;
 		}
-
-		logger.debug('detectDeviceImpl() | using ReactNative106 handler');
-
-		return 'ReactNative106';
 	}
 
 	logger.warn(
-		'detectDeviceImpl() | device not supported [userAgent:%s, userAgentData:%o]',
+		'detectDeviceImpl() | device not supported [userAgent:"%s", userAgentData:%o]',
 		userAgent,
 		userAgentData
 	);

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -1635,10 +1635,12 @@ describe('detectDevice() and detectDeviceAsync() assign proper handler based on 
 					};
 				}
 
-				expect(detectDevice(uaTestCase.ua)).toBe(uaTestCase.expect);
-				await expect(detectDeviceAsync(uaTestCase.ua)).resolves.toBe(
-					uaTestCase.expect
-				);
+				expect(
+					detectDevice(uaTestCase.userAgent, uaTestCase.userAgentData)
+				).toBe(uaTestCase.expect);
+				await expect(
+					detectDeviceAsync(uaTestCase.userAgent, uaTestCase.userAgentData)
+				).resolves.toBe(uaTestCase.expect);
 
 				// Cleanup.
 				global.RTCRtpTransceiver = originalRTCRtpTransceiver;

--- a/src/test/uaTestCases.ts
+++ b/src/test/uaTestCases.ts
@@ -2,95 +2,219 @@ import type { BuiltinHandlerName } from '../Device';
 
 type UATestCase = {
 	desc: string;
-	ua: string;
+	userAgent: string;
+	userAgentData?: NavigatorUAData;
 	expect?: BuiltinHandlerName;
 };
 
 export const uaTestCases: UATestCase[] = [
 	{
+		desc: 'Chrome 140 (MacOS)',
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+		userAgentData: {
+			brands: [
+				{
+					brand: 'Chromium',
+					version: '140',
+				},
+				{
+					brand: 'Not=A?Brand',
+					version: '24',
+				},
+				{
+					brand: 'Google Chrome',
+					version: '140',
+				},
+			],
+			mobile: false,
+			platform: 'macOS',
+		},
+		expect: 'Chrome111',
+	},
+	{
+		desc: 'Chrome Canary 142 (MacOS)',
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36',
+		userAgentData: {
+			brands: [
+				{
+					brand: 'Chromium',
+					version: '142',
+				},
+				{
+					brand: 'Google Chrome',
+					version: '142',
+				},
+				{
+					brand: 'Not_A Brand',
+					version: '99',
+				},
+			],
+			mobile: false,
+			platform: 'macOS',
+		},
+		expect: 'Chrome111',
+	},
+	{
+		desc: 'Microsoft Edge 140 (MacOS)',
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.0.0',
+		userAgentData: {
+			brands: [
+				{
+					brand: 'Chromium',
+					version: '140',
+				},
+				{
+					brand: 'Not=A?Brand',
+					version: '24',
+				},
+				{
+					brand: 'Microsoft Edge',
+					version: '140',
+				},
+			],
+			mobile: false,
+			platform: 'macOS',
+		},
+		expect: 'Chrome111',
+	},
+	{
+		desc: 'Opera 122 (MacOS)',
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 OPR/122.0.0.0',
+		userAgentData: {
+			brands: [
+				{
+					brand: 'Not)A;Brand',
+					version: '8',
+				},
+				{
+					brand: 'Chromium',
+					version: '138',
+				},
+				{
+					brand: 'Opera',
+					version: '122',
+				},
+			],
+			mobile: false,
+			platform: 'macOS',
+		},
+		expect: 'Chrome111',
+	},
+	{
+		desc: 'Firefox 142 (on MacOS)',
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:142.0) Gecko/20100101 Firefox/142.0',
+		expect: 'Firefox120',
+	},
+	{
+		desc: 'Safari 18 (on MacOS)',
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15',
+		expect: 'Safari12',
+	},
+	{
 		desc: 'Microsoft Edge 100',
-		ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.1108.55 Safari/537.36 Edg/100.0.1108.55',
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.1108.55 Safari/537.36 Edg/100.0.1108.55',
 		expect: 'Chrome74',
 	},
 	{
 		desc: 'Mac (Intel) Chrome 112',
-		ua: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',
+		userAgent:
+			'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',
 		expect: 'Chrome111',
 	},
 	{
 		desc: 'iPhone iOS 16',
-		ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Mobile/15E148 Safari/604.1',
+		userAgent:
+			'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Mobile/15E148 Safari/604.1',
 		expect: 'Safari12',
 	},
 	{
 		desc: 'Generic Android Chrome 112',
-		ua: 'Mozilla/5.0 (Linux; Android 13; M2012K11AG) AppleWebKit/537.36 (KHTML, like Gecko) Soul/4.0 Chrome/112.0.5615.135 Mobile Safari/537.36',
+		userAgent:
+			'Mozilla/5.0 (Linux; Android 13; M2012K11AG) AppleWebKit/537.36 (KHTML, like Gecko) Soul/4.0 Chrome/112.0.5615.135 Mobile Safari/537.36',
 		expect: 'Chrome111',
 	},
 	{
 		desc: 'Motorola Edge Chrome 104',
-		ua: 'Mozilla/5.0 (Linux; Android 10; motorola edge) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Mobile Safari/537.36',
+		userAgent:
+			'Mozilla/5.0 (Linux; Android 10; motorola edge) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Mobile Safari/537.36',
 		expect: 'Chrome74',
 	},
 	{
 		desc: 'In-app WebView (Android)',
-		ua: 'Mozilla/5.0 (Linux; Android 11; G91 Pro Build/RP1A.200720.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/114.0.5735.130 Mobile Safari/537.36',
+		userAgent:
+			'Mozilla/5.0 (Linux; Android 11; G91 Pro Build/RP1A.200720.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/114.0.5735.130 Mobile Safari/537.36',
 		expect: 'Chrome111',
 	},
 	{
 		desc: 'Brave',
-		ua: 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.4044.113 Safari/5370.36 Brave/9085',
+		userAgent:
+			'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.4044.113 Safari/5370.36 Brave/9085',
 		expect: 'Chrome111',
 	},
 	{
 		desc: 'In-app WebView (Android) (Facebook)',
-		ua: 'Mozilla/5.0 (Linux; Android 12; SM-S908U1 Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/100.0.4896.88 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/377.0.0.22.107;]',
+		userAgent:
+			'Mozilla/5.0 (Linux; Android 12; SM-S908U1 Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/100.0.4896.88 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/377.0.0.22.107;]',
 		expect: 'Chrome74',
 	},
 	{
 		desc: 'Firefox (iOS)',
-		ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/142.0.1 Mobile/15E148 Safari/605.1.15',
+		userAgent:
+			'Mozilla/5.0 (iPhone; CPU iPhone OS 18_6_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/142.0.1 Mobile/15E148 Safari/605.1.15',
 		expect: 'Safari12',
 	},
 	{
 		desc: 'In-app WKWebView (iOS) (TikTok)',
-		ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_8 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 musical_ly_21.1.0 JsSdk/2.0 NetType/4G Channel/App Store ByteLocale/ru Region/RU ByteFullLocale/ru-RU isDarkMode/1 WKWebView/1 BytedanceWebview/d8a21c6',
+		userAgent:
+			'Mozilla/5.0 (iPhone; CPU iPhone OS 14_8 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 musical_ly_21.1.0 JsSdk/2.0 NetType/4G Channel/App Store ByteLocale/ru Region/RU ByteFullLocale/ru-RU isDarkMode/1 WKWebView/1 BytedanceWebview/d8a21c6',
 		expect: 'Safari12',
 	},
 	{
 		desc: 'In-app WkWebView (iOS) (WeChat)',
-		ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MicroMessenger/8.0.37(0x1800252f) NetType/WIFI Language/zh_CN',
+		userAgent:
+			'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MicroMessenger/8.0.37(0x1800252f) NetType/WIFI Language/zh_CN',
 		expect: 'Safari12',
 	},
 	{
 		desc: 'Custom Webview in iPad',
-		ua: 'Mozilla/5.0 (iPad; CPU iPadOS 16_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Mobile/15E148 Safari/604.1 MyApp/1.0',
+		userAgent:
+			'Mozilla/5.0 (iPad; CPU iPadOS 16_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.4 Mobile/15E148 Safari/604.1 MyApp/1.0',
 		expect: 'Safari12',
 	},
 	{
 		desc: 'Chrome Mobile (iOS)',
-		ua: 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/114.0.5735.124 Mobile/15E148 Safari/604.1',
+		userAgent:
+			'Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/114.0.5735.124 Mobile/15E148 Safari/604.1',
 		expect: 'Safari12',
 	},
 	{
 		desc: 'Fake Foo Invalid Browser - Unsupported',
-		ua: 'Fake/5.0 (Foo; Bar Lalala OS_19.5) Foo/22.2',
+		userAgent: 'Fake/5.0 (Foo; Bar Lalala OS_19.5) Foo/22.2',
 		expect: undefined,
 	},
 	{
 		// Zoom App Marketplace browser.
 		desc: 'Zoom App Marketplace browser - Unsupported',
-		ua: 'Mozilla/5.0 ZoomWebKit/537.36 (KHTML, like Gecko) ZoomApps/1.0',
+		userAgent: 'Mozilla/5.0 ZoomWebKit/537.36 (KHTML, like Gecko) ZoomApps/1.0',
 		expect: undefined,
 	},
 	{
 		desc: 'Electron in Windows',
-		ua: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Electron/37.4.0 Chrome/138.0.7204.243 Safari/537.36',
+		userAgent:
+			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Electron/37.4.0 Chrome/138.0.7204.243 Safari/537.36',
 		expect: 'Chrome111',
 	},
 	{
 		desc: 'Samsung Browser (Android)',
-		ua: 'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/28.0 Chrome/130.0.0.0 Mobile Safari/537.36',
+		userAgent:
+			'Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/28.0 Chrome/130.0.0.0 Mobile Safari/537.36',
 		expect: 'Chrome111',
 	},
 ];


### PR DESCRIPTION
## Details

- Completes #344
- Remove [browser-dtector](https://www.npmjs.com/package/browser-dtector) because it's not maintained and honestly I don't like it.
- Create our own browser/device detector system. See issue #344 for more rationale.

## TODO

- [x] Document the new `userAgentData` argument in website.
- [x] Announce the change.