### PR TITLE
Nullish Coalescing Assignment operator replacement

### DIFF
--- a/src/handlers/fakeEvents/FakeEventTarget.ts
+++ b/src/handlers/fakeEvents/FakeEventTarget.ts
@@ -23,7 +23,7 @@ export class FakeEventTarget implements EventTarget {
 			return;
 		}
 
-		this.listeners[type] ??= [];
+		this.listeners[type] = this.listeners[type] ?? [];
 
 		this.listeners[type].push({
 			callback:

--- a/src/handlers/sdp/commonUtils.ts
+++ b/src/handlers/sdp/commonUtils.ts
@@ -148,8 +148,8 @@ export function extractDtlsParameters({
 		);
 
 		if (mediaObject) {
-			setup ??= mediaObject.setup;
-			fingerprint ??= mediaObject.fingerprint;
+			setup = setup ?? mediaObject.setup;
+			fingerprint = fingerprint ?? mediaObject.fingerprint;
 		}
 	}
 


### PR DESCRIPTION
Operator _Nullish Coalescing Assignment_ (??=) is not supported in older browsers below Chrome 87 and causes a syntax error `Uncaught SyntaxError: Unexpected token '='`.

PR replaces operator call with two separate operators:
`variable ??= expression` => `variable = variable ?? expression`