### PR TITLE
fix: s.brands.find is not a function error

### DIFF
--- a/src/Device.ts
+++ b/src/Device.ts
@@ -706,7 +706,10 @@ function getChromiumMajorVersion(
 		// Some nasty browser extensions define their own custom
 		// navigator.userAgentData without mandatory `brands` field, so let's be
 		// ready for it.
-		const chromiumBrand = (userAgentData.brands ?? []).find(
+		const brands = Array.isArray(userAgentData.brands)
+			? userAgentData.brands
+			: [];
+		const chromiumBrand = brands.find(
 			b => b.brand === 'Chromium'
 		);
 


### PR DESCRIPTION
**Details**

Some browsers throw `(s.brands ?? []).find is not a function` error when a new Device is created. 

That error prevents people with such browsers from starting any webrtc call.

The fix changes the way we check a browser brands, checking exactly that `brands` property is array, not only null/undefined. 