### PR TITLE
fix: VP8/H264 simulcast producer fails on mic change in Chrome 148+ (…

### DIFF
--- a/src/handlers/sdp/MediaSection.ts
+++ b/src/handlers/sdp/MediaSection.ts
@@ -338,6 +338,31 @@ export class AnswerMediaSection extends MediaSection {
 					});
 				}
 
+				// Starting with Chrome 148, libwebrtc records every extmap ID seen in
+				// a local offer into a per-PeerConnection history
+				// (historical_rtp_header_extensions_ in BaseChannel, introduced in
+				// https://webrtc.googlesource.com/src/+/5788235). Any subsequent
+				// setLocalDescription that tries to bind the same ID to a different
+				// URI is rejected with "RTP extension ID reassignment not supported".
+				//
+				// Previously, extensions unsupported by the server were simply omitted
+				// from the synthetic answer. Chrome then considered their IDs "free"
+				// and could reuse them when negotiating new m-sections (e.g. adding
+				// audio after video simulcast), triggering the reassignment error.
+				// Including them back in the answer — even without server support —
+				// causes Chrome to permanently associate those IDs with their original
+				// URIs, preventing any future reuse.
+				const confirmedExtUris = new Set(this._mediaObject.ext.map(e => e.uri));
+
+				for (const offerExt of offerMediaObject.ext ?? []) {
+					if (!confirmedExtUris.has(offerExt.uri)) {
+						this._mediaObject.ext.push({
+							uri: offerExt.uri,
+							value: offerExt.value,
+						});
+					}
+				}
+
 				// Allow both 1 byte and 2 bytes length header extensions since
 				// mediasoup can receive both at any time.
 				if (offerMediaObject.extmapAllowMixed === 'extmap-allow-mixed') {

--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -18,8 +18,6 @@ import type { MediaKind, RtpParameters } from '../../RtpParameters';
 import type { SctpParameters } from '../../SctpParameters';
 import { version as mediasoupClientVersion } from '../../';
 
-const DependencyDescriptorCodecs = ['av1', 'h264'];
-
 const logger = new Logger('RemoteSdp');
 
 export class RemoteSdp {
@@ -174,22 +172,6 @@ export class RemoteSdp {
 			answerRtpParameters,
 			codecOptions,
 		});
-
-		const mediaObject = mediaSection.getObject();
-
-		// Remove Dependency Descriptor extension unless there is support for
-		// the codec in mediasoup.
-		const ddCodec = mediaObject.rtp.find(rtp =>
-			DependencyDescriptorCodecs.includes(rtp.codec.toLowerCase())
-		);
-
-		if (!ddCodec) {
-			mediaObject.ext = mediaObject.ext?.filter(
-				extmap =>
-					extmap.uri !==
-					'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension'
-			);
-		}
 
 		// Unified-Plan with closed media section replacement.
 		if (reuseMid) {


### PR DESCRIPTION
## Background

Chrome 148 ships libwebrtc [commit 5788235](https://webrtc.googlesource.com/src/+/5788235) ("Consolidate RTP header extension validation in BaseChannel"), which enforces global uniqueness of extmap IDs for the lifetime of an `RTCPeerConnection`. Once an ID is bound to a URI in any bundled m-section, it's recorded in `historical_rtp_header_extensions_` and cannot be reused for a different URI — not in later offer/answer exchanges, not in new m-sections. The violation surfaces as:

```
RTP extension ID reassignment not supported (<old_uri> → <new_uri>)
```

…thrown from `setLocalDescription`.

## Root cause

`AnswerMediaSection` builds the synthetic SDP answer from `answerRtpParameters.headerExtensions`, i.e. the intersection of Chrome's offer and the server's `routerRtpCapabilities`. Anything Chrome offered that the server doesn't support (`video-layers-allocation00` for simulcast, `dependency-descriptor` for VP8/VP9) is dropped from the answer.

That used to be fine. Under the new rules, those dropped extensions still get registered in Chrome's internal ID history when the offer is set as local description. When a later m-section needs to allocate IDs for audio extensions like `ssrc-audio-level`, Chrome may pick an ID previously occupied by one of the dropped video extensions, and the strict check kills the renegotiation.

For VP8/VP9 the problem was worse: `RemoteSdp.send()` explicitly stripped `dependency-descriptor` from the answer after `AnswerMediaSection` had already built it. Correct before, actively harmful now.

## Fix

- **`src/handlers/sdp/MediaSection.ts`** — after `AnswerMediaSection` emits the confirmed (server-supported) extensions, a second pass writes back every remaining offer extension with no direction attribute (`sendrecv` per RFC 5285). Chrome registers the ID against its original URI and won't hand it out to anything else.
- **`src/handlers/sdp/RemoteSdp.ts`** — removed the post-processing step that stripped `dependency-descriptor` for non-AV1/H264 codecs. It ran after `AnswerMediaSection` and silently undid the pinning on VP8/VP9.

## Why this is safe

- **AV1 / H264** — `dependency-descriptor` is in `routerRtpCapabilities` for these codecs, so it already shows up in `answerRtpParameters.headerExtensions` and the first loop emits it as active. The deleted `RemoteSdp` filter was a no-op here anyway: it only triggered when `ddCodec` was missing (i.e. VP8/VP9).
- **VP8 / VP9** — `dependency-descriptor` now appears in the answer as a pin-only entry. The server doesn't activate it (not in `routerRtpCapabilities` for these codecs) and ignores it. Chrome won't put the extension on VP8/VP9 packets either, since there's no SVC layer structure to describe. Net effect: the extmap ID is locked to the URI and nothing else changes.
- **Other browsers** — `AnswerMediaSection` is shared with `Chrome111`, `Chrome74`, `Firefox120`, `Safari12`, `ReactNative106`. Either they confirmed the extension (second loop skips it) or they dropped it themselves, in which case a pin entry in the synthetic answer is harmless.

## Reproduction (mediasoup-demo)

The stock demo UI doesn't let you pick devices individually, so:

1. Split webcam/mic into separate "Enable Webcam" and "Enable Mic" buttons backed by `enableWebcam()` / `enableMic()`.
2. Add a "Change Mic" button that does `disableMic()` then `enableMic()` with a different `deviceId`.
3. Open the demo in Chrome 148+ with VP8 as the preferred video codec.
4. Click **Enable Webcam** → **Enable Mic** → **Change Mic**.

Without the patch, `setLocalDescription` throws `RTP extension ID reassignment not supported (dependency-descriptor → ssrc-audio-level)`. With it, the sequence goes through cleanly on both VP8 and H264.