### PR TITLE
Add `transport.getDataChannelMaxMessageSize()`

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -875,6 +875,10 @@ export class Transport<
 		}, 'transport.consumeData()');
 	}
 
+	getDataChannelMaxMessageSize(): number | undefined {
+		return this._handler.getDataChannelMaxMessageSize();
+	}
+
 	// This method is guaranteed to never throw.
 	private createPendingConsumers<ConsumerAppData extends AppData>(): void {
 		this._consumerCreationInProgress = true;

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -1240,6 +1240,10 @@ export class Chrome111
 		return { dataChannel };
 	}
 
+	getDataChannelMaxMessageSize(): number | undefined {
+		return this._pc.sctp?.maxMessageSize;
+	}
+
 	private async setupTransport({
 		localDtlsRole,
 		localSdpObject,

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -1246,6 +1246,10 @@ export class Chrome74
 		return { dataChannel };
 	}
 
+	getDataChannelMaxMessageSize(): number | undefined {
+		return this._pc.sctp?.maxMessageSize;
+	}
+
 	private async setupTransport({
 		localDtlsRole,
 		localSdpObject,

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -453,6 +453,10 @@ export class FakeHandler
 		return { dataChannel };
 	}
 
+	getDataChannelMaxMessageSize(): number | undefined {
+		return 500000;
+	}
+
 	private async setupTransport({
 		localDtlsRole,
 		// eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -1201,6 +1201,10 @@ export class Firefox120
 		return { dataChannel };
 	}
 
+	getDataChannelMaxMessageSize(): number | undefined {
+		return this._pc.sctp?.maxMessageSize;
+	}
+
 	private async setupTransport({
 		localDtlsRole,
 		localSdpObject,

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -186,4 +186,6 @@ export abstract class HandlerInterface extends EnhancedEventEmitter<HandlerEvent
 	abstract receiveDataChannel(
 		options: HandlerReceiveDataChannelOptions
 	): Promise<HandlerReceiveDataChannelResult>;
+
+	abstract getDataChannelMaxMessageSize(): number | undefined;
 }

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -1297,6 +1297,10 @@ export class ReactNative106
 		return { dataChannel };
 	}
 
+	getDataChannelMaxMessageSize(): number | undefined {
+		return this._pc.sctp?.maxMessageSize;
+	}
+
 	private async setupTransport({
 		localDtlsRole,
 		localSdpObject,

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -1249,6 +1249,10 @@ export class Safari12
 		return { dataChannel };
 	}
 
+	getDataChannelMaxMessageSize(): number | undefined {
+		return this._pc.sctp?.maxMessageSize;
+	}
+
 	private async setupTransport({
 		localDtlsRole,
 		localSdpObject,


### PR DESCRIPTION
# Details

- In a send `Transport` it returns the maximum DataChannel message size that it can send.
- In a receive `Transport` it returns the maximum DataChannel message size that it can receive.
- Note that it can return `undefined` (if DataChannels is not enabled).