### PR TITLE
Fix regression in Chrome 143 due to changes in RTP extensions handling

### DIFF
--- a/src/handlers/sdp/MediaSection.ts
+++ b/src/handlers/sdp/MediaSection.ts
@@ -107,7 +107,12 @@ export abstract class MediaSection {
 
 	disable(): void {
 		this.pause();
+	}
 
+	close(): void {
+		this.disable();
+
+		this._mediaObject.port = 0;
 		delete this._mediaObject.ext;
 		delete this._mediaObject.ssrcs;
 		delete this._mediaObject.ssrcGroups;
@@ -115,12 +120,6 @@ export abstract class MediaSection {
 		delete this._mediaObject.simulcast_03;
 		delete this._mediaObject.rids;
 		delete this._mediaObject.extmapAllowMixed;
-	}
-
-	close(): void {
-		this.disable();
-
-		this._mediaObject.port = 0;
 	}
 }
 

--- a/src/handlers/sdp/MediaSection.ts
+++ b/src/handlers/sdp/MediaSection.ts
@@ -112,8 +112,19 @@ export abstract class MediaSection {
 	close(): void {
 		this.disable();
 
+		// Set port in m= line to 0, which means that the media sction is closed.
 		this._mediaObject.port = 0;
-		delete this._mediaObject.ext;
+
+		// NOTE: Do not remove header extensions since it's controversial in the spec.
+		delete this._mediaObject.candidates;
+		delete this._mediaObject.endOfCandidates;
+		delete this._mediaObject.iceUfrag;
+		delete this._mediaObject.icePwd;
+		delete this._mediaObject.iceOptions;
+		this._mediaObject.rtp = [];
+		this._mediaObject.fmtp = [];
+		delete this._mediaObject.rtcp;
+		delete this._mediaObject.rtcpFb;
 		delete this._mediaObject.ssrcs;
 		delete this._mediaObject.ssrcGroups;
 		delete this._mediaObject.simulcast;


### PR DESCRIPTION
# Details

- Fixes #353
- Tested in Chrome 143.
- Tested in Opera 122 which uses Chromium version:138.0.7204.251.
- Tested in Firefox 144.0.2.
- Tested in Safari 18.6.

## Rationale

Chrome 143 complains when we disable the first m= section in the sending PeerConnection. It complains because its locally generated offer contains simulcast attributes but the SDP answer mediasoup-client generates doesn't contain the corresponding RTP extensions for simulcast (RID). And since we are not closing the transceiver (because it's the first one so it would disconnect ICE), we only "disable" it which means that the response has "a=inactive" but the lack of RID extension makes Chrome 143 throw an error because the offer requests simulcast. Solution is to NOT remove RTP extension attributes from the disabled m= section in the remote SDP answer, and only do it when closing the transceiver (which involves remote port set to 0).