### PR TITLE
Add header extension options to transport.produce()

### DIFF
--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -15,6 +15,7 @@ export type ProducerOptions<ProducerAppData extends AppData = AppData> = {
 	track?: MediaStreamTrack;
 	encodings?: RtpEncodingParameters[];
 	codecOptions?: ProducerCodecOptions;
+	headerExtensionOptions?: ProducerHeaderExtensionOptions;
 	codec?: RtpCodecCapability;
 	stopTracks?: boolean;
 	disableTrackOnPause?: boolean;
@@ -41,6 +42,11 @@ export type ProducerCodecOptions = {
 	videoGoogleStartBitrate?: number;
 	videoGoogleMaxBitrate?: number;
 	videoGoogleMinBitrate?: number;
+};
+
+// https://mediasoup.org/documentation/v3/mediasoup-client/api/#HeaderExtensionOptions
+export type ProducerHeaderExtensionOptions = {
+	absCaptureTime?: boolean;
 };
 
 export type ProducerEvents = {

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -502,6 +502,7 @@ export class Transport<
 		track,
 		encodings,
 		codecOptions,
+		headerExtensionOptions,
 		codec,
 		stopTracks = true,
 		disableTrackOnPause = true,
@@ -588,6 +589,7 @@ export class Transport<
 							track,
 							encodings: normalizedEncodings,
 							codecOptions,
+							headerExtensionOptions,
 							codec,
 							onRtpSender,
 						});

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -10,6 +10,8 @@ import type {
 	RtpCapabilities,
 	MediaKind,
 	ExtendedRtpCapabilities,
+	RtpHeaderExtensionUri,
+	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
 import * as sdpCommonUtils from './sdp/commonUtils';
@@ -126,7 +128,12 @@ export class Chrome111
 	}
 
 	private static getLocalRtpCapabilities(
-		localSdpObject: SdpTransform.SessionDescription
+		localSdpObject: SdpTransform.SessionDescription,
+		extraHeaderExtensions: {
+			uri: RtpHeaderExtensionUri;
+			kind: MediaKind;
+			direction: RtpHeaderExtensionDirection;
+		}[] = []
 	): RtpCapabilities {
 		const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
 			sdpObject: localSdpObject,
@@ -137,6 +144,13 @@ export class Chrome111
 
 		// libwebrtc supports NACK for OPUS but doesn't announce it.
 		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+
+		for (const headerExtension of extraHeaderExtensions) {
+			ortcUtils.addHeaderExtensionSupport(
+				nativeRtpCapabilities,
+				headerExtension
+			);
+		}
 
 		return nativeRtpCapabilities;
 	}
@@ -324,6 +338,7 @@ export class Chrome111
 		track,
 		encodings,
 		codecOptions,
+		headerExtensionOptions,
 		codec,
 		onRtpSender,
 	}: HandlerSendOptions): Promise<HandlerSendResult> {
@@ -367,15 +382,30 @@ export class Chrome111
 			onRtpSender(transceiver.sender);
 		}
 
-		const offer = await this._pc.createOffer();
+		let offer = await this._pc.createOffer();
 		let localSdpObject = sdpTransform.parse(offer.sdp!);
 
 		if (localSdpObject.extmapAllowMixed) {
 			this._remoteSdp.setSessionExtmapAllowMixed();
 		}
 
-		const nativeRtpCapabilities =
-			Chrome111.getLocalRtpCapabilities(localSdpObject);
+		const extraHeaderExtensions: {
+			uri: RtpHeaderExtensionUri;
+			kind: MediaKind;
+			direction: RtpHeaderExtensionDirection;
+		}[] = [];
+
+		extraHeaderExtensions.push({
+			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+			kind: track.kind as MediaKind,
+			direction: 'sendonly',
+		});
+
+		const nativeRtpCapabilities = Chrome111.getLocalRtpCapabilities(
+			localSdpObject,
+			extraHeaderExtensions
+		);
+
 		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
 			nativeRtpCapabilities
 		);
@@ -409,6 +439,27 @@ export class Chrome111
 				localDtlsRole: this._forcedLocalDtlsRole ?? 'client',
 				localSdpObject,
 			});
+		}
+
+		// Optimize. Only generate new offer if needed.
+		if (headerExtensionOptions?.absCaptureTime) {
+			const offerMediaObject = localSdpObject.media[mediaSectionIdx.idx]!;
+
+			sdpCommonUtils.addHeaderExtension({
+				offerMediaObject,
+				headerExtensionUri:
+					'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+				headerExtensionId: sendingRemoteRtpParameters.headerExtensions!.find(
+					headerExtension =>
+						headerExtension.uri ===
+						'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time'
+				)!.id,
+			});
+
+			offer = {
+				type: 'offer',
+				sdp: sdpTransform.write(localSdpObject),
+			};
 		}
 
 		logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -11,6 +11,8 @@ import type {
 	MediaKind,
 	RtpEncodingParameters,
 	ExtendedRtpCapabilities,
+	RtpHeaderExtensionUri,
+	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
 import * as sdpCommonUtils from './sdp/commonUtils';
@@ -123,7 +125,12 @@ export class Chrome74
 	}
 
 	private static getLocalRtpCapabilities(
-		localSdpObject: SdpTransform.SessionDescription
+		localSdpObject: SdpTransform.SessionDescription,
+		extraHeaderExtensions: {
+			uri: RtpHeaderExtensionUri;
+			kind: MediaKind;
+			direction: RtpHeaderExtensionDirection;
+		}[] = []
 	): RtpCapabilities {
 		const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
 			sdpObject: localSdpObject,
@@ -134,6 +141,13 @@ export class Chrome74
 
 		// libwebrtc supports NACK for OPUS but doesn't announce it.
 		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+
+		for (const headerExtension of extraHeaderExtensions) {
+			ortcUtils.addHeaderExtensionSupport(
+				nativeRtpCapabilities,
+				headerExtension
+			);
+		}
 
 		return nativeRtpCapabilities;
 	}
@@ -321,6 +335,7 @@ export class Chrome74
 		track,
 		encodings,
 		codecOptions,
+		headerExtensionOptions,
 		codec,
 	}: HandlerSendOptions): Promise<HandlerSendResult> {
 		this.assertNotClosed();
@@ -347,8 +362,23 @@ export class Chrome74
 			this._remoteSdp.setSessionExtmapAllowMixed();
 		}
 
-		const nativeRtpCapabilities =
-			Chrome74.getLocalRtpCapabilities(localSdpObject);
+		const extraHeaderExtensions: {
+			uri: RtpHeaderExtensionUri;
+			kind: MediaKind;
+			direction: RtpHeaderExtensionDirection;
+		}[] = [];
+
+		extraHeaderExtensions.push({
+			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+			kind: track.kind as MediaKind,
+			direction: 'sendonly',
+		});
+
+		const nativeRtpCapabilities = Chrome74.getLocalRtpCapabilities(
+			localSdpObject,
+			extraHeaderExtensions
+		);
+
 		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
 			nativeRtpCapabilities
 		);
@@ -417,6 +447,27 @@ export class Chrome74
 		}
 
 		logger.debug('send() | calling pc.setLocalDescription() [offer:%o]', offer);
+
+		// Optimize. Only generate new offer if needed.
+		if (headerExtensionOptions?.absCaptureTime) {
+			offerMediaObject = localSdpObject.media[mediaSectionIdx.idx]!;
+
+			sdpCommonUtils.addHeaderExtension({
+				offerMediaObject,
+				headerExtensionUri:
+					'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+				headerExtensionId: sendingRemoteRtpParameters.headerExtensions!.find(
+					headerExtension =>
+						headerExtension.uri ===
+						'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time'
+				)!.id,
+			});
+
+			offer = {
+				type: 'offer',
+				sdp: sdpTransform.write(localSdpObject),
+			};
+		}
 
 		await this._pc.setLocalDescription(offer);
 

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -6,7 +6,11 @@ import type {
 	IceGatheringState,
 	ConnectionState,
 } from '../Transport';
-import type { ProducerCodecOptions, OnRtpSenderCallback } from '../Producer';
+import type {
+	ProducerCodecOptions,
+	ProducerHeaderExtensionOptions,
+	OnRtpSenderCallback,
+} from '../Producer';
 import type { OnRtpReceiverCallback } from '../Consumer';
 import type {
 	RtpCapabilities,
@@ -46,6 +50,7 @@ export type HandlerSendOptions = {
 	track: MediaStreamTrack;
 	encodings?: RtpEncodingParameters[];
 	codecOptions?: ProducerCodecOptions;
+	headerExtensionOptions?: ProducerHeaderExtensionOptions;
 	codec?: RtpCodecCapability;
 	onRtpSender?: OnRtpSenderCallback;
 };

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -11,6 +11,8 @@ import type {
 	MediaKind,
 	RtpEncodingParameters,
 	ExtendedRtpCapabilities,
+	RtpHeaderExtensionUri,
+	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
 import type {
@@ -124,7 +126,12 @@ export class ReactNative106
 	}
 
 	private static getLocalRtpCapabilities(
-		localSdpObject: SdpTransform.SessionDescription
+		localSdpObject: SdpTransform.SessionDescription,
+		extraHeaderExtensions: {
+			uri: RtpHeaderExtensionUri;
+			kind: MediaKind;
+			direction: RtpHeaderExtensionDirection;
+		}[] = []
 	): RtpCapabilities {
 		const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
 			sdpObject: localSdpObject,
@@ -135,6 +142,13 @@ export class ReactNative106
 
 		// libwebrtc supports NACK for OPUS but doesn't announce it.
 		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+
+		for (const headerExtension of extraHeaderExtensions) {
+			ortcUtils.addHeaderExtensionSupport(
+				nativeRtpCapabilities,
+				headerExtension
+			);
+		}
 
 		return nativeRtpCapabilities;
 	}
@@ -327,6 +341,7 @@ export class ReactNative106
 		track,
 		encodings,
 		codecOptions,
+		headerExtensionOptions,
 		codec,
 		onRtpSender,
 	}: HandlerSendOptions): Promise<HandlerSendResult> {
@@ -359,8 +374,23 @@ export class ReactNative106
 			this._remoteSdp.setSessionExtmapAllowMixed();
 		}
 
-		const nativeRtpCapabilities =
-			ReactNative106.getLocalRtpCapabilities(localSdpObject);
+		const extraHeaderExtensions: {
+			uri: RtpHeaderExtensionUri;
+			kind: MediaKind;
+			direction: RtpHeaderExtensionDirection;
+		}[] = [];
+
+		extraHeaderExtensions.push({
+			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+			kind: track.kind as MediaKind,
+			direction: 'sendonly',
+		});
+
+		const nativeRtpCapabilities = ReactNative106.getLocalRtpCapabilities(
+			localSdpObject,
+			extraHeaderExtensions
+		);
+
 		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
 			nativeRtpCapabilities
 		);
@@ -424,6 +454,27 @@ export class ReactNative106
 
 			offer = {
 				type: 'offer' as RTCSdpType,
+				sdp: sdpTransform.write(localSdpObject),
+			};
+		}
+
+		// Optimize. Only generate new offer if needed.
+		if (headerExtensionOptions?.absCaptureTime) {
+			offerMediaObject = localSdpObject.media[mediaSectionIdx.idx]!;
+
+			sdpCommonUtils.addHeaderExtension({
+				offerMediaObject,
+				headerExtensionUri:
+					'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+				headerExtensionId: sendingRemoteRtpParameters.headerExtensions!.find(
+					headerExtension =>
+						headerExtension.uri ===
+						'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time'
+				)!.id,
+			});
+
+			offer = {
+				type: 'offer',
 				sdp: sdpTransform.write(localSdpObject),
 			};
 		}

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -10,6 +10,8 @@ import type {
 	RtpCapabilities,
 	MediaKind,
 	ExtendedRtpCapabilities,
+	RtpHeaderExtensionUri,
+	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
 import type {
@@ -122,7 +124,12 @@ export class Safari12
 	}
 
 	private static getLocalRtpCapabilities(
-		localSdpObject: SdpTransform.SessionDescription
+		localSdpObject: SdpTransform.SessionDescription,
+		extraHeaderExtensions: {
+			uri: RtpHeaderExtensionUri;
+			kind: MediaKind;
+			direction: RtpHeaderExtensionDirection;
+		}[] = []
 	): RtpCapabilities {
 		const nativeRtpCapabilities = sdpCommonUtils.extractRtpCapabilities({
 			sdpObject: localSdpObject,
@@ -133,6 +140,13 @@ export class Safari12
 
 		// libwebrtc supports NACK for OPUS but doesn't announce it.
 		ortcUtils.addNackSupportForOpus(nativeRtpCapabilities);
+
+		for (const headerExtension of extraHeaderExtensions) {
+			ortcUtils.addHeaderExtensionSupport(
+				nativeRtpCapabilities,
+				headerExtension
+			);
+		}
 
 		return nativeRtpCapabilities;
 	}
@@ -331,6 +345,7 @@ export class Safari12
 		track,
 		encodings,
 		codecOptions,
+		headerExtensionOptions,
 		codec,
 		onRtpSender,
 	}: HandlerSendOptions): Promise<HandlerSendResult> {
@@ -356,8 +371,23 @@ export class Safari12
 			this._remoteSdp.setSessionExtmapAllowMixed();
 		}
 
-		const nativeRtpCapabilities =
-			Safari12.getLocalRtpCapabilities(localSdpObject);
+		const extraHeaderExtensions: {
+			uri: RtpHeaderExtensionUri;
+			kind: MediaKind;
+			direction: RtpHeaderExtensionDirection;
+		}[] = [];
+
+		extraHeaderExtensions.push({
+			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+			kind: track.kind as MediaKind,
+			direction: 'sendonly',
+		});
+
+		const nativeRtpCapabilities = Safari12.getLocalRtpCapabilities(
+			localSdpObject,
+			extraHeaderExtensions
+		);
+
 		const sendExtendedRtpCapabilities = this._getSendExtendedRtpCapabilities(
 			nativeRtpCapabilities
 		);
@@ -412,6 +442,27 @@ export class Safari12
 
 			offer = {
 				type: 'offer' as RTCSdpType,
+				sdp: sdpTransform.write(localSdpObject),
+			};
+		}
+
+		// Optimize. Only generate new offer if needed.
+		if (headerExtensionOptions?.absCaptureTime) {
+			offerMediaObject = localSdpObject.media[mediaSectionIdx.idx]!;
+
+			sdpCommonUtils.addHeaderExtension({
+				offerMediaObject,
+				headerExtensionUri:
+					'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+				headerExtensionId: sendingRemoteRtpParameters.headerExtensions!.find(
+					headerExtension =>
+						headerExtension.uri ===
+						'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time'
+				)!.id,
+			});
+
+			offer = {
+				type: 'offer',
 				sdp: sdpTransform.write(localSdpObject),
 			};
 		}

--- a/src/handlers/ortc/utils.ts
+++ b/src/handlers/ortc/utils.ts
@@ -1,4 +1,9 @@
-import type { RtpCapabilities } from '../../RtpParameters';
+import type {
+	RtpCapabilities,
+	MediaKind,
+	RtpHeaderExtensionUri,
+	RtpHeaderExtensionDirection,
+} from '../../RtpParameters';
 
 /**
  * This function adds RTCP NACK support for OPUS codec in given capabilities.
@@ -17,4 +22,51 @@ export function addNackSupportForOpus(rtpCapabilities: RtpCapabilities): void {
 			codec.rtcpFeedback.push({ type: 'nack' });
 		}
 	}
+}
+
+/**
+ * This function adds the given RTP header extension to given capabilities.
+ */
+export function addHeaderExtensionSupport(
+	rtpCapabilities: RtpCapabilities,
+	headerExtension: {
+		uri: RtpHeaderExtensionUri;
+		kind: MediaKind;
+		direction: RtpHeaderExtensionDirection;
+	}
+): void {
+	if (
+		rtpCapabilities.headerExtensions?.some(
+			exten =>
+				exten.kind === headerExtension.kind && exten.uri === headerExtension.uri
+		)
+	) {
+		return;
+	}
+
+	if (!rtpCapabilities.headerExtensions) {
+		rtpCapabilities.headerExtensions = [];
+	}
+
+	const setPreferredIds = new Set(
+		rtpCapabilities.headerExtensions
+			.filter(exten => exten.uri !== headerExtension.uri)
+			.map(exten => exten.preferredId)
+	);
+
+	let preferredId: number = 1;
+
+	while (setPreferredIds.has(preferredId)) {
+		++preferredId;
+	}
+
+	const newHeaderExtension = {
+		kind: headerExtension.kind,
+		uri: headerExtension.uri,
+		preferredId,
+		preferredEncrypt: false,
+		direction: headerExtension.direction,
+	};
+
+	rtpCapabilities.headerExtensions.push(newHeaderExtension);
 }

--- a/src/handlers/sdp/commonUtils.ts
+++ b/src/handlers/sdp/commonUtils.ts
@@ -275,3 +275,25 @@ export function applyCodecParameters({
 		}
 	}
 }
+
+/**
+ * Add header extension in the given SDP m= section offer.
+ */
+export function addHeaderExtension({
+	offerMediaObject,
+	headerExtensionUri,
+	headerExtensionId,
+}: {
+	offerMediaObject: SdpTransform.MediaDescription;
+	headerExtensionUri: RtpHeaderExtensionUri;
+	headerExtensionId: number;
+}): void {
+	if (!offerMediaObject.ext) {
+		offerMediaObject.ext = [];
+	}
+
+	offerMediaObject.ext.push({
+		uri: headerExtensionUri,
+		value: headerExtensionId,
+	});
+}


### PR DESCRIPTION
# Details

- When calling `sendTransport.produce()` a new option `headerExtensionOptions` can be given:
  ```ts
  type ProducerHeaderExtensionOptions = {
    absCaptureTime?: boolean;
  };
  ```
- If `absCaptureTime` is set to `true`, then the `abs-capture-time` header extension will be added to the SDP negotiation and the browser will add such a header extension into RTP packets.