### PR TITLE
`RtpParameters`: add `msid` optional field

### DIFF
--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -7,9 +7,9 @@ import type { AppData } from './types';
 const logger = new Logger('Consumer');
 
 export type ConsumerOptions<ConsumerAppData extends AppData = AppData> = {
-	id?: string;
-	producerId?: string;
-	kind?: 'audio' | 'video';
+	id: string;
+	producerId: string;
+	kind: 'audio' | 'video';
 	rtpParameters: RtpParameters;
 	streamId?: string;
 	onRtpReceiver?: OnRtpReceiverCallback;

--- a/src/DataConsumer.ts
+++ b/src/DataConsumer.ts
@@ -7,8 +7,8 @@ const logger = new Logger('DataConsumer');
 
 export type DataConsumerOptions<DataConsumerAppData extends AppData = AppData> =
 	{
-		id?: string;
-		dataProducerId?: string;
+		id: string;
+		dataProducerId: string;
 		sctpStreamParameters: SctpStreamParameters;
 		label?: string;
 		protocol?: string;

--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -13,6 +13,7 @@ const logger = new Logger('Producer');
 
 export type ProducerOptions<ProducerAppData extends AppData = AppData> = {
 	track?: MediaStreamTrack;
+	stream?: MediaStream;
 	encodings?: RtpEncodingParameters[];
 	codecOptions?: ProducerCodecOptions;
 	headerExtensionOptions?: ProducerHeaderExtensionOptions;

--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -13,7 +13,7 @@ const logger = new Logger('Producer');
 
 export type ProducerOptions<ProducerAppData extends AppData = AppData> = {
 	track?: MediaStreamTrack;
-	stream?: MediaStream;
+	streamId?: string;
 	encodings?: RtpEncodingParameters[];
 	codecOptions?: ProducerCodecOptions;
 	headerExtensionOptions?: ProducerHeaderExtensionOptions;

--- a/src/RtpParameters.ts
+++ b/src/RtpParameters.ts
@@ -164,6 +164,12 @@ export type RtpParameters = {
 	 * Parameters used for RTCP.
 	 */
 	rtcp?: RtcpParameters;
+	/**
+	 * MSID (WebRTC MediaStream Identification).
+	 *
+	 * @see https://datatracker.ietf.org/doc/html/rfc8830
+	 */
+	msid?: string;
 };
 
 /**

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -500,7 +500,7 @@ export class Transport<
 	 */
 	async produce<ProducerAppData extends AppData = AppData>({
 		track,
-		stream,
+		streamId,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -588,7 +588,7 @@ export class Transport<
 					const { localId, rtpParameters, rtpSender } =
 						await this._handler.send({
 							track,
-							stream,
+							streamId,
 							encodings: normalizedEncodings,
 							codecOptions,
 							headerExtensionOptions,

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -500,6 +500,7 @@ export class Transport<
 	 */
 	async produce<ProducerAppData extends AppData = AppData>({
 		track,
+		stream,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -587,6 +588,7 @@ export class Transport<
 					const { localId, rtpParameters, rtpSender } =
 						await this._handler.send({
 							track,
+							stream,
 							encodings: normalizedEncodings,
 							codecOptions,
 							headerExtensionOptions,
@@ -902,8 +904,8 @@ export class Transport<
 						task.consumerOptions;
 
 					optionsList.push({
-						trackId: id!,
-						kind: kind!,
+						trackId: id,
+						kind: kind,
 						rtpParameters,
 						streamId,
 						onRtpReceiver,
@@ -920,9 +922,9 @@ export class Transport<
 							task.consumerOptions;
 						const { localId, rtpReceiver, track } = result;
 						const consumer: Consumer<ConsumerAppData> = new Consumer({
-							id: id!,
+							id,
 							localId,
-							producerId: producerId!,
+							producerId,
 							rtpReceiver,
 							track,
 							rtpParameters,

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -336,7 +336,7 @@ export class Chrome111
 
 	async send({
 		track,
-		stream,
+		streamId,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -347,10 +347,10 @@ export class Chrome111
 		this.assertSendDirection();
 
 		logger.debug(
-			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			'send() [kind:%s, track.id:%s, streamId:%s]',
 			track.kind,
 			track.id,
-			stream?.id
+			streamId
 		);
 
 		if (encodings && encodings.length > 1) {
@@ -380,7 +380,7 @@ export class Chrome111
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [stream ?? this._sendStream],
+			streams: [this._sendStream],
 			sendEncodings: encodings,
 		});
 
@@ -488,7 +488,7 @@ export class Chrome111
 		});
 
 		// Set msid.
-		sendingRtpParameters.msid = offerMediaObject.msid;
+		sendingRtpParameters.msid = `${streamId ?? this._sendStream.id} ${track.id}`;
 
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -487,8 +487,6 @@ export class Chrome111
 			offerMediaObject,
 		});
 
-		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
-
 		// Set msid.
 		sendingRtpParameters.msid = offerMediaObject.msid;
 
@@ -536,8 +534,6 @@ export class Chrome111
 
 		// Store in the map.
 		this._mapMidTransceiver.set(localId, transceiver);
-
-		console.log('FOOOO sendingRtpParameters:', sendingRtpParameters);
 
 		return {
 			localId,
@@ -923,8 +919,6 @@ export class Chrome111
 			const { msidStreamId } = ortcUtils.getMsidStreamIdAndTrackId(
 				rtpParameters.msid
 			);
-
-			console.log('FOOOOO receive() msidStreamId:%o', msidStreamId);
 
 			this._remoteSdp.receive({
 				mid: localId,

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -14,6 +14,7 @@ import type {
 	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
 import * as ortcUtils from './ortc/utils';
@@ -31,7 +32,6 @@ import type {
 	HandlerReceiveDataChannelOptions,
 	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
-import { RemoteSdp } from './sdp/RemoteSdp';
 
 const logger = new Logger('Chrome111');
 
@@ -914,7 +914,7 @@ export class Chrome111
 
 			mapLocalId.set(trackId, localId);
 
-			// We ignore MSID `trackId` when consuming and always us our computed
+			// We ignore MSID `trackId` when consuming and always use our computed
 			// `trackId` which matches the `consumer.id`.
 			const { msidStreamId } = ortcUtils.getMsidStreamIdAndTrackId(
 				rtpParameters.msid

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -60,7 +60,7 @@ export class Chrome111
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Local stream for sending.
+	// Default local stream for sending if no stream is given.
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;
@@ -336,6 +336,7 @@ export class Chrome111
 
 	async send({
 		track,
+		stream,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -345,7 +346,12 @@ export class Chrome111
 		this.assertNotClosed();
 		this.assertSendDirection();
 
-		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+		logger.debug(
+			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			track.kind,
+			track.id,
+			stream?.id
+		);
 
 		if (encodings && encodings.length > 1) {
 			// Set rid and verify scalabilityMode in each encoding.
@@ -374,7 +380,7 @@ export class Chrome111
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [this._sendStream],
+			streams: [stream ?? this._sendStream],
 			sendEncodings: encodings,
 		});
 
@@ -481,6 +487,11 @@ export class Chrome111
 			offerMediaObject,
 		});
 
+		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
+
+		// Set msid.
+		sendingRtpParameters.msid = offerMediaObject.msid;
+
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {
 			sendingRtpParameters.encodings = sdpUnifiedPlanUtils.getRtpEncodings({
@@ -525,6 +536,8 @@ export class Chrome111
 
 		// Store in the map.
 		this._mapMidTransceiver.set(localId, transceiver);
+
+		console.log('FOOOO sendingRtpParameters:', sendingRtpParameters);
 
 		return {
 			localId,
@@ -905,11 +918,19 @@ export class Chrome111
 
 			mapLocalId.set(trackId, localId);
 
+			// We ignore MSID `trackId` when consuming and always us our computed
+			// `trackId` which matches the `consumer.id`.
+			const { msidStreamId } = ortcUtils.getMsidStreamIdAndTrackId(
+				rtpParameters.msid
+			);
+
+			console.log('FOOOOO receive() msidStreamId:%o', msidStreamId);
+
 			this._remoteSdp.receive({
 				mid: localId,
 				kind,
 				offerRtpParameters: rtpParameters,
-				streamId: streamId ?? rtpParameters.rtcp!.cname!,
+				streamId: streamId ?? msidStreamId ?? rtpParameters.rtcp?.cname ?? '-',
 				trackId,
 			});
 		}

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -60,7 +60,7 @@ export class Chrome111
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Default local stream for sending if no stream is given.
+	// Default local stream for sending if no `streamId` is given in send().
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -61,7 +61,7 @@ export class Chrome74
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Default local stream for sending if no stream is given.
+	// Default local stream for sending if no `streamId` is given in send().
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -333,7 +333,7 @@ export class Chrome74
 
 	async send({
 		track,
-		stream,
+		streamId,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -343,10 +343,10 @@ export class Chrome74
 		this.assertSendDirection();
 
 		logger.debug(
-			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			'send() [kind:%s, track.id:%s, streamId:%s]',
 			track.kind,
 			track.id,
-			stream?.id
+			streamId
 		);
 
 		if (encodings && encodings.length > 1) {
@@ -358,7 +358,7 @@ export class Chrome74
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [stream ?? this._sendStream],
+			streams: [this._sendStream],
 			sendEncodings: encodings,
 		});
 		let offer = await this._pc.createOffer();
@@ -489,6 +489,9 @@ export class Chrome74
 		sendingRtpParameters.rtcp!.cname = sdpCommonUtils.getCname({
 			offerMediaObject,
 		});
+
+		// Set msid.
+		sendingRtpParameters.msid = `${streamId ?? this._sendStream.id} ${track.id}`;
 
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -15,6 +15,7 @@ import type {
 	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
 import * as ortcUtils from './ortc/utils';
@@ -32,7 +33,6 @@ import type {
 	HandlerReceiveDataChannelOptions,
 	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
-import { RemoteSdp } from './sdp/RemoteSdp';
 
 const logger = new Logger('Chrome74');
 
@@ -938,11 +938,17 @@ export class Chrome74
 
 			mapLocalId.set(trackId, localId);
 
+			// We ignore MSID `trackId` when consuming and always use our computed
+			// `trackId` which matches the `consumer.id`.
+			const { msidStreamId } = ortcUtils.getMsidStreamIdAndTrackId(
+				rtpParameters.msid
+			);
+
 			this._remoteSdp.receive({
 				mid: localId,
 				kind,
 				offerRtpParameters: rtpParameters,
-				streamId: streamId ?? rtpParameters.rtcp!.cname!,
+				streamId: streamId ?? msidStreamId ?? rtpParameters.rtcp?.cname ?? '-',
 				trackId,
 			});
 		}

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -490,8 +490,6 @@ export class Chrome74
 			offerMediaObject,
 		});
 
-		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
-
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {
 			sendingRtpParameters.encodings = sdpUnifiedPlanUtils.getRtpEncodings({

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -61,7 +61,7 @@ export class Chrome74
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Local stream for sending.
+	// Default local stream for sending if no stream is given.
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;
@@ -333,6 +333,7 @@ export class Chrome74
 
 	async send({
 		track,
+		stream,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -341,7 +342,12 @@ export class Chrome74
 		this.assertNotClosed();
 		this.assertSendDirection();
 
-		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+		logger.debug(
+			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			track.kind,
+			track.id,
+			stream?.id
+		);
 
 		if (encodings && encodings.length > 1) {
 			encodings.forEach((encoding: RtpEncodingParameters, idx: number) => {
@@ -352,7 +358,7 @@ export class Chrome74
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [this._sendStream],
+			streams: [stream ?? this._sendStream],
 			sendEncodings: encodings,
 		});
 		let offer = await this._pc.createOffer();
@@ -483,6 +489,8 @@ export class Chrome74
 		sendingRtpParameters.rtcp!.cname = sdpCommonUtils.getCname({
 			offerMediaObject,
 		});
+
+		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
 
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -179,7 +179,7 @@ export class FakeHandler
 
 	async send(
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		{ track, encodings, codecOptions, codec }: HandlerSendOptions
+		{ track, stream, encodings, codecOptions, codec }: HandlerSendOptions
 	): Promise<HandlerSendResult> {
 		this.assertNotClosed();
 
@@ -213,6 +213,8 @@ export class FakeHandler
 		);
 
 		sendingRtpParameters.mid = `mid-${utils.generateRandomNumber()}`;
+
+		sendingRtpParameters.msid = `${stream?.id ?? '-'} ${track.id}`;
 
 		if (!encodings) {
 			encodings = [{}];

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -65,6 +65,8 @@ export class FakeHandler
 	) => ExtendedRtpCapabilities;
 	// Local RTCP CNAME.
 	private _cname = `CNAME-${utils.generateRandomNumber()}`;
+	// Default sending MediaStream id.
+	private _defaultSendStreamId = `${utils.generateRandomNumber()}`;
 	// Got transport local and remote parameters.
 	private _transportReady = false;
 	// Next localId.
@@ -179,7 +181,7 @@ export class FakeHandler
 
 	async send(
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		{ track, stream, encodings, codecOptions, codec }: HandlerSendOptions
+		{ track, streamId, encodings, codecOptions, codec }: HandlerSendOptions
 	): Promise<HandlerSendResult> {
 		this.assertNotClosed();
 
@@ -214,7 +216,7 @@ export class FakeHandler
 
 		sendingRtpParameters.mid = `mid-${utils.generateRandomNumber()}`;
 
-		sendingRtpParameters.msid = `${stream?.id ?? '-'} ${track.id}`;
+		sendingRtpParameters.msid = `${streamId ?? '-'} ${track.id}`;
 
 		if (!encodings) {
 			encodings = [{}];
@@ -236,6 +238,9 @@ export class FakeHandler
 			reducedSize: true,
 			mux: true,
 		};
+
+		// Set msid.
+		sendingRtpParameters.msid = `${streamId ?? this._defaultSendStreamId} ${track.id}`;
 
 		const localId = this._nextLocalId++;
 

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -19,6 +19,13 @@ import type {
 	ExtendedRtpCapabilities,
 } from '../RtpParameters';
 import type { SctpCapabilities } from '../SctpParameters';
+import { FakeEventTarget } from './fakeEvents/FakeEventTarget';
+import {
+	FakeEventListener,
+	FakeAddEventListenerOptions,
+	FakeEventListenerOptions,
+} from './fakeEvents/FakeEventListener';
+import { FakeEvent } from './fakeEvents/FakeEvent';
 import type {
 	HandlerFactory,
 	HandlerInterface,
@@ -33,13 +40,6 @@ import type {
 	HandlerReceiveDataChannelOptions,
 	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
-import { FakeEventTarget } from './fakeEvents/FakeEventTarget';
-import {
-	FakeEventListener,
-	FakeAddEventListenerOptions,
-	FakeEventListenerOptions,
-} from './fakeEvents/FakeEventListener';
-import { FakeEvent } from './fakeEvents/FakeEvent';
 
 const logger = new Logger('FakeHandler');
 

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -55,7 +55,7 @@ export class Firefox120
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Local stream for sending.
+	// Default local stream for sending if no stream is given.
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;
@@ -336,6 +336,7 @@ export class Firefox120
 
 	async send({
 		track,
+		stream,
 		encodings,
 		codecOptions,
 		codec,
@@ -344,7 +345,12 @@ export class Firefox120
 		this.assertNotClosed();
 		this.assertSendDirection();
 
-		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+		logger.debug(
+			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			track.kind,
+			track.id,
+			stream?.id
+		);
 
 		if (encodings && encodings.length > 1) {
 			encodings.forEach((encoding: RtpEncodingParameters, idx: number) => {
@@ -360,7 +366,7 @@ export class Firefox120
 
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [this._sendStream],
+			streams: [stream ?? this._sendStream],
 			sendEncodings: encodings,
 		});
 
@@ -434,6 +440,8 @@ export class Firefox120
 		sendingRtpParameters.rtcp!.cname = sdpCommonUtils.getCname({
 			offerMediaObject,
 		});
+
+		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
 
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -56,7 +56,7 @@ export class Firefox120
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Default local stream for sending if no stream is given.
+	// Default local stream for sending if no `streamId` is given in send().
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -336,7 +336,7 @@ export class Firefox120
 
 	async send({
 		track,
-		stream,
+		streamId,
 		encodings,
 		codecOptions,
 		codec,
@@ -346,10 +346,10 @@ export class Firefox120
 		this.assertSendDirection();
 
 		logger.debug(
-			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			'send() [kind:%s, track.id:%s, streamId:%s]',
 			track.kind,
 			track.id,
-			stream?.id
+			streamId
 		);
 
 		if (encodings && encodings.length > 1) {
@@ -366,7 +366,7 @@ export class Firefox120
 
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [stream ?? this._sendStream],
+			streams: [this._sendStream],
 			sendEncodings: encodings,
 		});
 
@@ -440,6 +440,9 @@ export class Firefox120
 		sendingRtpParameters.rtcp!.cname = sdpCommonUtils.getCname({
 			offerMediaObject,
 		});
+
+		// Set msid.
+		sendingRtpParameters.msid = `${streamId ?? this._sendStream.id} ${track.id}`;
 
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -13,8 +13,10 @@ import type {
 	ExtendedRtpCapabilities,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
+import * as ortcUtils from './ortc/utils';
 import type {
 	HandlerFactory,
 	HandlerInterface,
@@ -29,7 +31,6 @@ import type {
 	HandlerReceiveDataChannelOptions,
 	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
-import { RemoteSdp } from './sdp/RemoteSdp';
 
 const logger = new Logger('Firefox120');
 
@@ -882,11 +883,17 @@ export class Firefox120
 
 			mapLocalId.set(trackId, localId);
 
+			// We ignore MSID `trackId` when consuming and always use our computed
+			// `trackId` which matches the `consumer.id`.
+			const { msidStreamId } = ortcUtils.getMsidStreamIdAndTrackId(
+				rtpParameters.msid
+			);
+
 			this._remoteSdp.receive({
 				mid: localId,
 				kind,
 				offerRtpParameters: rtpParameters,
-				streamId: streamId ?? rtpParameters.rtcp!.cname!,
+				streamId: streamId ?? msidStreamId ?? rtpParameters.rtcp?.cname ?? '-',
 				trackId,
 			});
 		}

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -441,8 +441,6 @@ export class Firefox120
 			offerMediaObject,
 		});
 
-		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
-
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {
 			sendingRtpParameters.encodings = sdpUnifiedPlanUtils.getRtpEncodings({

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -48,6 +48,7 @@ export type HandlerFactory = {
 
 export type HandlerSendOptions = {
 	track: MediaStreamTrack;
+	stream?: MediaStream;
 	encodings?: RtpEncodingParameters[];
 	codecOptions?: ProducerCodecOptions;
 	headerExtensionOptions?: ProducerHeaderExtensionOptions;

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -48,7 +48,13 @@ export type HandlerFactory = {
 
 export type HandlerSendOptions = {
 	track: MediaStreamTrack;
-	stream?: MediaStream;
+	/**
+	 * Stream id (it affects the `id` field of the `a=msid` attribute in the
+	 * local SDP. If not given, all `Producers` will have the same `streamId`
+	 * in their `rtpParameters.msid`. Such a value tells consuming endpoints
+	 * which tracks to syncronize on reception.
+	 */
+	streamId?: string;
 	encodings?: RtpEncodingParameters[];
 	codecOptions?: ProducerCodecOptions;
 	headerExtensionOptions?: ProducerHeaderExtensionOptions;
@@ -67,8 +73,9 @@ export type HandlerReceiveOptions = {
 	kind: 'audio' | 'video';
 	rtpParameters: RtpParameters;
 	/**
-	 * Stream id. WebRTC based devices try to synchronize inbound streams with
-	 * same streamId. If not given, the consuming device will be told to
+	 * Stream id (it affects the `id` field of the `a=msid` attribute in the
+	 * remote SDP. WebRTC based devices try to synchronize inbound streams with
+	 * same `streamId`. If not given, the consuming device will be told to
 	 * synchronize all streams produced by the same endpoint. However libwebrtc
 	 * can just synchronize up to one audio stream with one video stream.
 	 */

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -339,7 +339,7 @@ export class ReactNative106
 
 	async send({
 		track,
-		stream,
+		streamId,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -350,10 +350,10 @@ export class ReactNative106
 		this.assertSendDirection();
 
 		logger.debug(
-			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			'send() [kind:%s, track.id:%s, streamId:%s]',
 			track.kind,
 			track.id,
-			stream?.id
+			streamId
 		);
 
 		if (encodings && encodings.length > 1) {
@@ -365,7 +365,7 @@ export class ReactNative106
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [stream ?? this._sendStream],
+			streams: [this._sendStream],
 			sendEncodings: encodings,
 		});
 
@@ -514,6 +514,9 @@ export class ReactNative106
 		sendingRtpParameters.rtcp!.cname = sdpCommonUtils.getCname({
 			offerMediaObject,
 		});
+
+		// Set msid.
+		sendingRtpParameters.msid = `${streamId ?? this._sendStream.id} ${track.id}`;
 
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -61,7 +61,7 @@ export class ReactNative106
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Local stream for sending.
+	// Default local stream for sending if no stream is given.
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;
@@ -339,6 +339,7 @@ export class ReactNative106
 
 	async send({
 		track,
+		stream,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -348,7 +349,12 @@ export class ReactNative106
 		this.assertNotClosed();
 		this.assertSendDirection();
 
-		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+		logger.debug(
+			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			track.kind,
+			track.id,
+			stream?.id
+		);
 
 		if (encodings && encodings.length > 1) {
 			encodings.forEach((encoding: RtpEncodingParameters, idx: number) => {
@@ -359,7 +365,7 @@ export class ReactNative106
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [this._sendStream],
+			streams: [stream ?? this._sendStream],
 			sendEncodings: encodings,
 		});
 
@@ -508,6 +514,8 @@ export class ReactNative106
 		sendingRtpParameters.rtcp!.cname = sdpCommonUtils.getCname({
 			offerMediaObject,
 		});
+
+		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
 
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -61,7 +61,7 @@ export class ReactNative106
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Default local stream for sending if no stream is given.
+	// Default local stream for sending if no `streamId` is given in send().
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -15,6 +15,10 @@ import type {
 	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import { RemoteSdp } from './sdp/RemoteSdp';
+import * as sdpCommonUtils from './sdp/commonUtils';
+import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
+import * as ortcUtils from './ortc/utils';
 import type {
 	HandlerFactory,
 	HandlerInterface,
@@ -29,10 +33,6 @@ import type {
 	HandlerReceiveDataChannelOptions,
 	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
-import { RemoteSdp } from './sdp/RemoteSdp';
-import * as sdpCommonUtils from './sdp/commonUtils';
-import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
-import * as ortcUtils from './ortc/utils';
 
 const logger = new Logger('ReactNative106');
 
@@ -972,11 +972,17 @@ export class ReactNative106
 
 			mapLocalId.set(trackId, localId);
 
+			// We ignore MSID `trackId` when consuming and always use our computed
+			// `trackId` which matches the `consumer.id`.
+			const { msidStreamId } = ortcUtils.getMsidStreamIdAndTrackId(
+				rtpParameters.msid
+			);
+
 			this._remoteSdp.receive({
 				mid: localId,
 				kind,
 				offerRtpParameters: rtpParameters,
-				streamId: streamId ?? rtpParameters.rtcp!.cname!,
+				streamId: streamId ?? msidStreamId ?? rtpParameters.rtcp?.cname ?? '-',
 				trackId,
 			});
 		}

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -515,8 +515,6 @@ export class ReactNative106
 			offerMediaObject,
 		});
 
-		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
-
 		// Set RTP encodings by parsing the SDP offer if no encodings are given.
 		if (!encodings) {
 			sendingRtpParameters.encodings = sdpUnifiedPlanUtils.getRtpEncodings({

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -60,7 +60,7 @@ export class Safari12
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Local stream for sending.
+	// Default local stream for sending if no stream is given.
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;
@@ -343,6 +343,7 @@ export class Safari12
 
 	async send({
 		track,
+		stream,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -352,12 +353,17 @@ export class Safari12
 		this.assertNotClosed();
 		this.assertSendDirection();
 
-		logger.debug('send() [kind:%s, track.id:%s]', track.kind, track.id);
+		logger.debug(
+			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			track.kind,
+			track.id,
+			stream?.id
+		);
 
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [this._sendStream],
+			streams: [stream ?? this._sendStream],
 		});
 
 		if (onRtpSender) {
@@ -484,6 +490,8 @@ export class Safari12
 		sendingRtpParameters.rtcp!.cname = sdpCommonUtils.getCname({
 			offerMediaObject,
 		});
+
+		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
 
 		// Set RTP encodings.
 		sendingRtpParameters.encodings = sdpUnifiedPlanUtils.getRtpEncodings({

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -60,7 +60,7 @@ export class Safari12
 	// Map of RTCTransceivers indexed by MID.
 	private readonly _mapMidTransceiver: Map<string, RTCRtpTransceiver> =
 		new Map();
-	// Default local stream for sending if no stream is given.
+	// Default local stream for sending if no `streamId` is given in send().
 	private readonly _sendStream = new MediaStream();
 	// Whether a DataChannel m=application section has been created.
 	private _hasDataChannelMediaSection = false;

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -343,7 +343,7 @@ export class Safari12
 
 	async send({
 		track,
-		stream,
+		streamId,
 		encodings,
 		codecOptions,
 		headerExtensionOptions,
@@ -354,16 +354,16 @@ export class Safari12
 		this.assertSendDirection();
 
 		logger.debug(
-			'send() [kind:%s, track.id:%s, stream.id:%s]',
+			'send() [kind:%s, track.id:%s, streamId:%s]',
 			track.kind,
 			track.id,
-			stream?.id
+			streamId
 		);
 
 		const mediaSectionIdx = this._remoteSdp.getNextMediaSectionIdx();
 		const transceiver = this._pc.addTransceiver(track, {
 			direction: 'sendonly',
-			streams: [stream ?? this._sendStream],
+			streams: [this._sendStream],
 		});
 
 		if (onRtpSender) {
@@ -490,6 +490,9 @@ export class Safari12
 		sendingRtpParameters.rtcp!.cname = sdpCommonUtils.getCname({
 			offerMediaObject,
 		});
+
+		// Set msid.
+		sendingRtpParameters.msid = `${streamId ?? this._sendStream.id} ${track.id}`;
 
 		// Set RTP encodings.
 		sendingRtpParameters.encodings = sdpUnifiedPlanUtils.getRtpEncodings({

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -491,8 +491,6 @@ export class Safari12
 			offerMediaObject,
 		});
 
-		console.log('FOOO offerMediaObject.msid:', offerMediaObject.msid);
-
 		// Set RTP encodings.
 		sendingRtpParameters.encodings = sdpUnifiedPlanUtils.getRtpEncodings({
 			offerMediaObject,

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -14,6 +14,10 @@ import type {
 	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
 import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import { RemoteSdp } from './sdp/RemoteSdp';
+import * as sdpCommonUtils from './sdp/commonUtils';
+import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
+import * as ortcUtils from './ortc/utils';
 import type {
 	HandlerFactory,
 	HandlerInterface,
@@ -28,10 +32,6 @@ import type {
 	HandlerReceiveDataChannelOptions,
 	HandlerReceiveDataChannelResult,
 } from './HandlerInterface';
-import { RemoteSdp } from './sdp/RemoteSdp';
-import * as sdpCommonUtils from './sdp/commonUtils';
-import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
-import * as ortcUtils from './ortc/utils';
 
 const logger = new Logger('Safari12');
 
@@ -925,11 +925,17 @@ export class Safari12
 
 			mapLocalId.set(trackId, localId);
 
+			// We ignore MSID `trackId` when consuming and always use our computed
+			// `trackId` which matches the `consumer.id`.
+			const { msidStreamId } = ortcUtils.getMsidStreamIdAndTrackId(
+				rtpParameters.msid
+			);
+
 			this._remoteSdp.receive({
 				mid: localId,
 				kind,
 				offerRtpParameters: rtpParameters,
-				streamId: streamId ?? rtpParameters.rtcp!.cname!,
+				streamId: streamId ?? msidStreamId ?? rtpParameters.rtcp?.cname ?? '-',
 				trackId,
 			});
 		}

--- a/src/handlers/ortc/utils.ts
+++ b/src/handlers/ortc/utils.ts
@@ -70,3 +70,24 @@ export function addHeaderExtensionSupport(
 
 	rtpCapabilities.headerExtensions.push(newHeaderExtension);
 }
+
+export function getMsidStreamIdAndTrackId(msid?: string): {
+	msidStreamId?: string;
+	msidTrackId?: string;
+} {
+	if (!msid || typeof msid !== 'string') {
+		return { msidStreamId: undefined, msidTrackId: undefined };
+	}
+
+	/**
+	 * `msidStreamId` must be an id or '-' (no stream).
+	 * `msidTrackId` is an optional id.
+	 */
+	const [msidStreamId, msidTrackId] = msid.trim().split(/\s+/);
+
+	if (!msidStreamId) {
+		return { msidStreamId: undefined, msidTrackId: undefined };
+	}
+
+	return { msidStreamId, msidTrackId };
+}

--- a/src/handlers/sdp/MediaSection.ts
+++ b/src/handlers/sdp/MediaSection.ts
@@ -479,6 +479,7 @@ export class OfferMediaSection extends MediaSection {
 		plainRtpParameters?: PlainRtpParameters;
 		mid: string;
 		kind: MediaKind | 'application';
+		// Those are optionals because they are only given if `kind` is a MediaKind.
 		offerRtpParameters?: RtpParameters;
 		streamId?: string;
 		trackId?: string;
@@ -518,7 +519,7 @@ export class OfferMediaSection extends MediaSection {
 				this._mediaObject.rtp = [];
 				this._mediaObject.rtcpFb = [];
 				this._mediaObject.fmtp = [];
-				this._mediaObject.msid = `${streamId ?? '-'} ${trackId}`;
+				this._mediaObject.msid = `${streamId} ${trackId}`;
 
 				for (const codec of offerRtpParameters!.codecs) {
 					const rtp: SdpTransform.MediaAttributes['rtp'][number] = {

--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -84,8 +84,6 @@ export class RemoteSdp {
 
 		// If DTLS parameters are given, assume WebRTC and BUNDLE.
 		if (dtlsParameters) {
-			this._sdpObject.msidSemantic = { semantic: 'WMS', token: '*' };
-
 			// NOTE: We take the latest fingerprint.
 			const numFingerprints = this._dtlsParameters!.fingerprints.length;
 
@@ -190,15 +188,15 @@ export class RemoteSdp {
 
 		// Unified-Plan with closed media section replacement.
 		if (reuseMid) {
-			this._replaceMediaSection(mediaSection, reuseMid);
+			this.replaceMediaSection(mediaSection, reuseMid);
 		}
 		// Unified-Plan or Plan-B with different media kind.
 		else if (!this._midToIndex.has(mediaSection.mid)) {
-			this._addMediaSection(mediaSection);
+			this.addMediaSection(mediaSection);
 		}
 		// Plan-B with same media kind.
 		else {
-			this._replaceMediaSection(mediaSection);
+			this.replaceMediaSection(mediaSection);
 		}
 	}
 
@@ -236,32 +234,32 @@ export class RemoteSdp {
 		const oldMediaSection = this._mediaSections.find(m => m.closed);
 
 		if (oldMediaSection) {
-			this._replaceMediaSection(mediaSection, oldMediaSection.mid);
+			this.replaceMediaSection(mediaSection, oldMediaSection.mid);
 		} else {
-			this._addMediaSection(mediaSection);
+			this.addMediaSection(mediaSection);
 		}
 	}
 
 	pauseMediaSection(mid: string): void {
-		const mediaSection = this._findMediaSection(mid);
+		const mediaSection = this.findMediaSection(mid);
 
 		mediaSection.pause();
 	}
 
 	resumeSendingMediaSection(mid: string): void {
-		const mediaSection = this._findMediaSection(mid);
+		const mediaSection = this.findMediaSection(mid);
 
 		mediaSection.resume();
 	}
 
 	resumeReceivingMediaSection(mid: string): void {
-		const mediaSection = this._findMediaSection(mid);
+		const mediaSection = this.findMediaSection(mid);
 
 		mediaSection.resume();
 	}
 
 	disableMediaSection(mid: string): void {
-		const mediaSection = this._findMediaSection(mid);
+		const mediaSection = this.findMediaSection(mid);
 
 		mediaSection.disable();
 	}
@@ -274,7 +272,7 @@ export class RemoteSdp {
 	 * transport, so instead closing it we just disable it.
 	 */
 	closeMediaSection(mid: string): boolean {
-		const mediaSection = this._findMediaSection(mid);
+		const mediaSection = this.findMediaSection(mid);
 
 		// NOTE: Closing the first m section is a pain since it invalidates the
 		// bundled transport, so let's avoid it.
@@ -292,7 +290,7 @@ export class RemoteSdp {
 		mediaSection.close();
 
 		// Regenerate BUNDLE mids.
-		this._regenerateBundleMids();
+		this.regenerateBundleMids();
 
 		return true;
 	}
@@ -301,11 +299,11 @@ export class RemoteSdp {
 		mid: string,
 		encodings: RTCRtpEncodingParameters[]
 	): void {
-		const mediaSection = this._findMediaSection(mid) as AnswerMediaSection;
+		const mediaSection = this.findMediaSection(mid) as AnswerMediaSection;
 
 		mediaSection.muxSimulcastStreams(encodings);
 
-		this._replaceMediaSection(mediaSection);
+		this.replaceMediaSection(mediaSection);
 	}
 
 	sendSctpAssociation({
@@ -322,7 +320,7 @@ export class RemoteSdp {
 			offerMediaObject,
 		});
 
-		this._addMediaSection(mediaSection);
+		this.addMediaSection(mediaSection);
 	}
 
 	receiveSctpAssociation(): void {
@@ -336,7 +334,7 @@ export class RemoteSdp {
 			kind: 'application',
 		});
 
-		this._addMediaSection(mediaSection);
+		this.addMediaSection(mediaSection);
 	}
 
 	getSdp(): string {
@@ -346,7 +344,7 @@ export class RemoteSdp {
 		return sdpTransform.write(this._sdpObject);
 	}
 
-	_addMediaSection(newMediaSection: MediaSection): void {
+	private addMediaSection(newMediaSection: MediaSection): void {
 		if (!this._firstMid) {
 			this._firstMid = newMediaSection.mid;
 		}
@@ -361,10 +359,13 @@ export class RemoteSdp {
 		this._sdpObject.media.push(newMediaSection.getObject());
 
 		// Regenerate BUNDLE mids.
-		this._regenerateBundleMids();
+		this.regenerateBundleMids();
 	}
 
-	_replaceMediaSection(newMediaSection: MediaSection, reuseMid?: string): void {
+	private replaceMediaSection(
+		newMediaSection: MediaSection,
+		reuseMid?: string
+	): void {
 		// Store it in the map.
 		if (typeof reuseMid === 'string') {
 			const idx = this._midToIndex.get(reuseMid);
@@ -386,7 +387,7 @@ export class RemoteSdp {
 			this._sdpObject.media[idx] = newMediaSection.getObject();
 
 			// Regenerate BUNDLE mids.
-			this._regenerateBundleMids();
+			this.regenerateBundleMids();
 		} else {
 			const idx = this._midToIndex.get(newMediaSection.mid);
 
@@ -404,7 +405,7 @@ export class RemoteSdp {
 		}
 	}
 
-	_findMediaSection(mid: string): MediaSection {
+	private findMediaSection(mid: string): MediaSection {
 		const idx = this._midToIndex.get(mid);
 
 		if (idx === undefined) {
@@ -414,7 +415,7 @@ export class RemoteSdp {
 		return this._mediaSections[idx]!;
 	}
 
-	_regenerateBundleMids(): void {
+	private regenerateBundleMids(): void {
 		if (!this._dtlsParameters) {
 			return;
 		}


### PR DESCRIPTION
# Details

- Specification: [RFC 8830](https://datatracker.ietf.org/doc/html/rfc8830)
- Corresponding PR in mediasoup: https://github.com/versatica/mediasoup/pull/1634
- The `msid` field contains a string which consists on `MEDIA_STREAM_ID MEDIA_STREAM_TRACK_ID?`, where `MEDIA_STREAM_ID` is the `id` of the `MediaStream` the sender endpoint. The `MEDIA_STREAM_ID` is used to group media stream tracks in reception side, and the endpoint/browser uses it to sync audio and video inbound stream tracks / consumers.
- Until now, when calling `sendTransport.produce({track, ...})` we always append the `track` to a single and internally created `MediaStream` in each handler. Now `produce()` as a new optional `streamId?: string` field. If given, the new `rtpParameters.msid` field of the `Producer` will have the given `streamId` as first component (the `msid` `id` field, which is the stream `id`) instead of using `this._sendStream.id`.
- So generated `RtpParameters` of the `Producer` will contain `msid` field.
- When calling `recvTransport.consume({ id, rtpParameters, ... })`, the `msid` (if present) in `rtpParameters` will be used to generate the `a=msid` attribute in the media section of the remote SDP. Note: Just the `MEDIA_STREAM_ID` (the `id` field of the `msid` line) will be honoured. The `MEDIA_STREAM_TRACK_ID` will remain matching the `consumer.id` value.

# Why?

- If the sender wants to send mic audio, webcam video and screen sharing over the same sending transport, now it can say that only mic audio and webcam video tracks must be synced when in reception (remember that libwebrtc can only sync one inbound audio track with one inbound video track). To achieve that, the sender should call `produce()` for mic and webcam without `streamId` parameter (or with same `streamId` parameter) and then call `produce()` for screen sharing with a different `streamId`.

# Bonus tracks

- Improve some signatures and types.
- `RemoteSdp`: Stop adding deprecated `a=msid-semantic` global attribute. It was dropped in favour of the new `a=msid` media session attribute as per [RFC 8830](https://datatracker.ietf.org/doc/html/rfc8830).

# Notes

- `msid` should be an array because a `MediaStreamTrack` can belong to N `MediaStream`. Unfortunately `sdp-transform` is buggy here and assumes a single entry. [PR done](https://github.com/clux/sdp-transform/pull/104) in mainstream project, although it would require both a new NPM version and new `@types/sdp-transform` version. Anyway, by design we only allow a single `MediaStream` so we are good.

# TODO

- [x] Website documentation.