### PR TITLE
Separate RTP capabilities for sending and receiving

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -130,10 +130,12 @@ export class Device {
 	// Callback for sending Transports to request sending extended RTP capabilities
 	// on demand.
 	private _getSendExtendedRtpCapabilities?: (
-		nativeRtpCapabilities: RtpCapabilities
+		nativeSendRtpCapabilities: RtpCapabilities
 	) => ExtendedRtpCapabilities;
 	// Local RTP capabilities for receiving media.
 	private _recvRtpCapabilities?: RtpCapabilities;
+	// Local RTP capabilities for sending media.
+	private _sendRtpCapabilities?: RtpCapabilities;
 	// Whether we can produce audio/video based on remote RTP capabilities.
 	private readonly _canProduceByKind: CanProduceByKind = {
 		audio: false,
@@ -260,14 +262,38 @@ export class Device {
 	/**
 	 * RTP capabilities of the Device for receiving media.
 	 *
+	 * @deprecated Use {@link recvRtpCapabilities} instead.
+	 *
 	 * @throws {InvalidStateError} if not loaded.
 	 */
 	get rtpCapabilities(): RtpCapabilities {
+		return this.recvRtpCapabilities;
+	}
+
+	/**
+	 * RTP capabilities of the Device for receiving media.
+	 *
+	 * @throws {InvalidStateError} if not loaded.
+	 */
+	get recvRtpCapabilities(): RtpCapabilities {
 		if (!this._loaded) {
 			throw new InvalidStateError('not loaded');
 		}
 
 		return this._recvRtpCapabilities!;
+	}
+
+	/**
+	 * RTP capabilities of the Device for sending media.
+	 *
+	 * @throws {InvalidStateError} if not loaded.
+	 */
+	get sendRtpCapabilities(): RtpCapabilities {
+		if (!this._loaded) {
+			throw new InvalidStateError('not loaded');
+		}
+
+		return this._sendRtpCapabilities!;
 	}
 
 	/**
@@ -314,24 +340,36 @@ export class Device {
 		const { getNativeRtpCapabilities, getNativeSctpCapabilities } =
 			this._handlerFactory;
 
-		const clonedNativeRtpCapabilities = utils.clone<RtpCapabilities>(
-			await getNativeRtpCapabilities()
+		const clonedNativeRecvRtpCapabilities = utils.clone<RtpCapabilities>(
+			await getNativeRtpCapabilities({ direction: 'recvonly' })
+		);
+
+		logger.debug(
+			'load() | got native receiving RTP capabilities:%o',
+			clonedNativeRecvRtpCapabilities
 		);
 
 		// This may throw.
-		ortc.validateAndNormalizeRtpCapabilities(clonedNativeRtpCapabilities);
+		ortc.validateAndNormalizeRtpCapabilities(clonedNativeRecvRtpCapabilities);
 
-		logger.debug(
-			'load() | got native RTP capabilities:%o',
-			clonedNativeRtpCapabilities
+		const clonedNativeSendRtpCapabilities = utils.clone<RtpCapabilities>(
+			await getNativeRtpCapabilities({ direction: 'sendonly' })
 		);
 
+		logger.debug(
+			'load() | got native sending RTP capabilities:%o',
+			clonedNativeSendRtpCapabilities
+		);
+
+		// This may throw.
+		ortc.validateAndNormalizeRtpCapabilities(clonedNativeSendRtpCapabilities);
+
 		this._getSendExtendedRtpCapabilities = (
-			nativeRtpCapabilities: RtpCapabilities
+			nativeSendRtpCapabilities: RtpCapabilities
 		) => {
 			return utils.clone<ExtendedRtpCapabilities>(
 				ortc.getExtendedRtpCapabilities(
-					nativeRtpCapabilities,
+					nativeSendRtpCapabilities,
 					clonedRouterRtpCapabilities,
 					preferLocalCodecsOrder
 				)
@@ -339,7 +377,7 @@ export class Device {
 		};
 
 		const recvExtendedRtpCapabilities = ortc.getExtendedRtpCapabilities(
-			clonedNativeRtpCapabilities,
+			clonedNativeRecvRtpCapabilities,
 			clonedRouterRtpCapabilities,
 			/* preferLocalCodecsOrder */ false
 		);
@@ -349,22 +387,41 @@ export class Device {
 			recvExtendedRtpCapabilities
 		);
 
-		// This may throw.
-		ortc.validateAndNormalizeRtpCapabilities(this._recvRtpCapabilities);
-
 		logger.debug(
 			'load() | got receiving RTP capabilities:%o',
 			this._recvRtpCapabilities
 		);
 
+		// This may throw.
+		ortc.validateAndNormalizeRtpCapabilities(this._recvRtpCapabilities);
+
+		const sendExtendedRtpCapabilities = ortc.getExtendedRtpCapabilities(
+			clonedNativeSendRtpCapabilities,
+			clonedRouterRtpCapabilities,
+			preferLocalCodecsOrder
+		);
+
+		// Generate our sending RTP capabilities for sending media.
+		this._sendRtpCapabilities = ortc.getSendRtpCapabilities(
+			sendExtendedRtpCapabilities
+		);
+
+		logger.debug(
+			'load() | got sending RTP capabilities:%o',
+			this._sendRtpCapabilities
+		);
+
+		// This may throw.
+		ortc.validateAndNormalizeRtpCapabilities(this._sendRtpCapabilities);
+
 		// Check whether we can produce audio/video.
 		this._canProduceByKind.audio = ortc.canSend(
 			'audio',
-			this._recvRtpCapabilities
+			this._sendRtpCapabilities
 		);
 		this._canProduceByKind.video = ortc.canSend(
 			'video',
-			this._recvRtpCapabilities
+			this._sendRtpCapabilities
 		);
 
 		// Generate our SCTP capabilities.

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -23,6 +23,7 @@ import type {
 	HandlerInterface,
 	HandlerEvents,
 	HandlerOptions,
+	HandlerGetNativeRtpCapabilitiesOptions,
 	HandlerSendOptions,
 	HandlerSendResult,
 	HandlerReceiveOptions,
@@ -50,7 +51,7 @@ export class Chrome111
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
 	private _getSendExtendedRtpCapabilities: (
-		nativeRtpCapabilities: RtpCapabilities
+		nativeSendRtpCapabilities: RtpCapabilities
 	) => ExtendedRtpCapabilities;
 	// Initial server side DTLS role. If not 'auto', it will force the opposite
 	// value in client side.
@@ -76,8 +77,10 @@ export class Chrome111
 		return {
 			name: NAME,
 			factory: (options: HandlerOptions): Chrome111 => new Chrome111(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
-				logger.debug('getNativeRtpCapabilities()');
+			getNativeRtpCapabilities: async ({
+				direction,
+			}: HandlerGetNativeRtpCapabilitiesOptions): Promise<RtpCapabilities> => {
+				logger.debug('getNativeRtpCapabilities() [direction:%o]', direction);
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
@@ -87,10 +90,11 @@ export class Chrome111
 				});
 
 				try {
-					pc.addTransceiver('audio');
+					pc.addTransceiver('audio', { direction });
 					// Create video transceiver with scalability mode in order to retrieve
 					// Dependency Descriptor header extension.
 					pc.addTransceiver('video', {
+						direction,
 						sendEncodings: [{ scalabilityMode: 'L3T3' }],
 					});
 

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -24,6 +24,7 @@ import type {
 	HandlerEvents,
 	HandlerInterface,
 	HandlerOptions,
+	HandlerGetNativeRtpCapabilitiesOptions,
 	HandlerSendOptions,
 	HandlerSendResult,
 	HandlerReceiveOptions,
@@ -51,7 +52,7 @@ export class Chrome74
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
 	private _getSendExtendedRtpCapabilities: (
-		nativeRtpCapabilities: RtpCapabilities
+		nativeSendRtpCapabilities: RtpCapabilities
 	) => ExtendedRtpCapabilities;
 	// Initial server side DTLS role. If not 'auto', it will force the opposite
 	// value in client side.
@@ -77,8 +78,10 @@ export class Chrome74
 		return {
 			name: NAME,
 			factory: (options: HandlerOptions): Chrome74 => new Chrome74(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
-				logger.debug('getNativeRtpCapabilities()');
+			getNativeRtpCapabilities: async ({
+				direction,
+			}: HandlerGetNativeRtpCapabilitiesOptions): Promise<RtpCapabilities> => {
+				logger.debug('getNativeRtpCapabilities() [direction:%o]', direction);
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
@@ -88,8 +91,8 @@ export class Chrome74
 				});
 
 				try {
-					pc.addTransceiver('audio');
-					pc.addTransceiver('video');
+					pc.addTransceiver('audio', { direction });
+					pc.addTransceiver('video', { direction });
 
 					const offer = await pc.createOffer();
 

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -31,6 +31,7 @@ import type {
 	HandlerInterface,
 	HandlerEvents,
 	HandlerOptions,
+	HandlerGetNativeRtpCapabilitiesOptions,
 	HandlerSendOptions,
 	HandlerSendResult,
 	HandlerReceiveOptions,
@@ -84,8 +85,10 @@ export class FakeHandler
 			name: NAME,
 			factory: (options: HandlerOptions): FakeHandler =>
 				new FakeHandler(options, fakeParameters),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
-				logger.debug('getNativeRtpCapabilities()');
+			getNativeRtpCapabilities: async ({
+				direction,
+			}: HandlerGetNativeRtpCapabilitiesOptions): Promise<RtpCapabilities> => {
+				logger.debug('getNativeRtpCapabilities() [direction:%o]', direction);
 
 				return FakeHandler.getLocalRtpCapabilities(fakeParameters);
 			},

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -22,6 +22,7 @@ import type {
 	HandlerInterface,
 	HandlerEvents,
 	HandlerOptions,
+	HandlerGetNativeRtpCapabilitiesOptions,
 	HandlerSendOptions,
 	HandlerSendResult,
 	HandlerReceiveOptions,
@@ -49,7 +50,7 @@ export class Firefox120
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
 	private _getSendExtendedRtpCapabilities: (
-		nativeRtpCapabilities: RtpCapabilities
+		nativeSendRtpCapabilities: RtpCapabilities
 	) => ExtendedRtpCapabilities;
 	// RTCPeerConnection instance.
 	private _pc: RTCPeerConnection;
@@ -72,8 +73,10 @@ export class Firefox120
 		return {
 			name: NAME,
 			factory: (options: HandlerOptions): Firefox120 => new Firefox120(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
-				logger.debug('getNativeRtpCapabilities()');
+			getNativeRtpCapabilities: async ({
+				direction,
+			}: HandlerGetNativeRtpCapabilitiesOptions): Promise<RtpCapabilities> => {
+				logger.debug('getNativeRtpCapabilities() [direction:%o]', direction);
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
@@ -93,10 +96,10 @@ export class Firefox120
 				const fakeVideoTrack = fakeStream.getVideoTracks()[0]!;
 
 				try {
-					pc.addTransceiver('audio', { direction: 'sendrecv' });
+					pc.addTransceiver('audio', { direction });
 
 					pc.addTransceiver(fakeVideoTrack, {
-						direction: 'sendrecv',
+						direction,
 						sendEncodings: [
 							{ rid: 'r0', maxBitrate: 100000 },
 							{ rid: 'r1', maxBitrate: 500000 },

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -25,6 +25,15 @@ import type {
 	SctpStreamParameters,
 } from '../SctpParameters';
 
+export type HandlerFactory = {
+	name: string;
+	factory: (options: HandlerOptions) => HandlerInterface;
+	getNativeRtpCapabilities(
+		options: HandlerGetNativeRtpCapabilitiesOptions
+	): Promise<RtpCapabilities>;
+	getNativeSctpCapabilities(): Promise<SctpCapabilities>;
+};
+
 export type HandlerOptions = {
 	direction: 'send' | 'recv';
 	iceParameters: IceParameters;
@@ -35,15 +44,12 @@ export type HandlerOptions = {
 	iceTransportPolicy?: RTCIceTransportPolicy;
 	additionalSettings?: Partial<RTCConfiguration>;
 	getSendExtendedRtpCapabilities: (
-		nativeRtpCapabilities: RtpCapabilities
+		nativeSendRtpCapabilities: RtpCapabilities
 	) => ExtendedRtpCapabilities;
 };
 
-export type HandlerFactory = {
-	name: string;
-	factory: (options: HandlerOptions) => HandlerInterface;
-	getNativeRtpCapabilities(): Promise<RtpCapabilities>;
-	getNativeSctpCapabilities(): Promise<SctpCapabilities>;
+export type HandlerGetNativeRtpCapabilitiesOptions = {
+	direction: Extract<RTCRtpTransceiverDirection, 'sendonly' | 'recvonly'>;
 };
 
 export type HandlerSendOptions = {

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -24,6 +24,7 @@ import type {
 	HandlerInterface,
 	HandlerEvents,
 	HandlerOptions,
+	HandlerGetNativeRtpCapabilitiesOptions,
 	HandlerSendOptions,
 	HandlerSendResult,
 	HandlerReceiveOptions,
@@ -51,7 +52,7 @@ export class ReactNative106
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
 	private _getSendExtendedRtpCapabilities: (
-		nativeRtpCapabilities: RtpCapabilities
+		nativeSendRtpCapabilities: RtpCapabilities
 	) => ExtendedRtpCapabilities;
 	// Initial server side DTLS role. If not 'auto', it will force the opposite
 	// value in client side.
@@ -78,8 +79,10 @@ export class ReactNative106
 			name: NAME,
 			factory: (options: HandlerOptions): ReactNative106 =>
 				new ReactNative106(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
-				logger.debug('getNativeRtpCapabilities()');
+			getNativeRtpCapabilities: async ({
+				direction,
+			}: HandlerGetNativeRtpCapabilitiesOptions): Promise<RtpCapabilities> => {
+				logger.debug('getNativeRtpCapabilities() [direction:%o]', direction);
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
@@ -89,8 +92,8 @@ export class ReactNative106
 				});
 
 				try {
-					pc.addTransceiver('audio');
-					pc.addTransceiver('video');
+					pc.addTransceiver('audio', { direction });
+					pc.addTransceiver('video', { direction });
 
 					const offer = await pc.createOffer();
 

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -23,6 +23,7 @@ import type {
 	HandlerInterface,
 	HandlerEvents,
 	HandlerOptions,
+	HandlerGetNativeRtpCapabilitiesOptions,
 	HandlerSendOptions,
 	HandlerSendResult,
 	HandlerReceiveOptions,
@@ -50,7 +51,7 @@ export class Safari12
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
 	private _getSendExtendedRtpCapabilities: (
-		nativeRtpCapabilities: RtpCapabilities
+		nativeSendRtpCapabilities: RtpCapabilities
 	) => ExtendedRtpCapabilities;
 	// Initial server side DTLS role. If not 'auto', it will force the opposite
 	// value in client side.
@@ -76,8 +77,10 @@ export class Safari12
 		return {
 			name: NAME,
 			factory: (options: HandlerOptions): Safari12 => new Safari12(options),
-			getNativeRtpCapabilities: async (): Promise<RtpCapabilities> => {
-				logger.debug('getNativeRtpCapabilities()');
+			getNativeRtpCapabilities: async ({
+				direction,
+			}: HandlerGetNativeRtpCapabilitiesOptions): Promise<RtpCapabilities> => {
+				logger.debug('getNativeRtpCapabilities() [direction:%o]', direction);
 
 				let pc: RTCPeerConnection | undefined = new RTCPeerConnection({
 					iceServers: [],
@@ -87,8 +90,8 @@ export class Safari12
 				});
 
 				try {
-					pc.addTransceiver('audio');
-					pc.addTransceiver('video');
+					pc.addTransceiver('audio', { direction });
+					pc.addTransceiver('video', { direction });
 
 					const offer = await pc.createOffer();
 

--- a/src/ortc.ts
+++ b/src/ortc.ts
@@ -368,66 +368,17 @@ export function getExtendedRtpCapabilities(
 export function getRecvRtpCapabilities(
 	extendedRtpCapabilities: ExtendedRtpCapabilities
 ): RtpCapabilities {
-	const rtpCapabilities: RtpCapabilities = {
-		codecs: [],
-		headerExtensions: [],
-	};
+	return getRtpCapabilities({ direction: 'recvonly', extendedRtpCapabilities });
+}
 
-	for (const extendedCodec of extendedRtpCapabilities.codecs) {
-		const codec = {
-			kind: extendedCodec.kind,
-			mimeType: extendedCodec.mimeType,
-			preferredPayloadType: extendedCodec.remotePayloadType,
-			clockRate: extendedCodec.clockRate,
-			channels: extendedCodec.channels,
-			parameters: extendedCodec.localParameters,
-			rtcpFeedback: extendedCodec.rtcpFeedback,
-		};
-
-		rtpCapabilities.codecs!.push(codec);
-
-		// Add RTX codec.
-		if (!extendedCodec.remoteRtxPayloadType) {
-			continue;
-		}
-
-		const rtxCodec: RtpCodecCapability = {
-			kind: extendedCodec.kind,
-			mimeType: `${extendedCodec.kind}/rtx`,
-			preferredPayloadType: extendedCodec.remoteRtxPayloadType,
-			clockRate: extendedCodec.clockRate,
-			parameters: {
-				apt: extendedCodec.remotePayloadType,
-			},
-			rtcpFeedback: [],
-		};
-
-		rtpCapabilities.codecs!.push(rtxCodec);
-
-		// TODO: In the future, we need to add FEC, CN, etc, codecs.
-	}
-
-	for (const extendedExtension of extendedRtpCapabilities.headerExtensions) {
-		// Ignore RTP extensions not valid for receiving.
-		if (
-			extendedExtension.direction !== 'sendrecv' &&
-			extendedExtension.direction !== 'recvonly'
-		) {
-			continue;
-		}
-
-		const ext: RtpHeaderExtension = {
-			kind: extendedExtension.kind,
-			uri: extendedExtension.uri,
-			preferredId: extendedExtension.recvId,
-			preferredEncrypt: extendedExtension.encrypt ?? false,
-			direction: extendedExtension.direction,
-		};
-
-		rtpCapabilities.headerExtensions!.push(ext);
-	}
-
-	return rtpCapabilities;
+/**
+ * Generate RTP capabilities for sending media based on the given extended
+ * RTP capabilities.
+ */
+export function getSendRtpCapabilities(
+	extendedRtpCapabilities: ExtendedRtpCapabilities
+): RtpCapabilities {
+	return getRtpCapabilities({ direction: 'sendonly', extendedRtpCapabilities });
 }
 
 /**
@@ -1070,6 +1021,79 @@ function validateNumSctpStreams(numStreams: NumSctpStreams): void {
 	if (typeof numStreams.MIS !== 'number') {
 		throw new TypeError('missing numStreams.MIS');
 	}
+}
+
+/**
+ * Generate RTP capabilities for sending or receiving media based on the given
+ * extended RTP capabilities.
+ */
+function getRtpCapabilities({
+	direction,
+	extendedRtpCapabilities,
+}: {
+	direction: Extract<RTCRtpTransceiverDirection, 'sendonly' | 'recvonly'>;
+	extendedRtpCapabilities: ExtendedRtpCapabilities;
+}): RtpCapabilities {
+	const rtpCapabilities: RtpCapabilities = {
+		codecs: [],
+		headerExtensions: [],
+	};
+
+	for (const extendedCodec of extendedRtpCapabilities.codecs) {
+		const codec = {
+			kind: extendedCodec.kind,
+			mimeType: extendedCodec.mimeType,
+			preferredPayloadType: extendedCodec.remotePayloadType,
+			clockRate: extendedCodec.clockRate,
+			channels: extendedCodec.channels,
+			parameters: extendedCodec.localParameters,
+			rtcpFeedback: extendedCodec.rtcpFeedback,
+		};
+
+		rtpCapabilities.codecs!.push(codec);
+
+		// Add RTX codec.
+		if (!extendedCodec.remoteRtxPayloadType) {
+			continue;
+		}
+
+		const rtxCodec: RtpCodecCapability = {
+			kind: extendedCodec.kind,
+			mimeType: `${extendedCodec.kind}/rtx`,
+			preferredPayloadType: extendedCodec.remoteRtxPayloadType,
+			clockRate: extendedCodec.clockRate,
+			parameters: {
+				apt: extendedCodec.remotePayloadType,
+			},
+			rtcpFeedback: [],
+		};
+
+		rtpCapabilities.codecs!.push(rtxCodec);
+
+		// TODO: In the future, we need to add FEC, CN, etc, codecs.
+	}
+
+	for (const extendedExtension of extendedRtpCapabilities.headerExtensions) {
+		// Ignore RTP extensions not valid for the given direction.
+		if (
+			extendedExtension.direction !== 'sendrecv' &&
+			extendedExtension.direction !== direction
+		) {
+			continue;
+		}
+
+		const ext: RtpHeaderExtension = {
+			kind: extendedExtension.kind,
+			uri: extendedExtension.uri,
+			preferredId: extendedExtension.recvId,
+			preferredEncrypt: extendedExtension.encrypt ?? false,
+			direction: extendedExtension.direction,
+		};
+
+		rtpCapabilities.headerExtensions!.push(ext);
+	}
+
+	return rtpCapabilities;
 }
 
 function isRtxCodec(codec?: RtpCodecCapability | RtpCodecParameters): boolean {

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -203,8 +203,16 @@ test('create a Device in Node with a valid handlerFactory succeeds', () => {
 	expect(device.loaded).toBe(false);
 });
 
-test('device.rtpCapabilities getter throws InvalidStateError if not loaded', () => {
+test('device.rtpCapabilities (deprecated) getter throws InvalidStateError if not loaded', () => {
 	expect(() => ctx.device!.rtpCapabilities).toThrow(InvalidStateError);
+});
+
+test('device.recvRtpCapabilities getter throws InvalidStateError if not loaded', () => {
+	expect(() => ctx.device!.recvRtpCapabilities).toThrow(InvalidStateError);
+});
+
+test('device.sendRtpCapabilities getter throws InvalidStateError if not loaded', () => {
+	expect(() => ctx.device!.sendRtpCapabilities).toThrow(InvalidStateError);
 });
 
 test('device.sctpCapabilities getter throws InvalidStateError if not loaded', () => {
@@ -278,6 +286,14 @@ test('device.load() rejects with InvalidStateError if already loaded', async () 
 
 test('device.rtpCapabilities getter succeeds', () => {
 	expect(typeof ctx.loadedDevice!.rtpCapabilities).toBe('object');
+});
+
+test('device.recvRtpCapabilities getter succeeds', () => {
+	expect(typeof ctx.loadedDevice!.recvRtpCapabilities).toBe('object');
+});
+
+test('device.sendRtpCapabilities getter succeeds', () => {
+	expect(typeof ctx.loadedDevice!.sendRtpCapabilities).toBe('object');
 });
 
 test('device.sctpCapabilities getter succeeds', () => {
@@ -491,7 +507,7 @@ test('transport.produce() succeeds', async () => {
 	// Use disableTrackOnPause: false and zeroRtpOnPause: true
 	const videoProducer = await ctx.connectedSendTransport!.produce({
 		track: videoTrack,
-		codec: ctx.loadedDevice!.rtpCapabilities.codecs!.find(
+		codec: ctx.loadedDevice!.sendRtpCapabilities.codecs!.find(
 			codec => codec.mimeType.toLowerCase() === 'video/vp9'
 		),
 		encodings: videoEncodings,


### PR DESCRIPTION
# Details

- Fixes #141
- This PR replaces PR #359 but it's basically a copy&paste of it with some minimal cosmetic changes. So absolutely all credits to @6uliver.
- Now we generate different RTP capabilities for sending and receiving and the only change in the public API is that `device.rtpCapabilities` getter is now deprecated and instead the app should use `device.recvRtpCapabilities` and `device.sendRtpCapabilities`.

# TODO

* [x] In the documentation website, document that `device.rtpCapabilities` getter is now deprecated and instead the app should use `device.recvRtpCapabilities` and `device.sendRtpCapabilities`.