### PR TITLE
Remove Node 18 support

### DIFF
--- a/.github/workflows/mediasoup-client.yaml
+++ b/.github/workflows/mediasoup-client.yaml
@@ -17,8 +17,10 @@ jobs:
     strategy:
       matrix:
         ci:
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             node: 20
+          - os: ubuntu-24.04
+            node: 22
           - os: ubuntu-24.04
             node: 24
           - os: macos-14

--- a/.github/workflows/mediasoup-client.yaml
+++ b/.github/workflows/mediasoup-client.yaml
@@ -17,8 +17,6 @@ jobs:
     strategy:
       matrix:
         ci:
-          - os: ubuntu-22.04
-            node: 18
           - os: ubuntu-24.04
             node: 20
           - os: ubuntu-24.04
@@ -52,9 +50,8 @@ jobs:
           restore-keys: |
             ${{ matrix.ci.os }}-node-
 
-      # NOTE: Add --force since some dev dependencies require Node >= 18.
-      - name: npm ci --force --foreground-scripts
-        run: npm ci --force --foreground-scripts
+      - name: npm ci
+        run: npm ci
 
       - name: npm run lint
         run: npm run lint

--- a/.github/workflows/mediasoup-client.yaml
+++ b/.github/workflows/mediasoup-client.yaml
@@ -50,8 +50,8 @@ jobs:
           restore-keys: |
             ${{ matrix.ci.os }}-node-
 
-      - name: npm ci
-        run: npm ci
+      - name: npm ci --foreground-scripts
+        run: npm ci --foreground-scripts
 
       - name: npm run lint
         run: npm run lint

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"lib"
 	],
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	},
 	"keywords": [
 		"webrtc",


### PR DESCRIPTION
# Details

- The end-of-life (EOL) for Node.js 18 was on April 30, 2025.