### PR TITLE
fix: prevent media type mismatch in closed media section reuse

### DIFF
--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -235,7 +235,7 @@ export class RemoteSdp {
 		});
 
 		// Let's try to recycle a closed media section (if any).
-		// NOTE: Yes, we can recycle a closed m=audio section with a new m=video.
+		// NOTE: We cannot recycle a closed m=audio section as m=video (or vice versa). Firefox rejects the SDP when the media type of a recycled m-line changes.
 		const oldMediaSection = this._mediaSections.find(m => m.closed && m.getObject().type === kind);
 
 		if (oldMediaSection) {

--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -236,7 +236,7 @@ export class RemoteSdp {
 
 		// Let's try to recycle a closed media section (if any).
 		// NOTE: Yes, we can recycle a closed m=audio section with a new m=video.
-		const oldMediaSection = this._mediaSections.find(m => m.closed);
+		const oldMediaSection = this._mediaSections.find(m => m.closed && m.getObject().type === kind);
 
 		if (oldMediaSection) {
 			this.replaceMediaSection(mediaSection, oldMediaSection.mid);


### PR DESCRIPTION
## Description
Fix an issue in `RemoteSdp.receive()` where closed media sections could be recycled 
regardless of their media type, potentially causing type mismatch errors.

## Changes
- Updated the condition for finding recyclable closed media sections
- Now checks that both `m.closed == true` AND `m.getObject().type === kind`
- This ensures only closed sections with matching media kinds (audio/video/etc) are reused

## Motivation
Previously, the code could recycle a closed `m=audio` section for new `m=video` media,
which would cause type inconsistencies. The updated logic ensures type compatibility
when attempting to reuse closed media sections.

## Testing
This fix prevents potential mismatches between the media section type and the requested kind,
improving the robustness of SDP media section management.