### PR TITLE
Adapt SCTP/DataChannels API to latest changes in mediasoup

### DIFF
--- a/.github/workflows/mediasoup-client.yaml
+++ b/.github/workflows/mediasoup-client.yaml
@@ -21,14 +21,16 @@ jobs:
             node: 22
           - os: ubuntu-24.04
             node: 24
+          - os: ubuntu-26.04
+            node: 26
           - os: macos-14
             node: 22
           - os: macos-15
-            node: 24
+            node: 26
           - os: windows-2022
-            node: 22
-          - os: windows-2025
             node: 24
+          - os: windows-2025
+            node: 26
 
     runs-on: ${{ matrix.ci.os }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,30 +11,30 @@
 			"dependencies": {
 				"@types/debug": "^4.1.13",
 				"@types/events-alias": "npm:@types/events@^3.0.3",
-				"awaitqueue": "^3.3.0",
+				"awaitqueue": "^3.3.1",
 				"debug": "^4.4.3",
 				"events-alias": "npm:events@^3.3.0",
 				"fake-mediastreamtrack": "^2.2.1",
-				"h264-profile-level-id": "^2.3.2",
+				"h264-profile-level-id": "^2.3.3",
 				"sdp-transform": "^3.0.0",
 				"supports-color": "^10.2.2"
 			},
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
 				"@types/jest": "^30.0.0",
-				"@types/sdp-transform": "^2.15.0",
-				"eslint": "^10.4.0",
+				"@types/sdp-transform": "^3.0.0",
+				"eslint": "^10.5.0",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-jest": "^29.15.2",
 				"eslint-plugin-prettier": "^5.5.6",
 				"globals": "^17.6.0",
 				"jest": "^30.4.2",
-				"knip": "^6.14.2",
+				"knip": "^6.17.1",
 				"open-cli": "^9.0.0",
-				"prettier": "^3.8.3",
+				"prettier": "^3.8.4",
 				"ts-jest": "^29.4.11",
 				"typescript": "^6.0.3",
-				"typescript-eslint": "^8.60.0"
+				"typescript-eslint": "^8.61.1"
 			},
 			"engines": {
 				"node": ">=22"
@@ -52,26 +52,14 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.2.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.1.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -80,9 +68,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
-			"integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -90,22 +78,22 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.4",
-				"@babel/parser": "^7.27.4",
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.27.4",
-				"@babel/types": "^7.27.3",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -130,46 +118,31 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-			"integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.27.5",
-				"@babel/types": "^7.27.3",
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.8",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/set-array": "^1.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.10",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -188,30 +161,40 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-			"integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.27.3"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -231,9 +214,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -241,9 +224,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -251,9 +234,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -261,27 +244,27 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-			"integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.6"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-			"integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.27.3"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -530,58 +513,48 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/parser": "^7.27.2",
-				"@babel/types": "^7.27.1"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-			"integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
-				"@babel/parser": "^7.27.4",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.3",
-				"debug": "^4.3.1",
-				"globals": "^11.1.0"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"debug": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/traverse/node_modules/globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@babel/types": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-			"integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -780,9 +753,9 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -892,16 +865,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -914,20 +877,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -1322,15 +1271,25 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.1.1",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/set-array": "^1.0.0",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -1341,25 +1300,19 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1406,9 +1359,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-android-arm-eabi": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.130.0.tgz",
-			"integrity": "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.135.0.tgz",
+			"integrity": "sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1423,9 +1376,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-android-arm64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.130.0.tgz",
-			"integrity": "sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.135.0.tgz",
+			"integrity": "sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1440,9 +1393,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-darwin-arm64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.130.0.tgz",
-			"integrity": "sha512-sGUzupdTplK9jQg7eJZ878HfEgQjJNBc6dAYVWJ9W5aU+J8rLfRJhTVsKThiu1pNwm6Y1qKCcbC6WhNWSXR3Ig==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.135.0.tgz",
+			"integrity": "sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==",
 			"cpu": [
 				"arm64"
 			],
@@ -1457,9 +1410,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-darwin-x64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.130.0.tgz",
-			"integrity": "sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.135.0.tgz",
+			"integrity": "sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1474,9 +1427,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-freebsd-x64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.130.0.tgz",
-			"integrity": "sha512-DgABp3l38hS77JbXCV4qk1+n6DPym5u8zzwuweokezm2tX194nDSJDENbDRECxVsiNbprKATLbk+Z5wlHT0OHw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.135.0.tgz",
+			"integrity": "sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==",
 			"cpu": [
 				"x64"
 			],
@@ -1491,9 +1444,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.130.0.tgz",
-			"integrity": "sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.135.0.tgz",
+			"integrity": "sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1508,9 +1461,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.130.0.tgz",
-			"integrity": "sha512-D35KZM3F4rRu1uAFKyBlg3Gaf/ybCjyaPR1hfgvk5ex8NtcTmRgc0JgSighEyNg96TPrFhemFba68SZuxaha8w==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.135.0.tgz",
+			"integrity": "sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==",
 			"cpu": [
 				"arm"
 			],
@@ -1525,9 +1478,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.130.0.tgz",
-			"integrity": "sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.135.0.tgz",
+			"integrity": "sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1545,9 +1498,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-arm64-musl": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.130.0.tgz",
-			"integrity": "sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.135.0.tgz",
+			"integrity": "sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1565,9 +1518,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.130.0.tgz",
-			"integrity": "sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.135.0.tgz",
+			"integrity": "sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1585,9 +1538,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.130.0.tgz",
-			"integrity": "sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.135.0.tgz",
+			"integrity": "sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1605,9 +1558,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.130.0.tgz",
-			"integrity": "sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.135.0.tgz",
+			"integrity": "sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1625,9 +1578,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.130.0.tgz",
-			"integrity": "sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.135.0.tgz",
+			"integrity": "sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==",
 			"cpu": [
 				"s390x"
 			],
@@ -1645,9 +1598,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-x64-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.130.0.tgz",
-			"integrity": "sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.135.0.tgz",
+			"integrity": "sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==",
 			"cpu": [
 				"x64"
 			],
@@ -1665,9 +1618,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-linux-x64-musl": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.130.0.tgz",
-			"integrity": "sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.135.0.tgz",
+			"integrity": "sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1685,9 +1638,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-openharmony-arm64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.130.0.tgz",
-			"integrity": "sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.135.0.tgz",
+			"integrity": "sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1702,9 +1655,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-wasm32-wasi": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.130.0.tgz",
-			"integrity": "sha512-sJgQkGaBX0WJvPUDfwciex6IcTk5O5NLQ1bhEb6f3nBruh1GshKMRSMt2bxZlYrgBzjyBbJzsnO+InPG0bg+fA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.135.0.tgz",
+			"integrity": "sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==",
 			"cpu": [
 				"wasm32"
 			],
@@ -1721,9 +1674,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.130.0.tgz",
-			"integrity": "sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.135.0.tgz",
+			"integrity": "sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -1738,9 +1691,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.130.0.tgz",
-			"integrity": "sha512-hRYbv6HhpSTzT4xTiIkadLI7upLQxuOdLPR/9nL1fTjwhgutBTPXrwaAPb/jTFVx6/8C7Jb5HcUKhmNwloTbFA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.135.0.tgz",
+			"integrity": "sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==",
 			"cpu": [
 				"ia32"
 			],
@@ -1755,9 +1708,9 @@
 			}
 		},
 		"node_modules/@oxc-parser/binding-win32-x64-msvc": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.130.0.tgz",
-			"integrity": "sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.135.0.tgz",
+			"integrity": "sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==",
 			"cpu": [
 				"x64"
 			],
@@ -1772,9 +1725,9 @@
 			}
 		},
 		"node_modules/@oxc-project/types": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.135.0.tgz",
+			"integrity": "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -2296,9 +2249,9 @@
 			}
 		},
 		"node_modules/@types/sdp-transform": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/@types/sdp-transform/-/sdp-transform-2.15.0.tgz",
-			"integrity": "sha512-ikIFF0EaYt/2XetIYYVeMj6SB52oVXFasJUXDzWHgzNJS5ep2Pbsu7f8f3Za+dEie8HQtt3Zr9mHYBpWT0XgxQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/sdp-transform/-/sdp-transform-3.0.0.tgz",
+			"integrity": "sha512-TLwbrRILH3mwnrXgjZLb2LXursBR/dnumGgFWKm8Jw3nTJCAN0g80pvS4KVpXHz4DpYtne762lcXin9GmShGbg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2325,17 +2278,17 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
-			"integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+			"integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/type-utils": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/type-utils": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -2348,7 +2301,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.60.0",
+				"@typescript-eslint/parser": "^8.61.1",
 				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.1.0"
 			}
@@ -2364,16 +2317,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
-			"integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+			"integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2389,14 +2342,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
-			"integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+			"integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.60.0",
-				"@typescript-eslint/types": "^8.60.0",
+				"@typescript-eslint/tsconfig-utils": "^8.61.1",
+				"@typescript-eslint/types": "^8.61.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -2411,14 +2364,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
-			"integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+			"integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0"
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2429,9 +2382,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
-			"integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+			"integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2446,15 +2399,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
-			"integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+			"integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			},
@@ -2471,9 +2424,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
-			"integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2485,16 +2438,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
-			"integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+			"integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.60.0",
-				"@typescript-eslint/tsconfig-utils": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
+				"@typescript-eslint/project-service": "8.61.1",
+				"@typescript-eslint/tsconfig-utils": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -2552,16 +2505,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
-			"integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+			"integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0"
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2576,13 +2529,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
-			"integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+			"integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/types": "8.61.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
@@ -3065,16 +3018,26 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
 		"node_modules/awaitqueue": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.0.tgz",
-			"integrity": "sha512-zLxDhzQbzHmOyvxi7g3OlfR7jLrcmElStPxfLPpJkrFSDm71RSrY/MvsDA8Btlx8X1nOHUzGhQvc6bdUjL2f2w==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.1.tgz",
+			"integrity": "sha512-kzMN6Bdfalok/JWZvwDfI704cIyCvHDi6Ez/bApGzNPjGHQhwJ07DzGd3DDzeXH2fjr9P5g8paESFUvYnbs7rA==",
 			"license": "ISC",
 			"dependencies": {
 				"debug": "^4.4.3"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3185,6 +3148,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/baseline-browser-mapping": {
+			"version": "2.10.37",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+			"integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.14",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -3197,9 +3173,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.25.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-			"integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3217,10 +3193,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001726",
-				"electron-to-chromium": "^1.5.173",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.3"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -3295,9 +3272,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001726",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
-			"integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3648,9 +3625,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.173",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.173.tgz",
-			"integrity": "sha512-2bFhXP2zqSfQHugjqJIDFVwa+qIxyNApenmXTp9EjaKtdPrES5Qcn9/aSFy/NaP2E+fWG/zxKu/LBvY36p5VNQ==",
+			"version": "1.5.373",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
+			"integrity": "sha512-G2Hym8JIf/QreuseqkDibgH8Ci8KfJzqGDKdakbhSx9UltwRBH2cBLAWU/lBX0sCdv0TlhyxQyDCnSfxgMWsjA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3706,18 +3683,21 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-			"integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+			"integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
 			"dev": true,
 			"license": "MIT",
+			"workspaces": [
+				"packages/*"
+			],
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.2",
 				"@eslint/config-array": "^0.23.5",
 				"@eslint/config-helpers": "^0.6.0",
 				"@eslint/core": "^1.2.1",
-				"@eslint/plugin-kit": "^0.7.1",
+				"@eslint/plugin-kit": "^0.7.2",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
@@ -4418,15 +4398,15 @@
 			"license": "ISC"
 		},
 		"node_modules/h264-profile-level-id": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.2.tgz",
-			"integrity": "sha512-hnq1UDlw7WGJV6GCr/g7wnkHYUjdAY2bis9rgn2JqSdQS2WfVvnt1ZE9g8nTguracodf5LLKZOwURsDN49YtBQ==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.3.tgz",
+			"integrity": "sha512-rPd5gpyWuIfEbBiHC/f9I4wdeCpAhg0aWdYgjMRdVTqhJT22C6VrWTi4hpAAgJad1Vv8BJDEvrzAQTW7CxzmJw==",
 			"license": "ISC",
 			"dependencies": {
 				"debug": "^4.4.3"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -5420,6 +5400,20 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/jsesc": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -5479,9 +5473,9 @@
 			}
 		},
 		"node_modules/knip": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-6.14.2.tgz",
-			"integrity": "sha512-Vg3JhIINjZew1I7qAFI4UHemW1mc4azP/BxJvsq9eGDfxpGO7oVCuD/bsWkog9TO/ZwwJeAeOMFZ1kd9jnY9+Q==",
+			"version": "6.17.1",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-6.17.1.tgz",
+			"integrity": "sha512-HcQsZSQ4Ymhuay4BVzJtM5pFZNDSomYYqcNCZOSITPQh9g18a09DqziWAxSt2G+BH9wGlG+0ZjWpEnaFlnKseQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -5499,14 +5493,13 @@
 				"formatly": "^0.3.0",
 				"get-tsconfig": "4.14.0",
 				"jiti": "^2.7.0",
-				"minimist": "^1.2.8",
-				"oxc-parser": "^0.130.0",
-				"oxc-resolver": "^11.19.1",
+				"oxc-parser": "^0.135.0",
+				"oxc-resolver": "^11.20.0",
 				"picomatch": "^4.0.4",
 				"smol-toml": "^1.6.1",
 				"strip-json-comments": "5.0.3",
-				"tinyglobby": "^0.2.16",
-				"unbash": "^3.0.0",
+				"tinyglobby": "^0.2.17",
+				"unbash": "^4.0.1",
 				"yaml": "^2.9.0",
 				"zod": "^4.1.11"
 			},
@@ -5753,11 +5746,14 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"version": "2.0.47",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+			"integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
@@ -5867,13 +5863,13 @@
 			}
 		},
 		"node_modules/oxc-parser": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.130.0.tgz",
-			"integrity": "sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.135.0.tgz",
+			"integrity": "sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@oxc-project/types": "^0.130.0"
+				"@oxc-project/types": "^0.135.0"
 			},
 			"engines": {
 				"node": "^20.19.0 || >=22.12.0"
@@ -5882,26 +5878,26 @@
 				"url": "https://github.com/sponsors/Boshen"
 			},
 			"optionalDependencies": {
-				"@oxc-parser/binding-android-arm-eabi": "0.130.0",
-				"@oxc-parser/binding-android-arm64": "0.130.0",
-				"@oxc-parser/binding-darwin-arm64": "0.130.0",
-				"@oxc-parser/binding-darwin-x64": "0.130.0",
-				"@oxc-parser/binding-freebsd-x64": "0.130.0",
-				"@oxc-parser/binding-linux-arm-gnueabihf": "0.130.0",
-				"@oxc-parser/binding-linux-arm-musleabihf": "0.130.0",
-				"@oxc-parser/binding-linux-arm64-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-arm64-musl": "0.130.0",
-				"@oxc-parser/binding-linux-ppc64-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-riscv64-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-riscv64-musl": "0.130.0",
-				"@oxc-parser/binding-linux-s390x-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-x64-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-x64-musl": "0.130.0",
-				"@oxc-parser/binding-openharmony-arm64": "0.130.0",
-				"@oxc-parser/binding-wasm32-wasi": "0.130.0",
-				"@oxc-parser/binding-win32-arm64-msvc": "0.130.0",
-				"@oxc-parser/binding-win32-ia32-msvc": "0.130.0",
-				"@oxc-parser/binding-win32-x64-msvc": "0.130.0"
+				"@oxc-parser/binding-android-arm-eabi": "0.135.0",
+				"@oxc-parser/binding-android-arm64": "0.135.0",
+				"@oxc-parser/binding-darwin-arm64": "0.135.0",
+				"@oxc-parser/binding-darwin-x64": "0.135.0",
+				"@oxc-parser/binding-freebsd-x64": "0.135.0",
+				"@oxc-parser/binding-linux-arm-gnueabihf": "0.135.0",
+				"@oxc-parser/binding-linux-arm-musleabihf": "0.135.0",
+				"@oxc-parser/binding-linux-arm64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-arm64-musl": "0.135.0",
+				"@oxc-parser/binding-linux-ppc64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-riscv64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-riscv64-musl": "0.135.0",
+				"@oxc-parser/binding-linux-s390x-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-x64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-x64-musl": "0.135.0",
+				"@oxc-parser/binding-openharmony-arm64": "0.135.0",
+				"@oxc-parser/binding-wasm32-wasi": "0.135.0",
+				"@oxc-parser/binding-win32-arm64-msvc": "0.135.0",
+				"@oxc-parser/binding-win32-ia32-msvc": "0.135.0",
+				"@oxc-parser/binding-win32-x64-msvc": "0.135.0"
 			}
 		},
 		"node_modules/oxc-resolver": {
@@ -6170,9 +6166,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+			"version": "3.8.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+			"integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -6760,9 +6756,9 @@
 			}
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6955,16 +6951,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
-			"integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+			"integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.60.0",
-				"@typescript-eslint/parser": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0"
+				"@typescript-eslint/eslint-plugin": "8.61.1",
+				"@typescript-eslint/parser": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7006,9 +7002,9 @@
 			}
 		},
 		"node_modules/unbash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
-			"integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.1.tgz",
+			"integrity": "sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -7077,9 +7073,9 @@
 			}
 		},
 		"node_modules/update-browserslist-db": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"funding": [
 				{
@@ -7437,47 +7433,39 @@
 			"version": "1.2.6",
 			"dev": true
 		},
-		"@ampproject/remapping": {
-			"version": "2.2.0",
-			"dev": true,
-			"requires": {
-				"@jridgewell/gen-mapping": "^0.1.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			}
-		},
 		"@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
-			"integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
-			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"requires": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.4",
-				"@babel/parser": "^7.27.4",
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.27.4",
-				"@babel/types": "^7.27.3",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -7494,39 +7482,26 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
-			"integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"requires": {
-				"@babel/parser": "^7.27.5",
-				"@babel/types": "^7.27.3",
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
-			},
-			"dependencies": {
-				"@jridgewell/gen-mapping": {
-					"version": "0.3.8",
-					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-					"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-					"dev": true,
-					"requires": {
-						"@jridgewell/set-array": "^1.2.1",
-						"@jridgewell/sourcemap-codec": "^1.4.10",
-						"@jridgewell/trace-mapping": "^0.3.24"
-					}
-				}
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.27.2",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -7540,25 +7515,31 @@
 				}
 			}
 		},
+		"@babel/helper-globals": {
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+			"dev": true
+		},
 		"@babel/helper-module-imports": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"requires": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-			"integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.27.3"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			}
 		},
 		"@babel/helper-plugin-utils": {
@@ -7568,40 +7549,40 @@
 			"dev": true
 		},
 		"@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true
 		},
 		"@babel/helpers": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-			"integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.6"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.27.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
-			"integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.27.3"
+				"@babel/types": "^7.29.7"
 			}
 		},
 		"@babel/plugin-syntax-async-generators": {
@@ -7758,47 +7739,39 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/parser": "^7.27.2",
-				"@babel/types": "^7.27.1"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.27.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
-			"integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.3",
-				"@babel/parser": "^7.27.4",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.3",
-				"debug": "^4.3.1",
-				"globals": "^11.1.0"
-			},
-			"dependencies": {
-				"globals": {
-					"version": "11.12.0",
-					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-					"dev": true
-				}
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
+				"debug": "^4.3.1"
 			}
 		},
 		"@babel/types": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
-			"integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			}
 		},
 		"@bcoe/v8-coverage": {
@@ -7928,9 +7901,9 @@
 			"dev": true
 		},
 		"@eslint/plugin-kit": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
 			"dev": true,
 			"requires": {
 				"@eslint/core": "^1.2.1",
@@ -7998,15 +7971,6 @@
 				"resolve-from": "^5.0.0"
 			},
 			"dependencies": {
-				"argparse": {
-					"version": "1.0.10",
-					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-					"dev": true,
-					"requires": {
-						"sprintf-js": "~1.0.2"
-					}
-				},
 				"find-up": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -8015,16 +7979,6 @@
 					"requires": {
 						"locate-path": "^5.0.0",
 						"path-exists": "^4.0.0"
-					}
-				},
-				"js-yaml": {
-					"version": "3.14.2",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-					"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
 					}
 				},
 				"locate-path": {
@@ -8314,31 +8268,39 @@
 			}
 		},
 		"@jridgewell/gen-mapping": {
-			"version": "0.1.1",
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
 			"dev": true,
 			"requires": {
-				"@jridgewell/set-array": "^1.0.0",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
+			"requires": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
 		"@jridgewell/resolve-uri": {
 			"version": "3.1.0",
 			"dev": true
 		},
-		"@jridgewell/set-array": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true
-		},
 		"@jridgewell/sourcemap-codec": {
-			"version": "1.4.14",
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
 			"dev": true
 		},
 		"@jridgewell/trace-mapping": {
-			"version": "0.3.25",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
 			"dev": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -8369,121 +8331,121 @@
 			}
 		},
 		"@oxc-parser/binding-android-arm-eabi": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.130.0.tgz",
-			"integrity": "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.135.0.tgz",
+			"integrity": "sha512-sHeZItACNcA5WRAWqF6ixriR4GkZDyY10gVgnZU7pXku1DjHFATSqnwZM809jl0gXPHxb6fKzYQCK7bNK5cACQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-android-arm64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.130.0.tgz",
-			"integrity": "sha512-oFWFJrsGv9siFM4HjMqKNB7IuIZD/SMmZdCXl8xyx7lDplGvPKyewpOo272rSWgMXe2Wx7bWI0Yj+gkHv4qbeg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.135.0.tgz",
+			"integrity": "sha512-wPte+SzgzWWFgMSF8YZDNM+tBXtJg0AXBi7+tU3yS2z1f2Af9kRLZLKuJojADmuD/cZexmnMHHC3SDItTW77Iw==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-darwin-arm64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.130.0.tgz",
-			"integrity": "sha512-sGUzupdTplK9jQg7eJZ878HfEgQjJNBc6dAYVWJ9W5aU+J8rLfRJhTVsKThiu1pNwm6Y1qKCcbC6WhNWSXR3Ig==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.135.0.tgz",
+			"integrity": "sha512-BmKz3lHIsqVos+9aPcdYCT9MG3APoUyM43KlEFhJMWNVDOGG8FKyiFz81Bc+mGz2o0hpuQ3PfXLfVWJrKXjo2g==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-darwin-x64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.130.0.tgz",
-			"integrity": "sha512-PsB4cdCISbC00Uy8eiD8bc2AkGWjZqrSrJnkBFuG2ptrrf6mZ2F5gLFSjOAVMMgZPg8B1D7OydJwLWSfyI2Plg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.135.0.tgz",
+			"integrity": "sha512-dM8BS+8+Br1fNvmh2QZbGiHaYttwLebRa6J4Uz9vuFzMNmvsdRYwf7993ptOaV0JTrR63AaoVLjX7nhWbijxjQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-freebsd-x64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.130.0.tgz",
-			"integrity": "sha512-DgABp3l38hS77JbXCV4qk1+n6DPym5u8zzwuweokezm2tX194nDSJDENbDRECxVsiNbprKATLbk+Z5wlHT0OHw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.135.0.tgz",
+			"integrity": "sha512-xlZnvvJdR9bGu2pOhvR5hMuKPHCE6Sa9owK5A484mzjHdm75VRV5nCs5w/jkmGODMMTFc+KN7EnZqEieM813kw==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-arm-gnueabihf": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.130.0.tgz",
-			"integrity": "sha512-4Kn3CTEmwFrzhTSC/JuUW16qovmaMdX7jeSKbL8w0pLtLww7To1a2XJi9Z5uD8QWUkfUHhqfV+VD6dVzBnWzoA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.135.0.tgz",
+			"integrity": "sha512-PSR8LmBK/H/PQRiN8g7RebQgZX/ntVCrdT/JBfNxE5ezdHG1s2i4rbazsRJYD83TTI1MmgTpC0MGL42PLtskQQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-arm-musleabihf": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.130.0.tgz",
-			"integrity": "sha512-D35KZM3F4rRu1uAFKyBlg3Gaf/ybCjyaPR1hfgvk5ex8NtcTmRgc0JgSighEyNg96TPrFhemFba68SZuxaha8w==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.135.0.tgz",
+			"integrity": "sha512-I85GJXzfUsigkkk7Ngdz95C217M4FdUi1Z2HrX5UyPmURobwQZ7m2bbUvwFkz4VGZd+lymFGKHvDZ3RQC9qOzA==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-arm64-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.130.0.tgz",
-			"integrity": "sha512-Q9o7oVlo955KHwS8l1u0bCzIx+JsZUA3XToLXC+MsMhye/9LeBQbt84nh120cl2XLy+TEzvugYDiHShg5yaX6Q==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.135.0.tgz",
+			"integrity": "sha512-zqEY0npz0g0aGZj/8a5BclunjVDytsBQHYtIC10Gd26HcrLwbVF6YDbqRQjunMGYdSo97u6xOBl05aTDI2diDQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-arm64-musl": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.130.0.tgz",
-			"integrity": "sha512-EiJ/gC0ljbcwVpycC8YWw6ggMbtsPX8XMOt0mPx0aqWeMsNR+L9m05Flbvd5T+GlivG+GkSWQL7tM9SRFpM/dw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.135.0.tgz",
+			"integrity": "sha512-mWAfprP819gQ2qYst1RxgTI8b/z0b29OpoKfRflIXLHde2dZLihQD4g47Onuvtpo5GPIkMYPRlX9QoeZfs/GnQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-ppc64-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.130.0.tgz",
-			"integrity": "sha512-b+h/lsLLurp756dMGizNs5uPaJfyEdWrTcV5t8M609jWm1DEHB1StpRXCkyvwtkJx3m+qL5BNQ0dEKan/4yGFA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.135.0.tgz",
+			"integrity": "sha512-gri8c2AOmJKJwOux2KTHFBfUaXoJURuVMKhmKEi/2hTF55cQteTDV2XNfTiE5oCC+Tnem1Y4/MWzcyDadtsSag==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-riscv64-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.130.0.tgz",
-			"integrity": "sha512-O19Cil83XAyjEFfo8WhkMwY58ALqZ7ckjGL+25mjMIuF84urWBeANH0FC8B8BsSSygWU3/1aY3ADdDbp+wlBnw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.135.0.tgz",
+			"integrity": "sha512-Y2tkupCG5wo0SxH2rMLG4d4Kmv6DaM3sBp+GuM5lox0S8Za6VxKgQrY2Mut088QQxKkEE89n/4CCCgmw2o0e3Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-riscv64-musl": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.130.0.tgz",
-			"integrity": "sha512-BgXRVC0+83n3YzCscLQjj6nbyeBIVeZYPTI4fFMAE4WNm2+4RXhWp03IVizL7esIz36kgmT48aebk1iM+cs8sw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.135.0.tgz",
+			"integrity": "sha512-xDRJq6i6WTynjeP+ISbDpyH4p9BaJ0wuQcL0lCSDkt9qOXC9dmwpOu1VG/TlwmPI3KpYntmO9nJCuc3TMTsNBA==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-s390x-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.130.0.tgz",
-			"integrity": "sha512-6tJz0xvnGhsokE7N1WlUSBXibpYmT9xSJFS1Ce41Km/+8gQvdlW8MLhRv8PD0L7ix8vRG0FDDepp3jdOFzdVdw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.135.0.tgz",
+			"integrity": "sha512-V4MoUuiCRNvihxhIufRxvK+ka013V4joTSK0FAGA1KEjLuNprfH6N/Qw2uxQEVIFuNYMhD/hV6xJ/ptbzlKdHg==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-x64-gnu": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.130.0.tgz",
-			"integrity": "sha512-9aCWj83dp3heTQGmGnZGdIWgxjZrr/7VQ0TGFHH5PKByxJKF2Hcr4qvaSUHhhGEa3MSsDjTL1YDP8RAgdL5/Cg==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.135.0.tgz",
+			"integrity": "sha512-JCFZ7zM7KXOKoPAbK/ZB4wY0M1jxRECiem2UQuiXLjzGqS9+hno7mtX+qyK2F7HWK2xPhyJb+frpcOtk5DKOtg==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-linux-x64-musl": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.130.0.tgz",
-			"integrity": "sha512-afXt87aZBqrUVli8TB/I8H1G50RDWcwirjWtXGXYqJ2ZqWEiErH7V72j3LUSDZaivmtu2OLX0KQ/mbhP81mr7A==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.135.0.tgz",
+			"integrity": "sha512-9jSVS1b3hOV7sdKH4aA2DFfnTz0RgQd0v2BefR+LYbH8yIlmSM22JJZbAAjVeVXmFgUAk3zJQ1tpE/Nd+Vi2YQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-openharmony-arm64": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.130.0.tgz",
-			"integrity": "sha512-I0NCrZV/YZuCGWgqwNN/GO/iXlLF2z+Wgc7u+Aa9N4P51oYeIa0XT+zVBUne4csO9GqxskXgI4g8JzzWGRpfOw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.135.0.tgz",
+			"integrity": "sha512-M857ZLBSdn1Uy/SJJz5zh0qGu67B4P9omCgXGBU2LLqTzraX6ZjVNaKq5yW1PDw/LgJXDXR/dbZfgmB310f11Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-wasm32-wasi": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.130.0.tgz",
-			"integrity": "sha512-sJgQkGaBX0WJvPUDfwciex6IcTk5O5NLQ1bhEb6f3nBruh1GshKMRSMt2bxZlYrgBzjyBbJzsnO+InPG0bg+fA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.135.0.tgz",
+			"integrity": "sha512-2w6DVcntQZX9U5RhXtgiWb3FLWFB5EcwI1U8yr3htOCJUJjagN4BFUHz/Y/d9ZsumndZ6ByxxWEtbUZNE1bfFw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -8493,30 +8455,30 @@
 			}
 		},
 		"@oxc-parser/binding-win32-arm64-msvc": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.130.0.tgz",
-			"integrity": "sha512-bjcma99sQrNh6RY4mPO9yTkfxql6TDFoN3HWdK31RCKXwNhcDgJXW/l8PUtzKNiQ+9vpKJfJtQq+LklBuxSOBA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.135.0.tgz",
+			"integrity": "sha512-rX1U8+IH2Z37EJjDXKa1iifvUQAdba+vZ4Ewj1iaG5eA/QaSybzclCOwtWa0/5BuUQnnK/T2JHUEFrwhL6Ck2Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-win32-ia32-msvc": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.130.0.tgz",
-			"integrity": "sha512-hRYbv6HhpSTzT4xTiIkadLI7upLQxuOdLPR/9nL1fTjwhgutBTPXrwaAPb/jTFVx6/8C7Jb5HcUKhmNwloTbFA==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.135.0.tgz",
+			"integrity": "sha512-9FAisBbH1QICGAjlJobiuKGd/jOuVmyqniWdQMwTa5SkCl6hhuotBCJf1n46B0flYbSOR5TzfV9HZCWSyb3c/Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-parser/binding-win32-x64-msvc": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.130.0.tgz",
-			"integrity": "sha512-RBpA9TsRucJq6HNVNCFF1iKg+QeTkLdZf7hi4xaOGCPvMZWvDHjQgSOEZMUpuW4JNciHbxNhLEYmz5CVygjVGQ==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.135.0.tgz",
+			"integrity": "sha512-wYF+A2AzJ2n7ul6q+Z2G/ia0S2+8cUp0AgWZzoFvF4WmUcl1P7p+o6se1Gdr5wGnWuF0iAMIkGddrjCarNr2yA==",
 			"dev": true,
 			"optional": true
 		},
 		"@oxc-project/types": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-			"integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.135.0.tgz",
+			"integrity": "sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==",
 			"dev": true
 		},
 		"@oxc-resolver/binding-android-arm-eabi": {
@@ -8837,9 +8799,9 @@
 			}
 		},
 		"@types/sdp-transform": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/@types/sdp-transform/-/sdp-transform-2.15.0.tgz",
-			"integrity": "sha512-ikIFF0EaYt/2XetIYYVeMj6SB52oVXFasJUXDzWHgzNJS5ep2Pbsu7f8f3Za+dEie8HQtt3Zr9mHYBpWT0XgxQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/sdp-transform/-/sdp-transform-3.0.0.tgz",
+			"integrity": "sha512-TLwbrRILH3mwnrXgjZLb2LXursBR/dnumGgFWKm8Jw3nTJCAN0g80pvS4KVpXHz4DpYtne762lcXin9GmShGbg==",
 			"dev": true
 		},
 		"@types/stack-utils": {
@@ -8862,16 +8824,16 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
-			"integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+			"integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/type-utils": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/type-utils": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.5.0"
@@ -8886,75 +8848,75 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
-			"integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+			"integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3"
 			}
 		},
 		"@typescript-eslint/project-service": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
-			"integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+			"integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/tsconfig-utils": "^8.60.0",
-				"@typescript-eslint/types": "^8.60.0",
+				"@typescript-eslint/tsconfig-utils": "^8.61.1",
+				"@typescript-eslint/types": "^8.61.1",
 				"debug": "^4.4.3"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
-			"integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+			"integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0"
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1"
 			}
 		},
 		"@typescript-eslint/tsconfig-utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
-			"integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+			"integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
 			"dev": true,
 			"requires": {}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
-			"integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+			"integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.5.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
-			"integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+			"integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
-			"integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+			"integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/project-service": "8.60.0",
-				"@typescript-eslint/tsconfig-utils": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/visitor-keys": "8.60.0",
+				"@typescript-eslint/project-service": "8.61.1",
+				"@typescript-eslint/tsconfig-utils": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/visitor-keys": "8.61.1",
 				"debug": "^4.4.3",
 				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
@@ -8989,24 +8951,24 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
-			"integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+			"integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.60.0",
-				"@typescript-eslint/types": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0"
+				"@typescript-eslint/scope-manager": "8.61.1",
+				"@typescript-eslint/types": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
-			"integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+			"integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.60.0",
+				"@typescript-eslint/types": "8.61.1",
 				"eslint-visitor-keys": "^5.0.0"
 			},
 			"dependencies": {
@@ -9248,10 +9210,19 @@
 				"picomatch": "^2.0.4"
 			}
 		},
+		"argparse": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+			"dev": true,
+			"requires": {
+				"sprintf-js": "~1.0.2"
+			}
+		},
 		"awaitqueue": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.0.tgz",
-			"integrity": "sha512-zLxDhzQbzHmOyvxi7g3OlfR7jLrcmElStPxfLPpJkrFSDm71RSrY/MvsDA8Btlx8X1nOHUzGhQvc6bdUjL2f2w==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.1.tgz",
+			"integrity": "sha512-kzMN6Bdfalok/JWZvwDfI704cIyCvHDi6Ez/bApGzNPjGHQhwJ07DzGd3DDzeXH2fjr9P5g8paESFUvYnbs7rA==",
 			"requires": {
 				"debug": "^4.4.3"
 			}
@@ -9330,6 +9301,12 @@
 			"version": "1.0.2",
 			"dev": true
 		},
+		"baseline-browser-mapping": {
+			"version": "2.10.37",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+			"integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
+			"dev": true
+		},
 		"brace-expansion": {
 			"version": "1.1.14",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -9341,15 +9318,16 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.25.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
-			"integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"dev": true,
 			"requires": {
-				"caniuse-lite": "^1.0.30001726",
-				"electron-to-chromium": "^1.5.173",
-				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.3"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			}
 		},
 		"bs-logger": {
@@ -9398,9 +9376,9 @@
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001726",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001726.tgz",
-			"integrity": "sha512-VQAUIUzBiZ/UnlM28fSp2CRF3ivUn1BWEvxMcVTNwpw91Py1pGbPIyIKtd+tzct9C3ouceCVdGAXxZOpZAsgdw==",
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
 			"dev": true
 		},
 		"chalk": {
@@ -9613,9 +9591,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.5.173",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.173.tgz",
-			"integrity": "sha512-2bFhXP2zqSfQHugjqJIDFVwa+qIxyNApenmXTp9EjaKtdPrES5Qcn9/aSFy/NaP2E+fWG/zxKu/LBvY36p5VNQ==",
+			"version": "1.5.373",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
+			"integrity": "sha512-G2Hym8JIf/QreuseqkDibgH8Ci8KfJzqGDKdakbhSx9UltwRBH2cBLAWU/lBX0sCdv0TlhyxQyDCnSfxgMWsjA==",
 			"dev": true
 		},
 		"emittery": {
@@ -9650,9 +9628,9 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-			"integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+			"integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.8.0",
@@ -9660,7 +9638,7 @@
 				"@eslint/config-array": "^0.23.5",
 				"@eslint/config-helpers": "^0.6.0",
 				"@eslint/core": "^1.2.1",
-				"@eslint/plugin-kit": "^0.7.1",
+				"@eslint/plugin-kit": "^0.7.2",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
@@ -10094,9 +10072,9 @@
 			"dev": true
 		},
 		"h264-profile-level-id": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.2.tgz",
-			"integrity": "sha512-hnq1UDlw7WGJV6GCr/g7wnkHYUjdAY2bis9rgn2JqSdQS2WfVvnt1ZE9g8nTguracodf5LLKZOwURsDN49YtBQ==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.3.3.tgz",
+			"integrity": "sha512-rPd5gpyWuIfEbBiHC/f9I4wdeCpAhg0aWdYgjMRdVTqhJT22C6VrWTi4hpAAgJad1Vv8BJDEvrzAQTW7CxzmJw==",
 			"requires": {
 				"debug": "^4.4.3"
 			}
@@ -10770,6 +10748,16 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
+		"js-yaml": {
+			"version": "3.14.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"dev": true,
+			"requires": {
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
+			}
+		},
 		"jsesc": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -10812,23 +10800,22 @@
 			}
 		},
 		"knip": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-6.14.2.tgz",
-			"integrity": "sha512-Vg3JhIINjZew1I7qAFI4UHemW1mc4azP/BxJvsq9eGDfxpGO7oVCuD/bsWkog9TO/ZwwJeAeOMFZ1kd9jnY9+Q==",
+			"version": "6.17.1",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-6.17.1.tgz",
+			"integrity": "sha512-HcQsZSQ4Ymhuay4BVzJtM5pFZNDSomYYqcNCZOSITPQh9g18a09DqziWAxSt2G+BH9wGlG+0ZjWpEnaFlnKseQ==",
 			"dev": true,
 			"requires": {
 				"fdir": "^6.5.0",
 				"formatly": "^0.3.0",
 				"get-tsconfig": "4.14.0",
 				"jiti": "^2.7.0",
-				"minimist": "^1.2.8",
-				"oxc-parser": "^0.130.0",
-				"oxc-resolver": "^11.19.1",
+				"oxc-parser": "^0.135.0",
+				"oxc-resolver": "^11.20.0",
 				"picomatch": "^4.0.4",
 				"smol-toml": "^1.6.1",
 				"strip-json-comments": "5.0.3",
-				"tinyglobby": "^0.2.16",
-				"unbash": "^3.0.0",
+				"tinyglobby": "^0.2.17",
+				"unbash": "^4.0.1",
 				"yaml": "^2.9.0",
 				"zod": "^4.1.11"
 			},
@@ -10983,9 +10970,9 @@
 			"dev": true
 		},
 		"node-releases": {
-			"version": "2.0.19",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-			"integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+			"version": "2.0.47",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+			"integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
 			"dev": true
 		},
 		"normalize-path": {
@@ -11060,32 +11047,32 @@
 			}
 		},
 		"oxc-parser": {
-			"version": "0.130.0",
-			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.130.0.tgz",
-			"integrity": "sha512-X0PJ+NmOok8qP3vK9uaW431ngkdM9UPEK7KG466urtIL2+EYTEgbZK2yqe2MWKJKBjRlFweP/pJPx0x9muMEVw==",
+			"version": "0.135.0",
+			"resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.135.0.tgz",
+			"integrity": "sha512-/DaPStu0s2zzNSRRniKyTPM6Z/o+DapOp2JYNKDL8AsgaBGPK2IdZyB87SQjVH+xeQPz+Qr9mrjglfkYgtbVRA==",
 			"dev": true,
 			"requires": {
-				"@oxc-parser/binding-android-arm-eabi": "0.130.0",
-				"@oxc-parser/binding-android-arm64": "0.130.0",
-				"@oxc-parser/binding-darwin-arm64": "0.130.0",
-				"@oxc-parser/binding-darwin-x64": "0.130.0",
-				"@oxc-parser/binding-freebsd-x64": "0.130.0",
-				"@oxc-parser/binding-linux-arm-gnueabihf": "0.130.0",
-				"@oxc-parser/binding-linux-arm-musleabihf": "0.130.0",
-				"@oxc-parser/binding-linux-arm64-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-arm64-musl": "0.130.0",
-				"@oxc-parser/binding-linux-ppc64-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-riscv64-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-riscv64-musl": "0.130.0",
-				"@oxc-parser/binding-linux-s390x-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-x64-gnu": "0.130.0",
-				"@oxc-parser/binding-linux-x64-musl": "0.130.0",
-				"@oxc-parser/binding-openharmony-arm64": "0.130.0",
-				"@oxc-parser/binding-wasm32-wasi": "0.130.0",
-				"@oxc-parser/binding-win32-arm64-msvc": "0.130.0",
-				"@oxc-parser/binding-win32-ia32-msvc": "0.130.0",
-				"@oxc-parser/binding-win32-x64-msvc": "0.130.0",
-				"@oxc-project/types": "^0.130.0"
+				"@oxc-parser/binding-android-arm-eabi": "0.135.0",
+				"@oxc-parser/binding-android-arm64": "0.135.0",
+				"@oxc-parser/binding-darwin-arm64": "0.135.0",
+				"@oxc-parser/binding-darwin-x64": "0.135.0",
+				"@oxc-parser/binding-freebsd-x64": "0.135.0",
+				"@oxc-parser/binding-linux-arm-gnueabihf": "0.135.0",
+				"@oxc-parser/binding-linux-arm-musleabihf": "0.135.0",
+				"@oxc-parser/binding-linux-arm64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-arm64-musl": "0.135.0",
+				"@oxc-parser/binding-linux-ppc64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-riscv64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-riscv64-musl": "0.135.0",
+				"@oxc-parser/binding-linux-s390x-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-x64-gnu": "0.135.0",
+				"@oxc-parser/binding-linux-x64-musl": "0.135.0",
+				"@oxc-parser/binding-openharmony-arm64": "0.135.0",
+				"@oxc-parser/binding-wasm32-wasi": "0.135.0",
+				"@oxc-parser/binding-win32-arm64-msvc": "0.135.0",
+				"@oxc-parser/binding-win32-ia32-msvc": "0.135.0",
+				"@oxc-parser/binding-win32-x64-msvc": "0.135.0",
+				"@oxc-project/types": "^0.135.0"
 			}
 		},
 		"oxc-resolver": {
@@ -11262,9 +11249,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+			"version": "3.8.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+			"integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -11625,9 +11612,9 @@
 			}
 		},
 		"tinyglobby": {
-			"version": "0.2.16",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-			"integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+			"version": "0.2.17",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+			"integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
 			"dev": true,
 			"requires": {
 				"fdir": "^6.5.0",
@@ -11723,15 +11710,15 @@
 			"dev": true
 		},
 		"typescript-eslint": {
-			"version": "8.60.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.0.tgz",
-			"integrity": "sha512-9f65qWLZdAW9m1JaxBDUHcqRUfL8bkxxXL7XxEfI+F09q56PkBvIfCjLF3yInsDM/BBmwkqmCQdCZe/RYlIWEw==",
+			"version": "8.61.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+			"integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/eslint-plugin": "8.60.0",
-				"@typescript-eslint/parser": "8.60.0",
-				"@typescript-eslint/typescript-estree": "8.60.0",
-				"@typescript-eslint/utils": "8.60.0"
+				"@typescript-eslint/eslint-plugin": "8.61.1",
+				"@typescript-eslint/parser": "8.61.1",
+				"@typescript-eslint/typescript-estree": "8.61.1",
+				"@typescript-eslint/utils": "8.61.1"
 			}
 		},
 		"uglify-js": {
@@ -11748,9 +11735,9 @@
 			"dev": true
 		},
 		"unbash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/unbash/-/unbash-3.0.0.tgz",
-			"integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/unbash/-/unbash-4.0.1.tgz",
+			"integrity": "sha512-1ajSo3813sDoVIHx4inJdUS4l5L2ic5cFiddemPiyjb/PZEoBAhFwHtbaEdRDFxbAKy7FCG7s5ww3/uCFawuIA==",
 			"dev": true
 		},
 		"undici-types": {
@@ -11800,9 +11787,9 @@
 			}
 		},
 		"update-browserslist-db": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
-			"integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
 			"dev": true,
 			"requires": {
 				"escalade": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -73,29 +73,29 @@
 	"dependencies": {
 		"@types/debug": "^4.1.13",
 		"@types/events-alias": "npm:@types/events@^3.0.3",
-		"awaitqueue": "^3.3.0",
+		"awaitqueue": "^3.3.1",
 		"debug": "^4.4.3",
 		"events-alias": "npm:events@^3.3.0",
 		"fake-mediastreamtrack": "^2.2.1",
-		"h264-profile-level-id": "^2.3.2",
+		"h264-profile-level-id": "^2.3.3",
 		"sdp-transform": "^3.0.0",
 		"supports-color": "^10.2.2"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
 		"@types/jest": "^30.0.0",
-		"@types/sdp-transform": "^2.15.0",
-		"eslint": "^10.4.0",
+		"@types/sdp-transform": "^3.0.0",
+		"eslint": "^10.5.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-jest": "^29.15.2",
 		"eslint-plugin-prettier": "^5.5.6",
 		"globals": "^17.6.0",
 		"jest": "^30.4.2",
-		"knip": "^6.14.2",
+		"knip": "^6.17.1",
 		"open-cli": "^9.0.0",
-		"prettier": "^3.8.3",
+		"prettier": "^3.8.4",
 		"ts-jest": "^29.4.11",
 		"typescript": "^6.0.3",
-		"typescript-eslint": "^8.60.0"
+		"typescript-eslint": "^8.61.1"
 	}
 }

--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -223,6 +223,10 @@ export class Consumer<
 
 		// Emit observer event.
 		this._observer.safeEmit('close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
+		this._observer.close();
 	}
 
 	/**

--- a/src/DataConsumer.ts
+++ b/src/DataConsumer.ts
@@ -201,6 +201,10 @@ export class DataConsumer<
 
 		// Emit observer event.
 		this._observer.safeEmit('close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
+		this._observer.close();
 	}
 
 	private handleDataChannel(): void {
@@ -240,15 +244,21 @@ export class DataConsumer<
 				return;
 			}
 
-			logger.warn('DataChannel "close" event');
+			logger.debug('DataChannel "close" event');
 
 			this._closed = true;
+
+			this._dataChannel.close();
 
 			this.emit('@close');
 			this.safeEmit('close');
 
 			// Emit observer event.
 			this._observer.safeEmit('close');
+
+			// Invoke close() in EnhancedEventEmitter classes.
+			super.close();
+			this._observer.close();
 		});
 
 		this._dataChannel.addEventListener('message', event => {

--- a/src/DataProducer.ts
+++ b/src/DataProducer.ts
@@ -196,6 +196,10 @@ export class DataProducer<
 
 		// Emit observer event.
 		this._observer.safeEmit('close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
+		this._observer.close();
 	}
 
 	/**
@@ -251,15 +255,21 @@ export class DataProducer<
 				return;
 			}
 
-			logger.warn('DataChannel "close" event');
+			logger.debug('DataChannel "close" event');
 
 			this._closed = true;
+
+			this._dataChannel.close();
 
 			this.emit('@close');
 			this.safeEmit('close');
 
 			// Emit observer event.
 			this._observer.safeEmit('close');
+
+			// Invoke close() in EnhancedEventEmitter classes.
+			super.close();
+			this._observer.close();
 		});
 
 		this._dataChannel.addEventListener('message', () => {

--- a/src/Device.ts
+++ b/src/Device.ts
@@ -19,7 +19,6 @@ import type {
 	MediaKind,
 	ExtendedRtpCapabilities,
 } from './RtpParameters';
-import type { SctpCapabilities } from './SctpParameters';
 import type { AppData } from './types';
 
 const logger = new Logger('Device');
@@ -141,8 +140,6 @@ export class Device {
 		audio: false,
 		video: false,
 	};
-	// Local SCTP capabilities.
-	private _sctpCapabilities?: SctpCapabilities;
 	// Observer instance.
 	protected readonly _observer: DeviceObserver =
 		new EnhancedEventEmitter<DeviceObserverEvents>();
@@ -296,19 +293,6 @@ export class Device {
 		return this._sendRtpCapabilities!;
 	}
 
-	/**
-	 * SCTP capabilities of the Device.
-	 *
-	 * @throws {InvalidStateError} if not loaded.
-	 */
-	get sctpCapabilities(): SctpCapabilities {
-		if (!this._loaded) {
-			throw new InvalidStateError('not loaded');
-		}
-
-		return this._sctpCapabilities!;
-	}
-
 	get observer(): DeviceObserver {
 		return this._observer;
 	}
@@ -337,8 +321,7 @@ export class Device {
 		// This may throw.
 		ortc.validateAndNormalizeRtpCapabilities(clonedRouterRtpCapabilities);
 
-		const { getNativeRtpCapabilities, getNativeSctpCapabilities } =
-			this._handlerFactory;
+		const { getNativeRtpCapabilities } = this._handlerFactory;
 
 		const clonedNativeRecvRtpCapabilities = utils.clone<RtpCapabilities>(
 			await getNativeRtpCapabilities({ direction: 'recvonly' })
@@ -422,17 +405,6 @@ export class Device {
 		this._canProduceByKind.video = ortc.canSend(
 			'video',
 			this._sendRtpCapabilities
-		);
-
-		// Generate our SCTP capabilities.
-		this._sctpCapabilities = await getNativeSctpCapabilities();
-
-		// This may throw.
-		ortc.validateSctpCapabilities(this._sctpCapabilities);
-
-		logger.debug(
-			'load() | got native SCTP capabilities:%o',
-			this._sctpCapabilities
 		);
 
 		logger.debug('load() succeeded');

--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -283,6 +283,10 @@ export class Producer<
 
 		// Emit observer event.
 		this._observer.safeEmit('close');
+
+		// Invoke close() in EnhancedEventEmitter classes.
+		super.close();
+		this._observer.close();
 	}
 
 	/**

--- a/src/SctpParameters.ts
+++ b/src/SctpParameters.ts
@@ -1,35 +1,24 @@
-export type SctpCapabilities = {
-	numStreams: NumSctpStreams;
-};
-
-export type NumSctpStreams = {
-	/**
-	 * Initially requested number of outgoing SCTP streams.
-	 */
-	OS: number;
-	/**
-	 * Maximum number of incoming SCTP streams.
-	 */
-	MIS: number;
-};
-
 export type SctpParameters = {
 	/**
-	 * Must always equal 5000.
+	 * SCTP source port of the mediasoup transport.
 	 */
 	port: number;
+
 	/**
-	 * Initially requested number of outgoing SCTP streams.
+	 * Maximum size for SCTP messages sent by mediasoup DataConsumers (in bytes).
 	 */
-	OS: number;
+	maxSendMessageSize: number;
+
 	/**
-	 * Maximum number of incoming SCTP streams.
+	 * Maximum size for SCTP messages received by mediasoup DataProducers (in
+	 * bytes).
 	 */
-	MIS: number;
-	/**
-	 * Maximum allowed size for SCTP messages.
-	 */
-	maxMessageSize: number;
+	maxReceiveMessageSize: number;
+
+	// TODO: SCTP: For backwards compatibility. Remove them in the future.
+	OS?: number;
+	MIS?: number;
+	maxMessageSize?: number;
 };
 
 /**
@@ -44,25 +33,31 @@ export type SctpStreamParameters = {
 	 * SCTP stream id.
 	 */
 	streamId?: number;
+
 	/**
 	 * Whether data messages must be received in order. if true the messages will
 	 * be sent reliably. Default true.
 	 */
 	ordered?: boolean;
+
 	/**
 	 * When ordered is false indicates the time (in milliseconds) after which a
 	 * SCTP packet will stop being retransmitted.
 	 */
+
 	maxPacketLifeTime?: number;
 	/**
 	 * When ordered is false indicates the maximum number of times a packet will
 	 * be retransmitted.
 	 */
+
 	maxRetransmits?: number;
+
 	/**
 	 * A label which can be used to distinguish this DataChannel from others.
 	 */
 	label?: string;
+
 	/**
 	 * Name of the sub-protocol used by this DataChannel.
 	 */

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -478,10 +478,9 @@ export class Transport<
 		}
 
 		// Enqueue command.
-		return this._awaitQueue.push(
-			async () => await this._handler.restartIce(iceParameters),
-			'transport.restartIce()'
-		);
+		await this._awaitQueue.push(async () => {
+			await this._handler.restartIce(iceParameters);
+		}, 'transport.restartIce()');
 	}
 
 	/**
@@ -499,10 +498,9 @@ export class Transport<
 		}
 
 		// Enqueue command.
-		return this._awaitQueue.push(
-			async () => this._handler.updateIceServers(iceServers),
-			'transport.updateIceServers()'
-		);
+		await this._awaitQueue.push(async () => {
+			await this._handler.updateIceServers(iceServers);
+		}, 'transport.updateIceServers()');
 	}
 
 	/**
@@ -1186,7 +1184,7 @@ export class Transport<
 		handler.on(
 			'@icecandidateerror',
 			(event: RTCPeerConnectionIceErrorEvent) => {
-				logger.warn(
+				logger.debug(
 					`ICE candidate error [url:${event.url}, localAddress:${event.address}, localPort:${event.port}]: ${event.errorCode} "${event.errorText}"`
 				);
 
@@ -1218,69 +1216,61 @@ export class Transport<
 			}
 
 			this._awaitQueue
-				.push(
-					async () => await this._handler.stopSending(producer.localId),
-					'producer @close event'
-				)
+				.push(async () => {
+					await this._handler.stopSending(producer.localId);
+				}, 'producer @close event')
 				.catch((error: Error) =>
-					logger.warn('producer.close() failed:%o', error)
+					logger.warn('producer closure failed:%o', error)
 				);
 		});
 
 		producer.on('@pause', (callback, errback) => {
 			this._awaitQueue
-				.push(
-					async () => await this._handler.pauseSending(producer.localId),
-					'producer @pause event'
-				)
+				.push(async () => {
+					await this._handler.pauseSending(producer.localId);
+				}, 'producer @pause event')
 				.then(callback)
 				.catch(errback);
 		});
 
 		producer.on('@resume', (callback, errback) => {
 			this._awaitQueue
-				.push(
-					async () => await this._handler.resumeSending(producer.localId),
-					'producer @resume event'
-				)
+				.push(async () => {
+					await this._handler.resumeSending(producer.localId);
+				}, 'producer @resume event')
 				.then(callback)
 				.catch(errback);
 		});
 
 		producer.on('@replacetrack', (track, callback, errback) => {
 			this._awaitQueue
-				.push(
-					async () => await this._handler.replaceTrack(producer.localId, track),
-					'producer @replacetrack event'
-				)
+				.push(async () => {
+					await this._handler.replaceTrack(producer.localId, track);
+				}, 'producer @replacetrack event')
 				.then(callback)
 				.catch(errback);
 		});
 
 		producer.on('@setmaxspatiallayer', (spatialLayer, callback, errback) => {
 			this._awaitQueue
-				.push(
-					async () =>
-						await this._handler.setMaxSpatialLayer(
-							producer.localId,
-							spatialLayer
-						),
-					'producer @setmaxspatiallayer event'
-				)
+				.push(async () => {
+					await this._handler.setMaxSpatialLayer(
+						producer.localId,
+						spatialLayer
+					);
+				}, 'producer @setmaxspatiallayer event')
 				.then(callback)
 				.catch(errback);
 		});
 
 		producer.on('@setrtpencodingparameters', (params, callback, errback) => {
 			this._awaitQueue
-				.push(
-					async () =>
-						await this._handler.setRtpEncodingParameters(
-							producer.localId,
-							params
-						),
-					'producer @setrtpencodingparameters event'
-				)
+				.push(async () => {
+					await this._handler.setRtpEncodingParameters(
+						producer.localId,
+						params
+					);
+				}, 'producer @setrtpencodingparameters event')
 				.then(callback)
 				.catch(errback);
 		});

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -220,8 +220,8 @@ export class Transport<
 	// Whether we can produce audio/video based on computed extended RTP
 	// capabilities.
 	private readonly _canProduceByKind: CanProduceByKind;
-	// SCTP max message size if enabled.
-	private readonly _maxSctpMessageSize?: number;
+	// SCTP parameters of the mediasoup transport.
+	private readonly _sctpParameters?: SctpParameters;
 	// RTC handler isntance.
 	private readonly _handler: HandlerInterface;
 	// Transport ICE gathering state.
@@ -295,7 +295,19 @@ export class Transport<
 		this._getSendExtendedRtpCapabilities = getSendExtendedRtpCapabilities;
 		this._recvRtpCapabilities = recvRtpCapabilities;
 		this._canProduceByKind = canProduceByKind;
-		this._maxSctpMessageSize = sctpParameters?.maxMessageSize;
+		// NOTE: Let's clone received SctpParameters and adapt them to be backwards
+		// compatible with old mediasoup server versions.
+		this._sctpParameters = utils.clone(sctpParameters);
+
+		if (this._sctpParameters) {
+			this._sctpParameters.maxSendMessageSize =
+				this._sctpParameters.maxSendMessageSize ??
+				this._sctpParameters.maxMessageSize;
+
+			this._sctpParameters.maxReceiveMessageSize =
+				this._sctpParameters.maxReceiveMessageSize ??
+				this._sctpParameters.maxMessageSize;
+		}
 
 		// Clone and sanitize additionalSettings.
 		const clonedAdditionalSettings = utils.clone(additionalSettings) ?? {};
@@ -310,7 +322,7 @@ export class Transport<
 			iceParameters,
 			iceCandidates,
 			dtlsParameters,
-			sctpParameters,
+			sctpParameters: this._sctpParameters,
 			iceServers,
 			iceTransportPolicy,
 			additionalSettings: clonedAdditionalSettings,
@@ -518,7 +530,7 @@ export class Transport<
 		} else if (!track) {
 			throw new TypeError('missing track');
 		} else if (this._direction !== 'send') {
-			throw new UnsupportedError('not a sending Transport');
+			throw new UnsupportedError('not a sending transport');
 		} else if (!this._canProduceByKind[track.kind]) {
 			throw new UnsupportedError(`cannot produce ${track.kind}`);
 		} else if (track.readyState === 'ended') {
@@ -669,7 +681,7 @@ export class Transport<
 		if (this._closed) {
 			throw new InvalidStateError('closed');
 		} else if (this._direction !== 'recv') {
-			throw new UnsupportedError('not a receiving Transport');
+			throw new UnsupportedError('not a receiving transport');
 		} else if (typeof id !== 'string') {
 			throw new TypeError('missing id');
 		} else if (typeof producerId !== 'string') {
@@ -743,9 +755,9 @@ export class Transport<
 		if (this._closed) {
 			throw new InvalidStateError('closed');
 		} else if (this._direction !== 'send') {
-			throw new UnsupportedError('not a sending Transport');
-		} else if (!this._maxSctpMessageSize) {
-			throw new UnsupportedError('SCTP not enabled by remote Transport');
+			throw new UnsupportedError('not a sending transport');
+		} else if (!this._sctpParameters) {
+			throw new UnsupportedError('SCTP not enabled by remote transport');
 		} else if (
 			this.listenerCount('connect') === 0 &&
 			this._connectionState === 'new'
@@ -826,9 +838,9 @@ export class Transport<
 		if (this._closed) {
 			throw new InvalidStateError('closed');
 		} else if (this._direction !== 'recv') {
-			throw new UnsupportedError('not a receiving Transport');
-		} else if (!this._maxSctpMessageSize) {
-			throw new UnsupportedError('SCTP not enabled by remote Transport');
+			throw new UnsupportedError('not a receiving transport');
+		} else if (!this._sctpParameters) {
+			throw new UnsupportedError('SCTP not enabled by remote transport');
 		} else if (typeof id !== 'string') {
 			throw new TypeError('missing id');
 		} else if (typeof dataProducerId !== 'string') {
@@ -851,7 +863,8 @@ export class Transport<
 		// Enqueue command.
 		return this._awaitQueue.push(async () => {
 			const { dataChannel } = await this._handler.receiveDataChannel({
-				maxMessageSize: this._maxSctpMessageSize!,
+				// NOTE: Mirror it.
+				maxMessageSize: this._sctpParameters?.maxSendMessageSize,
 				sctpStreamParameters: clonedSctpStreamParameters,
 				label,
 				protocol,

--- a/src/handlers/Chrome111.ts
+++ b/src/handlers/Chrome111.ts
@@ -13,7 +13,7 @@ import type {
 	RtpHeaderExtensionUri,
 	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
-import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { SctpStreamParameters } from '../SctpParameters';
 import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
@@ -37,7 +37,6 @@ import type {
 const logger = new Logger('Chrome111');
 
 const NAME = 'Chrome111';
-const SCTP_NUM_STREAMS = { OS: 65535, MIS: 65535 };
 
 export class Chrome111
 	extends EnhancedEventEmitter<HandlerEvents>
@@ -47,6 +46,8 @@ export class Chrome111
 	private _closed = false;
 	// Handler direction.
 	private _direction: 'send' | 'recv';
+	// DataChannel max receive message size.
+	private _sctpMaxReceiveMessageSize?: number;
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
@@ -122,13 +123,6 @@ export class Chrome111
 					throw error;
 				}
 			},
-			getNativeSctpCapabilities: async (): Promise<SctpCapabilities> => {
-				logger.debug('getNativeSctpCapabilities()');
-
-				return {
-					numStreams: SCTP_NUM_STREAMS,
-				};
-			},
 		};
 	}
 
@@ -176,6 +170,9 @@ export class Chrome111
 		logger.debug('constructor()');
 
 		this._direction = direction;
+
+		// NOTE: Mirror it.
+		this._sctpMaxReceiveMessageSize = sctpParameters?.maxSendMessageSize;
 
 		this._remoteSdp = new RemoteSdp({
 			iceParameters,
@@ -850,7 +847,7 @@ export class Chrome111
 
 		// Increase next id.
 		this._nextSendSctpStreamId =
-			++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+			++this._nextSendSctpStreamId % (this._pc.sctp?.maxChannels ?? 65536);
 
 		// If this is the first DataChannel we need to create the SDP answer with
 		// m=application section.
@@ -1213,7 +1210,9 @@ export class Chrome111
 				m => m.type === 'application'
 			)!;
 
-			answerMediaObject.maxMessageSize = maxMessageSize;
+			if (typeof maxMessageSize === 'number') {
+				answerMediaObject.maxMessageSize = maxMessageSize;
+			}
 
 			if (!this._transportReady) {
 				await this.setupTransport({
@@ -1241,7 +1240,9 @@ export class Chrome111
 	}
 
 	getDataChannelMaxMessageSize(): number | undefined {
-		return this._pc.sctp?.maxMessageSize;
+		return this._direction === 'send'
+			? this._pc.sctp?.maxMessageSize
+			: this._sctpMaxReceiveMessageSize;
 	}
 
 	private async setupTransport({

--- a/src/handlers/Chrome74.ts
+++ b/src/handlers/Chrome74.ts
@@ -14,7 +14,7 @@ import type {
 	RtpHeaderExtensionUri,
 	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
-import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { SctpStreamParameters } from '../SctpParameters';
 import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
@@ -38,7 +38,6 @@ import type {
 const logger = new Logger('Chrome74');
 
 const NAME = 'Chrome74';
-const SCTP_NUM_STREAMS = { OS: 1024, MIS: 1024 };
 
 export class Chrome74
 	extends EnhancedEventEmitter<HandlerEvents>
@@ -48,6 +47,8 @@ export class Chrome74
 	private _closed = false;
 	// Handler direction.
 	private _direction: 'send' | 'recv';
+	// DataChannel max receive message size.
+	private _sctpMaxReceiveMessageSize?: number;
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
@@ -118,13 +119,6 @@ export class Chrome74
 					throw error;
 				}
 			},
-			getNativeSctpCapabilities: async (): Promise<SctpCapabilities> => {
-				logger.debug('getNativeSctpCapabilities()');
-
-				return {
-					numStreams: SCTP_NUM_STREAMS,
-				};
-			},
 		};
 	}
 
@@ -172,6 +166,9 @@ export class Chrome74
 		logger.debug('constructor()');
 
 		this._direction = direction;
+
+		// NOTE: Mirror it.
+		this._sctpMaxReceiveMessageSize = sctpParameters?.maxSendMessageSize;
 
 		this._remoteSdp = new RemoteSdp({
 			iceParameters,
@@ -873,7 +870,7 @@ export class Chrome74
 
 		// Increase next id.
 		this._nextSendSctpStreamId =
-			++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+			++this._nextSendSctpStreamId % (this._pc.sctp?.maxChannels ?? 65536);
 
 		// If this is the first DataChannel we need to create the SDP answer with
 		// m=application section.
@@ -1219,7 +1216,9 @@ export class Chrome74
 				m => m.type === 'application'
 			)!;
 
-			answerMediaObject.maxMessageSize = maxMessageSize;
+			if (typeof maxMessageSize === 'number') {
+				answerMediaObject.maxMessageSize = maxMessageSize;
+			}
 
 			if (!this._transportReady) {
 				await this.setupTransport({
@@ -1247,7 +1246,9 @@ export class Chrome74
 	}
 
 	getDataChannelMaxMessageSize(): number | undefined {
-		return this._pc.sctp?.maxMessageSize;
+		return this._direction === 'send'
+			? this._pc.sctp?.maxMessageSize
+			: this._sctpMaxReceiveMessageSize;
 	}
 
 	private async setupTransport({

--- a/src/handlers/FakeHandler.ts
+++ b/src/handlers/FakeHandler.ts
@@ -18,7 +18,6 @@ import type {
 	RtpParameters,
 	ExtendedRtpCapabilities,
 } from '../RtpParameters';
-import type { SctpCapabilities } from '../SctpParameters';
 import { FakeEventTarget } from './fakeEvents/FakeEventTarget';
 import {
 	FakeEventListener,
@@ -48,7 +47,6 @@ const NAME = 'FakeHandler';
 
 export type FakeParameters = {
 	generateNativeRtpCapabilities: () => RtpCapabilities;
-	generateNativeSctpCapabilities: () => SctpCapabilities;
 	generateLocalDtlsParameters: () => DtlsParameters;
 };
 
@@ -91,11 +89,6 @@ export class FakeHandler
 				logger.debug('getNativeRtpCapabilities() [direction:%o]', direction);
 
 				return FakeHandler.getLocalRtpCapabilities(fakeParameters);
-			},
-			getNativeSctpCapabilities: async (): Promise<SctpCapabilities> => {
-				logger.debug('getNativeSctpCapabilities()');
-
-				return fakeParameters.generateNativeSctpCapabilities();
 			},
 		};
 	}

--- a/src/handlers/Firefox120.ts
+++ b/src/handlers/Firefox120.ts
@@ -12,7 +12,7 @@ import type {
 	RtpEncodingParameters,
 	ExtendedRtpCapabilities,
 } from '../RtpParameters';
-import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { SctpStreamParameters } from '../SctpParameters';
 import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
@@ -36,7 +36,6 @@ import type {
 const logger = new Logger('Firefox120');
 
 const NAME = 'Firefox120';
-const SCTP_NUM_STREAMS = { OS: 16, MIS: 2048 };
 
 export class Firefox120
 	extends EnhancedEventEmitter<HandlerEvents>
@@ -46,6 +45,8 @@ export class Firefox120
 	private _closed = false;
 	// Handler direction.
 	private _direction: 'send' | 'recv';
+	// DataChannel max receive message size.
+	private _sctpMaxReceiveMessageSize?: number;
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
@@ -146,13 +147,6 @@ export class Firefox120
 					throw error;
 				}
 			},
-			getNativeSctpCapabilities: async (): Promise<SctpCapabilities> => {
-				logger.debug('getNativeSctpCapabilities()');
-
-				return {
-					numStreams: SCTP_NUM_STREAMS,
-				};
-			},
 		};
 	}
 
@@ -185,6 +179,9 @@ export class Firefox120
 		logger.debug('constructor()');
 
 		this._direction = direction;
+
+		// NOTE: Mirror it.
+		this._sctpMaxReceiveMessageSize = sctpParameters?.maxSendMessageSize;
 
 		this._remoteSdp = new RemoteSdp({
 			iceParameters,
@@ -821,7 +818,7 @@ export class Firefox120
 
 		// Increase next id.
 		this._nextSendSctpStreamId =
-			++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+			++this._nextSendSctpStreamId % (this._pc.sctp?.maxChannels ?? 65536);
 
 		// If this is the first DataChannel we need to create the SDP answer with
 		// m=application section.
@@ -1177,7 +1174,9 @@ export class Firefox120
 				m => m.type === 'application'
 			)!;
 
-			answerMediaObject.maxMessageSize = maxMessageSize;
+			if (typeof maxMessageSize === 'number') {
+				answerMediaObject.maxMessageSize = maxMessageSize;
+			}
 
 			if (!this._transportReady) {
 				await this.setupTransport({ localDtlsRole: 'client', localSdpObject });
@@ -1202,7 +1201,9 @@ export class Firefox120
 	}
 
 	getDataChannelMaxMessageSize(): number | undefined {
-		return this._pc.sctp?.maxMessageSize;
+		return this._direction === 'send'
+			? this._pc.sctp?.maxMessageSize
+			: this._sctpMaxReceiveMessageSize;
 	}
 
 	private async setupTransport({

--- a/src/handlers/HandlerInterface.ts
+++ b/src/handlers/HandlerInterface.ts
@@ -19,11 +19,7 @@ import type {
 	RtpEncodingParameters,
 	ExtendedRtpCapabilities,
 } from '../RtpParameters';
-import type {
-	SctpCapabilities,
-	SctpParameters,
-	SctpStreamParameters,
-} from '../SctpParameters';
+import type { SctpParameters, SctpStreamParameters } from '../SctpParameters';
 
 export type HandlerFactory = {
 	name: string;
@@ -31,7 +27,6 @@ export type HandlerFactory = {
 	getNativeRtpCapabilities(
 		options: HandlerGetNativeRtpCapabilitiesOptions
 	): Promise<RtpCapabilities>;
-	getNativeSctpCapabilities(): Promise<SctpCapabilities>;
 };
 
 export type HandlerOptions = {
@@ -105,7 +100,7 @@ export type HandlerSendDataChannelResult = {
 };
 
 export type HandlerReceiveDataChannelOptions = {
-	maxMessageSize: number;
+	maxMessageSize?: number;
 	sctpStreamParameters: SctpStreamParameters;
 	label?: string;
 	protocol?: string;

--- a/src/handlers/ReactNative106.ts
+++ b/src/handlers/ReactNative106.ts
@@ -14,7 +14,7 @@ import type {
 	RtpHeaderExtensionUri,
 	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
-import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { SctpStreamParameters } from '../SctpParameters';
 import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
@@ -38,7 +38,6 @@ import type {
 const logger = new Logger('ReactNative106');
 
 const NAME = 'ReactNative106';
-const SCTP_NUM_STREAMS = { OS: 65535, MIS: 65535 };
 
 export class ReactNative106
 	extends EnhancedEventEmitter<HandlerEvents>
@@ -48,6 +47,8 @@ export class ReactNative106
 	private _closed = false;
 	// Handler direction.
 	private _direction: 'send' | 'recv';
+	// DataChannel max receive message size.
+	private _sctpMaxReceiveMessageSize?: number;
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
@@ -119,13 +120,6 @@ export class ReactNative106
 					throw error;
 				}
 			},
-			getNativeSctpCapabilities: async (): Promise<SctpCapabilities> => {
-				logger.debug('getNativeSctpCapabilities()');
-
-				return {
-					numStreams: SCTP_NUM_STREAMS,
-				};
-			},
 		};
 	}
 
@@ -173,6 +167,9 @@ export class ReactNative106
 		logger.debug('constructor()');
 
 		this._direction = direction;
+
+		// NOTE: Mirror it.
+		this._sctpMaxReceiveMessageSize = sctpParameters?.maxSendMessageSize;
 
 		this._remoteSdp = new RemoteSdp({
 			iceParameters,
@@ -907,7 +904,7 @@ export class ReactNative106
 
 		// Increase next id.
 		this._nextSendSctpStreamId =
-			++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+			++this._nextSendSctpStreamId % (this._pc.sctp?.maxChannels ?? 65536);
 
 		// If this is the first DataChannel we need to create the SDP answer with
 		// m=application section.
@@ -1270,7 +1267,9 @@ export class ReactNative106
 				m => m.type === 'application'
 			)!;
 
-			answerMediaObject.maxMessageSize = maxMessageSize;
+			if (typeof maxMessageSize === 'number') {
+				answerMediaObject.maxMessageSize = maxMessageSize;
+			}
 
 			if (!this._transportReady) {
 				await this.setupTransport({
@@ -1298,7 +1297,9 @@ export class ReactNative106
 	}
 
 	getDataChannelMaxMessageSize(): number | undefined {
-		return this._pc.sctp?.maxMessageSize;
+		return this._direction === 'send'
+			? this._pc.sctp?.maxMessageSize
+			: this._sctpMaxReceiveMessageSize;
 	}
 
 	private async setupTransport({

--- a/src/handlers/Safari12.ts
+++ b/src/handlers/Safari12.ts
@@ -13,7 +13,7 @@ import type {
 	RtpHeaderExtensionUri,
 	RtpHeaderExtensionDirection,
 } from '../RtpParameters';
-import type { SctpCapabilities, SctpStreamParameters } from '../SctpParameters';
+import type { SctpStreamParameters } from '../SctpParameters';
 import { RemoteSdp } from './sdp/RemoteSdp';
 import * as sdpCommonUtils from './sdp/commonUtils';
 import * as sdpUnifiedPlanUtils from './sdp/unifiedPlanUtils';
@@ -37,7 +37,6 @@ import type {
 const logger = new Logger('Safari12');
 
 const NAME = 'Safari12';
-const SCTP_NUM_STREAMS = { OS: 65535, MIS: 65535 };
 
 export class Safari12
 	extends EnhancedEventEmitter<HandlerEvents>
@@ -47,6 +46,8 @@ export class Safari12
 	private _closed = false;
 	// Handler direction.
 	private _direction: 'send' | 'recv';
+	// DataChannel max receive message size.
+	private _sctpMaxReceiveMessageSize?: number;
 	// Remote SDP handler.
 	private _remoteSdp: RemoteSdp;
 	// Callback to request sending extended RTP capabilities on demand.
@@ -117,13 +118,6 @@ export class Safari12
 					throw error;
 				}
 			},
-			getNativeSctpCapabilities: async (): Promise<SctpCapabilities> => {
-				logger.debug('getNativeSctpCapabilities()');
-
-				return {
-					numStreams: SCTP_NUM_STREAMS,
-				};
-			},
 		};
 	}
 
@@ -171,6 +165,9 @@ export class Safari12
 		logger.debug('constructor()');
 
 		this._direction = direction;
+
+		// NOTE: Mirror it.
+		this._sctpMaxReceiveMessageSize = sctpParameters?.maxSendMessageSize;
 
 		this._remoteSdp = new RemoteSdp({
 			iceParameters,
@@ -859,7 +856,7 @@ export class Safari12
 
 		// Increase next id.
 		this._nextSendSctpStreamId =
-			++this._nextSendSctpStreamId % SCTP_NUM_STREAMS.MIS;
+			++this._nextSendSctpStreamId % (this._pc.sctp?.maxChannels ?? 65536);
 
 		// If this is the first DataChannel we need to create the SDP answer with
 		// m=application section.
@@ -1222,7 +1219,9 @@ export class Safari12
 				m => m.type === 'application'
 			)!;
 
-			answerMediaObject.maxMessageSize = maxMessageSize;
+			if (typeof maxMessageSize === 'number') {
+				answerMediaObject.maxMessageSize = maxMessageSize;
+			}
 
 			if (!this._transportReady) {
 				await this.setupTransport({
@@ -1250,7 +1249,9 @@ export class Safari12
 	}
 
 	getDataChannelMaxMessageSize(): number | undefined {
-		return this._pc.sctp?.maxMessageSize;
+		return this._direction === 'send'
+			? this._pc.sctp?.maxMessageSize
+			: this._sctpMaxReceiveMessageSize;
 	}
 
 	private async setupTransport({

--- a/src/handlers/sdp/RemoteMediaSection.ts
+++ b/src/handlers/sdp/RemoteMediaSection.ts
@@ -17,7 +17,7 @@ import type {
 } from '../../RtpParameters';
 import type { SctpParameters } from '../../SctpParameters';
 
-export abstract class MediaSection {
+export abstract class RemoteMediaSection {
 	// SDP media object.
 	protected readonly _mediaObject: SdpTransform.MediaDescription;
 
@@ -134,7 +134,7 @@ export abstract class MediaSection {
 	}
 }
 
-export class AnswerMediaSection extends MediaSection {
+export class RemoteAnswerMediaSection extends RemoteMediaSection {
 	constructor({
 		iceParameters,
 		iceCandidates,
@@ -395,7 +395,8 @@ export class AnswerMediaSection extends MediaSection {
 				if (typeof offerMediaObject.sctpPort === 'number') {
 					this._mediaObject.payloads = 'webrtc-datachannel';
 					this._mediaObject.sctpPort = sctpParameters!.port;
-					this._mediaObject.maxMessageSize = sctpParameters!.maxMessageSize;
+					this._mediaObject.maxMessageSize =
+						sctpParameters!.maxReceiveMessageSize;
 				}
 				// Old spec.
 				else if (offerMediaObject.sctpmap) {
@@ -403,7 +404,7 @@ export class AnswerMediaSection extends MediaSection {
 					this._mediaObject.sctpmap = {
 						app: 'webrtc-datachannel',
 						sctpmapNumber: sctpParameters!.port,
-						maxMessageSize: sctpParameters!.maxMessageSize,
+						maxMessageSize: sctpParameters!.maxReceiveMessageSize,
 					};
 				}
 
@@ -469,7 +470,7 @@ export class AnswerMediaSection extends MediaSection {
 	}
 }
 
-export class OfferMediaSection extends MediaSection {
+export class RemoteOfferMediaSection extends RemoteMediaSection {
 	constructor({
 		iceParameters,
 		iceCandidates,
@@ -627,7 +628,8 @@ export class OfferMediaSection extends MediaSection {
 			case 'application': {
 				this._mediaObject.payloads = 'webrtc-datachannel';
 				this._mediaObject.sctpPort = sctpParameters!.port;
-				this._mediaObject.maxMessageSize = sctpParameters!.maxMessageSize;
+				this._mediaObject.maxMessageSize =
+					sctpParameters!.maxReceiveMessageSize;
 
 				break;
 			}

--- a/src/handlers/sdp/RemoteSdp.ts
+++ b/src/handlers/sdp/RemoteSdp.ts
@@ -2,10 +2,10 @@ import * as sdpTransform from 'sdp-transform';
 import type * as SdpTransform from 'sdp-transform';
 import { Logger } from '../../Logger';
 import {
-	MediaSection,
-	AnswerMediaSection,
-	OfferMediaSection,
-} from './MediaSection';
+	RemoteMediaSection,
+	RemoteAnswerMediaSection,
+	RemoteOfferMediaSection,
+} from './RemoteMediaSection';
 import type {
 	IceParameters,
 	IceCandidate,
@@ -33,9 +33,9 @@ export class RemoteSdp {
 	private readonly _sctpParameters?: SctpParameters;
 	// Parameters for plain RTP (no SRTP nor DTLS no BUNDLE).
 	private readonly _plainRtpParameters?: PlainRtpParameters;
-	// MediaSection instances with same order as in the SDP.
-	private readonly _mediaSections: MediaSection[] = [];
-	// MediaSection indices indexed by MID.
+	// RemoteMediaSection instances with same order as in the SDP.
+	private readonly _mediaSections: RemoteMediaSection[] = [];
+	// RemoteMediaSection indices indexed by MID.
 	private readonly _midToIndex: Map<string, number> = new Map();
 	// First MID.
 	private _firstMid?: string;
@@ -164,7 +164,7 @@ export class RemoteSdp {
 		answerRtpParameters: RtpParameters;
 		codecOptions?: ProducerCodecOptions;
 	}): void {
-		const mediaSection = new AnswerMediaSection({
+		const mediaSection = new RemoteAnswerMediaSection({
 			iceParameters: this._iceParameters,
 			iceCandidates: this._iceCandidates,
 			dtlsParameters: this._dtlsParameters,
@@ -222,7 +222,7 @@ export class RemoteSdp {
 		// mediasoup can send both at any time.
 		this.setSessionExtmapAllowMixed();
 
-		const mediaSection = new OfferMediaSection({
+		const mediaSection = new RemoteOfferMediaSection({
 			iceParameters: this._iceParameters,
 			iceCandidates: this._iceCandidates,
 			dtlsParameters: this._dtlsParameters,
@@ -308,7 +308,7 @@ export class RemoteSdp {
 		mid: string,
 		encodings: RTCRtpEncodingParameters[]
 	): void {
-		const mediaSection = this.findMediaSection(mid) as AnswerMediaSection;
+		const mediaSection = this.findMediaSection(mid) as RemoteAnswerMediaSection;
 
 		mediaSection.muxSimulcastStreams(encodings);
 
@@ -320,7 +320,7 @@ export class RemoteSdp {
 	}: {
 		offerMediaObject: SdpTransform.MediaDescription;
 	}): void {
-		const mediaSection = new AnswerMediaSection({
+		const mediaSection = new RemoteAnswerMediaSection({
 			iceParameters: this._iceParameters,
 			iceCandidates: this._iceCandidates,
 			dtlsParameters: this._dtlsParameters,
@@ -333,7 +333,7 @@ export class RemoteSdp {
 	}
 
 	receiveSctpAssociation(): void {
-		const mediaSection = new OfferMediaSection({
+		const mediaSection = new RemoteOfferMediaSection({
 			iceParameters: this._iceParameters,
 			iceCandidates: this._iceCandidates,
 			dtlsParameters: this._dtlsParameters,
@@ -353,7 +353,7 @@ export class RemoteSdp {
 		return sdpTransform.write(this._sdpObject);
 	}
 
-	private addMediaSection(newMediaSection: MediaSection): void {
+	private addMediaSection(newMediaSection: RemoteMediaSection): void {
 		if (!this._firstMid) {
 			this._firstMid = newMediaSection.mid;
 		}
@@ -372,7 +372,7 @@ export class RemoteSdp {
 	}
 
 	private replaceMediaSection(
-		newMediaSection: MediaSection,
+		newMediaSection: RemoteMediaSection,
 		reuseMid?: string
 	): void {
 		// Store it in the map.
@@ -414,7 +414,7 @@ export class RemoteSdp {
 		}
 	}
 
-	private findMediaSection(mid: string): MediaSection {
+	private findMediaSection(mid: string): RemoteMediaSection {
 		const idx = this._midToIndex.get(mid);
 
 		if (idx === undefined) {
@@ -430,8 +430,8 @@ export class RemoteSdp {
 		}
 
 		this._sdpObject.groups![0]!.mids = this._mediaSections
-			.filter((mediaSection: MediaSection) => !mediaSection.closed)
-			.map((mediaSection: MediaSection) => mediaSection.mid)
+			.filter((mediaSection: RemoteMediaSection) => !mediaSection.closed)
+			.map((mediaSection: RemoteMediaSection) => mediaSection.mid)
 			.join(' ');
 	}
 }

--- a/src/ortc.ts
+++ b/src/ortc.ts
@@ -14,11 +14,7 @@ import type {
 	ExtendedRtpCodecCapability,
 	ExtendedRtpHeaderExtension,
 } from './RtpParameters';
-import type {
-	SctpCapabilities,
-	NumSctpStreams,
-	SctpStreamParameters,
-} from './SctpParameters';
+import type { SctpStreamParameters } from './SctpParameters';
 import * as utils from './utils';
 
 const RTP_PROBATOR_MID = 'probator';
@@ -185,23 +181,6 @@ export function validateAndNormalizeSctpStreamParameters(
 	if (params.protocol && typeof params.protocol !== 'string') {
 		throw new TypeError('invalid params.protocol');
 	}
-}
-
-/**
- * Validates SctpCapabilities.
- * It throws if invalid.
- */
-export function validateSctpCapabilities(caps: SctpCapabilities): void {
-	if (typeof caps !== 'object') {
-		throw new TypeError('caps is not an object');
-	}
-
-	// numStreams is mandatory.
-	if (!caps.numStreams || typeof caps.numStreams !== 'object') {
-		throw new TypeError('missing caps.numStreams');
-	}
-
-	validateNumSctpStreams(caps.numStreams);
 }
 
 /**
@@ -1000,26 +979,6 @@ function validateAndNormalizeRtcpParameters(rtcp: RtcpParameters): void {
 	// reducedSize is optional. If unset set it to true.
 	if (!rtcp.reducedSize || typeof rtcp.reducedSize !== 'boolean') {
 		rtcp.reducedSize = true;
-	}
-}
-
-/**
- * Validates NumSctpStreams.
- * It throws if invalid.
- */
-function validateNumSctpStreams(numStreams: NumSctpStreams): void {
-	if (typeof numStreams !== 'object') {
-		throw new TypeError('numStreams is not an object');
-	}
-
-	// OS is mandatory.
-	if (typeof numStreams.OS !== 'number') {
-		throw new TypeError('missing numStreams.OS');
-	}
-
-	// MIS is mandatory.
-	if (typeof numStreams.MIS !== 'number') {
-		throw new TypeError('missing numStreams.MIS');
 	}
 }
 

--- a/src/test/fakeParameters.ts
+++ b/src/test/fakeParameters.ts
@@ -367,12 +367,6 @@ export function generateNativeRtpCapabilities(): mediasoupClient.types.RtpCapabi
 	};
 }
 
-export function generateNativeSctpCapabilities(): mediasoupClient.types.SctpCapabilities {
-	return utils.deepFreeze<mediasoupClient.types.SctpCapabilities>({
-		numStreams: { OS: 2048, MIS: 2048 },
-	});
-}
-
 export function generateLocalDtlsParameters(): mediasoupClient.types.DtlsParameters {
 	return utils.deepFreeze<mediasoupClient.types.DtlsParameters>({
 		fingerprints: [
@@ -438,9 +432,8 @@ export function generateTransportRemoteParameters(): mediasoupClient.types.Trans
 		}),
 		sctpParameters: utils.deepFreeze<mediasoupClient.types.SctpParameters>({
 			port: 5000,
-			OS: 2048,
-			MIS: 2048,
-			maxMessageSize: 2000000,
+			maxSendMessageSize: 50000,
+			maxReceiveMessageSize: 50000,
 		}),
 	};
 }

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -215,10 +215,6 @@ test('device.sendRtpCapabilities getter throws InvalidStateError if not loaded',
 	expect(() => ctx.device!.sendRtpCapabilities).toThrow(InvalidStateError);
 });
 
-test('device.sctpCapabilities getter throws InvalidStateError if not loaded', () => {
-	expect(() => ctx.device!.sctpCapabilities).toThrow(InvalidStateError);
-});
-
 test('device.canProduce() throws InvalidStateError if not loaded', () => {
 	expect(() => ctx.device!.canProduce('audio')).toThrow(InvalidStateError);
 });
@@ -294,10 +290,6 @@ test('device.recvRtpCapabilities getter succeeds', () => {
 
 test('device.sendRtpCapabilities getter succeeds', () => {
 	expect(typeof ctx.loadedDevice!.sendRtpCapabilities).toBe('object');
-});
-
-test('device.sctpCapabilities getter succeeds', () => {
-	expect(typeof ctx.loadedDevice!.sctpCapabilities).toBe('object');
 });
 
 test('device.canProduce() with "audio"/"video" kind returns true', () => {


### PR DESCRIPTION
# Details

- Fixes #374.
- **[BREAKING CHANGE]** Remove `device.sctpCapabilities`. Why? See next bullet.
- **[BREAKING CHANGE]** Remove `SctpCapabilities` type because it only contains `OS` and `MIS` which are hardcoded max number of outgoing and incoming SCTP streams, which means nothing because those values are later negotiated during the SCTP association handshake with the peer.
- Improve the way next sendong DataChannel `id` is computed by using the real negotiated max number of outgoing SCTP streams.
- Update deps.
- CI: Add `ubuntu-26.04` host and test Node 26.

## TODO

* [ ] Update docs.