### PR TITLE
fix: Failed to set remote offer sdp: Duplicate a=mid value 'datachannel' error

### DIFF
--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -320,6 +320,10 @@ export class RemoteSdp {
 	}: {
 		offerMediaObject: SdpTransform.MediaDescription;
 	}): void {
+		if (offerMediaObject.mid && this._midToIndex.has(offerMediaObject.mid)) {
+			return;
+		}
+
 		const mediaSection = new AnswerMediaSection({
 			iceParameters: this._iceParameters,
 			iceCandidates: this._iceCandidates,
@@ -333,6 +337,10 @@ export class RemoteSdp {
 	}
 
 	receiveSctpAssociation(): void {
+		if (this._midToIndex.has('datachannel')) {
+			return;
+		}
+
 		const mediaSection = new OfferMediaSection({
 			iceParameters: this._iceParameters,
 			iceCandidates: this._iceCandidates,


### PR DESCRIPTION
This PR fixes `Failed to execute 'setRemoteDescription' on 'RTCPeerConnection': Failed to set remote offer sdp: Duplicate a=mid value 'datachannel'` error.

## Summary

When `receiveDataChannel()` fails after `receiveSctpAssociation()` mutates the
internal `RemoteSdp` state but before `_hasDataChannelMediaSection` is set to
`true`, any subsequent `receiveDataChannel()` call adds a second
`m=application` section with `mid=datachannel` to the SDP. The browser then
rejects the offer with:

```
Failed to execute 'setRemoteDescription' on 'RTCPeerConnection':
Failed to set remote offer sdp: Duplicate a=mid value 'datachannel'
```

After this point the transport is permanently broken and cannot create any new
data channels.

## Root cause

In every handler (`Chrome111`, `Chrome74`, `Safari12`, `Firefox120`,
`ReactNative106`) the `receiveDataChannel()` method follows this sequence:

```ts
if (!this._hasDataChannelMediaSection) {
    this._remoteSdp.receiveSctpAssociation();   // 1. mutates RemoteSdp
    const offer = { type: 'offer', sdp: this._remoteSdp.getSdp() };
    await this._pc.setRemoteDescription(offer); // 2. can throw
    // ...
    this._hasDataChannelMediaSection = true;    // 3. never reached on failure
}
```

`receiveSctpAssociation()` unconditionally pushes a new `OfferMediaSection`
with `mid: 'datachannel'` into `_mediaSections` and `_midToIndex`. If step 2
throws, the section remains in the SDP but the guard flag stays `false`. The
next call enters the `if` block again, calls `receiveSctpAssociation()` again,
and produces a duplicate `a=mid`.

The same pattern exists in `sendSctpAssociation()` for the send direction.

## The fix in the PR

The fix ensures that even if `_hasDataChannelMediaSection` is out of sync with the
actual SDP state, the media section is never duplicated (idempotent).