### PR TITLE
Handle sending and receiving RTP capabilities separately

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -134,6 +134,8 @@ export class Device {
 	) => ExtendedRtpCapabilities;
 	// Local RTP capabilities for receiving media.
 	private _recvRtpCapabilities?: RtpCapabilities;
+	// Local RTP capabilities for sending media.
+	private _sendRtpCapabilities?: RtpCapabilities;
 	// Whether we can produce audio/video based on remote RTP capabilities.
 	private readonly _canProduceByKind: CanProduceByKind = {
 		audio: false,
@@ -260,14 +262,38 @@ export class Device {
 	/**
 	 * RTP capabilities of the Device for receiving media.
 	 *
+	 * @deprecated Use {@link rtpReceiveCapabilities} instead.
+	 *
 	 * @throws {InvalidStateError} if not loaded.
 	 */
 	get rtpCapabilities(): RtpCapabilities {
+		return this.rtpReceiveCapabilities;
+	}
+
+	/**
+	 * RTP capabilities of the Device for receiving media.
+	 *
+	 * @throws {InvalidStateError} if not loaded.
+	 */
+	get rtpReceiveCapabilities(): RtpCapabilities {
 		if (!this._loaded) {
 			throw new InvalidStateError('not loaded');
 		}
 
 		return this._recvRtpCapabilities!;
+	}
+
+	/**
+	 * RTP capabilities of the Device for sending media.
+	 *
+	 * @throws {InvalidStateError} if not loaded.
+	 */
+	get rtpSendCapabilities(): RtpCapabilities {
+		if (!this._loaded) {
+			throw new InvalidStateError('not loaded');
+		}
+
+		return this._sendRtpCapabilities!;
 	}
 
 	/**
@@ -314,16 +340,30 @@ export class Device {
 		const { getNativeRtpCapabilities, getNativeSctpCapabilities } =
 			this._handlerFactory;
 
-		const clonedNativeRtpCapabilities = utils.clone<RtpCapabilities>(
-			await getNativeRtpCapabilities()
+		const clonedNativeRtpReceiveCapabilities = utils.clone<RtpCapabilities>(
+			await getNativeRtpCapabilities('recvonly')
 		);
 
 		// This may throw.
-		ortc.validateAndNormalizeRtpCapabilities(clonedNativeRtpCapabilities);
+		ortc.validateAndNormalizeRtpCapabilities(
+			clonedNativeRtpReceiveCapabilities
+		);
 
 		logger.debug(
-			'load() | got native RTP capabilities:%o',
-			clonedNativeRtpCapabilities
+			'load() | got native RTP capabilities for receiving:%o',
+			clonedNativeRtpReceiveCapabilities
+		);
+
+		const clonedNativeRtpSendCapabilities = utils.clone<RtpCapabilities>(
+			await getNativeRtpCapabilities('sendonly')
+		);
+
+		// This may throw.
+		ortc.validateAndNormalizeRtpCapabilities(clonedNativeRtpSendCapabilities);
+
+		logger.debug(
+			'load() | got native RTP capabilities for sending:%o',
+			clonedNativeRtpSendCapabilities
 		);
 
 		this._getSendExtendedRtpCapabilities = (
@@ -339,14 +379,25 @@ export class Device {
 		};
 
 		const recvExtendedRtpCapabilities = ortc.getExtendedRtpCapabilities(
-			clonedNativeRtpCapabilities,
+			clonedNativeRtpReceiveCapabilities,
 			clonedRouterRtpCapabilities,
 			/* preferLocalCodecsOrder */ false
+		);
+
+		const sendExtendedRtpCapabilities = ortc.getExtendedRtpCapabilities(
+			clonedNativeRtpSendCapabilities,
+			clonedRouterRtpCapabilities,
+			preferLocalCodecsOrder
 		);
 
 		// Generate our receiving RTP capabilities for receiving media.
 		this._recvRtpCapabilities = ortc.getRecvRtpCapabilities(
 			recvExtendedRtpCapabilities
+		);
+
+		// Generate our sending RTP capabilities for sending media.
+		this._sendRtpCapabilities = ortc.getSendRtpCapabilities(
+			sendExtendedRtpCapabilities
 		);
 
 		// This may throw.
@@ -360,11 +411,11 @@ export class Device {
 		// Check whether we can produce audio/video.
 		this._canProduceByKind.audio = ortc.canSend(
 			'audio',
-			this._recvRtpCapabilities
+			this._sendRtpCapabilities
 		);
 		this._canProduceByKind.video = ortc.canSend(
 			'video',
-			this._recvRtpCapabilities
+			this._sendRtpCapabilities
 		);
 
 		// Generate our SCTP capabilities.

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -76,7 +76,9 @@ export class Chrome111
 		return {
 			name: NAME,
 			factory: (options: HandlerOptions): Chrome111 => new Chrome111(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
+			getNativeRtpCapabilities: async (
+				direction: 'sendonly' | 'recvonly'
+			): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
@@ -87,10 +89,13 @@ export class Chrome111
 				});
 
 				try {
-					pc.addTransceiver('audio');
+					pc.addTransceiver('audio', {
+						direction,
+					});
 					// Create video transceiver with scalability mode in order to retrieve
 					// Dependency Descriptor header extension.
 					pc.addTransceiver('video', {
+						direction,
 						sendEncodings: [{ scalabilityMode: 'L3T3' }],
 					});
 

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -77,7 +77,9 @@ export class Chrome74
 		return {
 			name: NAME,
 			factory: (options: HandlerOptions): Chrome74 => new Chrome74(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
+			getNativeRtpCapabilities: async (
+				direction: 'sendonly' | 'recvonly'
+			): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
@@ -88,8 +90,12 @@ export class Chrome74
 				});
 
 				try {
-					pc.addTransceiver('audio');
-					pc.addTransceiver('video');
+					pc.addTransceiver('audio', {
+						direction,
+					});
+					pc.addTransceiver('video', {
+						direction,
+					});
 
 					const offer = await pc.createOffer();
 

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -72,7 +72,9 @@ export class Firefox120
 		return {
 			name: NAME,
 			factory: (options: HandlerOptions): Firefox120 => new Firefox120(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
+			getNativeRtpCapabilities: async (
+				direction: 'sendonly' | 'recvonly'
+			): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
@@ -93,10 +95,10 @@ export class Firefox120
 				const fakeVideoTrack = fakeStream.getVideoTracks()[0]!;
 
 				try {
-					pc.addTransceiver('audio', { direction: 'sendrecv' });
+					pc.addTransceiver('audio', { direction });
 
 					pc.addTransceiver(fakeVideoTrack, {
-						direction: 'sendrecv',
+						direction,
 						sendEncodings: [
 							{ rid: 'r0', maxBitrate: 100000 },
 							{ rid: 'r1', maxBitrate: 500000 },

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -42,7 +42,9 @@ export type HandlerOptions = {
 export type HandlerFactory = {
 	name: string;
 	factory: (options: HandlerOptions) => HandlerInterface;
-	getNativeRtpCapabilities(): Promise<RtpCapabilities>;
+	getNativeRtpCapabilities(
+		direction: 'sendonly' | 'recvonly'
+	): Promise<RtpCapabilities>;
 	getNativeSctpCapabilities(): Promise<SctpCapabilities>;
 };
 

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -78,7 +78,9 @@ export class ReactNative106
 			name: NAME,
 			factory: (options: HandlerOptions): ReactNative106 =>
 				new ReactNative106(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
+			getNativeRtpCapabilities: async (
+				direction: 'sendonly' | 'recvonly'
+			): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
@@ -89,8 +91,8 @@ export class ReactNative106
 				});
 
 				try {
-					pc.addTransceiver('audio');
-					pc.addTransceiver('video');
+					pc.addTransceiver('audio', { direction });
+					pc.addTransceiver('video', { direction });
 
 					const offer = await pc.createOffer();
 

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -76,7 +76,9 @@ export class Safari12
 		return {
 			name: NAME,
 			factory: (options: HandlerOptions): Safari12 => new Safari12(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
+			getNativeRtpCapabilities: async (
+				direction: 'sendonly' | 'recvonly'
+			): Promise<RtpCapabilities> => {
 				logger.debug('getNativeRtpCapabilities()');
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
@@ -87,8 +89,8 @@ export class Safari12
 				});
 
 				try {
-					pc.addTransceiver('audio');
-					pc.addTransceiver('video');
+					pc.addTransceiver('audio', { direction });
+					pc.addTransceiver('video', { direction });
 
 					const offer = await pc.createOffer();
 

--- a/src/ortc.ts
+++ b/src/ortc.ts
@@ -368,6 +368,27 @@ export function getExtendedRtpCapabilities(
 export function getRecvRtpCapabilities(
 	extendedRtpCapabilities: ExtendedRtpCapabilities
 ): RtpCapabilities {
+	return getRtpCapabilities(extendedRtpCapabilities, 'recv');
+}
+
+/**
+ * Generate RTP capabilities for sending media based on the given extended
+ * RTP capabilities.
+ */
+export function getSendRtpCapabilities(
+	extendedRtpCapabilities: ExtendedRtpCapabilities
+): RtpCapabilities {
+	return getRtpCapabilities(extendedRtpCapabilities, 'send');
+}
+
+/**
+ * Generate RTP capabilities for media based on the given extended
+ * RTP capabilities.
+ */
+function getRtpCapabilities(
+	extendedRtpCapabilities: ExtendedRtpCapabilities,
+	direction: 'send' | 'recv'
+): RtpCapabilities {
 	const rtpCapabilities: RtpCapabilities = {
 		codecs: [],
 		headerExtensions: [],
@@ -408,10 +429,10 @@ export function getRecvRtpCapabilities(
 	}
 
 	for (const extendedExtension of extendedRtpCapabilities.headerExtensions) {
-		// Ignore RTP extensions not valid for receiving.
+		// Ignore RTP extensions not valid for the given direction.
 		if (
 			extendedExtension.direction !== 'sendrecv' &&
-			extendedExtension.direction !== 'recvonly'
+			extendedExtension.direction !== `${direction}only`
 		) {
 			continue;
 		}

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -207,6 +207,14 @@ test('device.rtpCapabilities getter throws InvalidStateError if not loaded', () 
 	expect(() => ctx.device!.rtpCapabilities).toThrow(InvalidStateError);
 });
 
+test('device.rtpReceiveCapabilities getter throws InvalidStateError if not loaded', () => {
+	expect(() => ctx.device!.rtpReceiveCapabilities).toThrow(InvalidStateError);
+});
+
+test('device.rtpSendCapabilities getter throws InvalidStateError if not loaded', () => {
+	expect(() => ctx.device!.rtpSendCapabilities).toThrow(InvalidStateError);
+});
+
 test('device.sctpCapabilities getter throws InvalidStateError if not loaded', () => {
 	expect(() => ctx.device!.sctpCapabilities).toThrow(InvalidStateError);
 });
@@ -278,6 +286,14 @@ test('device.load() rejects with InvalidStateError if already loaded', async () 
 
 test('device.rtpCapabilities getter succeeds', () => {
 	expect(typeof ctx.loadedDevice!.rtpCapabilities).toBe('object');
+});
+
+test('device.rtpReceiveCapabilities getter succeeds', () => {
+	expect(typeof ctx.loadedDevice!.rtpReceiveCapabilities).toBe('object');
+});
+
+test('device.rtpSendCapabilities getter succeeds', () => {
+	expect(typeof ctx.loadedDevice!.rtpSendCapabilities).toBe('object');
 });
 
 test('device.sctpCapabilities getter succeeds', () => {
@@ -491,7 +507,7 @@ test('transport.produce() succeeds', async () => {
 	// Use disableTrackOnPause: false and zeroRtpOnPause: true
 	const videoProducer = await ctx.connectedSendTransport!.produce({
 		track: videoTrack,
-		codec: ctx.loadedDevice!.rtpCapabilities.codecs!.find(
+		codec: ctx.loadedDevice!.rtpSendCapabilities.codecs!.find(
 			codec => codec.mimeType.toLowerCase() === 'video/vp9'
 		),
 		encodings: videoEncodings,


### PR DESCRIPTION
@ibc as you mentioned in this ticket (#141):

"The device can later create send transports and recv transports. There is where we should run different code to get capabilities from a local SDP offer. But unfortunately we don't do that (yet)."

As the library has separate transports we don't need to set the direction in the Device constructor anymore but we can have a direction parameter in the getNativeRtpCapabilities. This will solve the problem mentioned in #141 that our team has as well: if the device can not encode (send) something the library won't detect the capability for decoding (receiving). By setting the direction for the transceivers in the getNativeRtpCapabilities we will get the correct capabilities for sending and receiving which are possibly different.

I tried to keep the public interface backward compatible (rtpCapabilities is doing the same as before but with the fix so it's really the capabilities for receiving media) and extend it with new functionalities: rtpReceiveCapabilities, rtpSendCapabilities.
The getRecvRtpCapabilities is working as before, I've just refactored it to a helper function and added the new getSendRtpCapabilities.

I hope you like it and can merge as soon as possible. In case you have any requests feel free to ask, I'm more than happy to fix anything related to this problem.