### PR TITLE
New workflows

### DIFF
--- a/.github/workflows/mediasoup-client-npm-publish.yaml
+++ b/.github/workflows/mediasoup-client-npm-publish.yaml
@@ -1,0 +1,93 @@
+name: mediasoup-client-npm-publish
+
+# Triggered by pushing a release tag (SEMVER, e.g. 3.20.8), which the `release`
+# task in npm-scripts.mjs creates. It creates the GitHub release and publishes
+# the NPM package via OIDC trusted publishing.
+on:
+  push:
+    tags:
+      # Node release tags only (SEMVER).
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  # Don't cancel an in-progress publish if a new run lands in the same group.
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+
+      - name: Ensure mediasoup-client version is not already published on NPM
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(jq -r '.version' package.json)
+          published_version=$(npm view "mediasoup-client@${version}" version 2>/dev/null || true)
+          if [ "${published_version}" = "${version}" ]; then
+            echo "mediasoup-client@${version} is already published on NPM, this should not happen"
+            exit 1
+          fi
+
+  # Create the GitHub release.
+  release:
+    needs: check
+    if: ${{ !cancelled() && needs.check.result == 'success' }}
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release create "${TAG}" --title "${TAG}" --generate-notes
+
+  # Publish the NPM package via OIDC trusted publishing.
+  publish:
+    needs: [check, release]
+    if: ${{ !cancelled() && needs.check.result == 'success' && needs.release.result == 'success' }}
+    runs-on: ubuntu-26.04
+    permissions:
+      # Allow requesting short-lived OIDC token used for NPM trusted publishing.
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing requires a recent npm (>= 11.5.1).
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: npm ci --ignore-scripts --foreground-scripts
+        run: npm ci --ignore-scripts --foreground-scripts
+
+      - name: npm publish
+        run: npm publish

--- a/.github/workflows/mediasoup-client.yaml
+++ b/.github/workflows/mediasoup-client.yaml
@@ -14,6 +14,9 @@ concurrency:
 
 jobs:
   ci:
+    # Skip the release commit pushed by `npm run release` (its message carries a
+    # `[no-ci]` marker).
+    if: ${{ !contains(github.event.head_commit.message, '[no-ci]') }}
     strategy:
       matrix:
         ci:
@@ -63,3 +66,6 @@ jobs:
 
       - name: npm run test
         run: npm run test
+
+      - name: npm run publish:dry-run
+        run: npm run publish:dry-run

--- a/.github/workflows/mediasoup-demo-update.yaml
+++ b/.github/workflows/mediasoup-demo-update.yaml
@@ -1,0 +1,82 @@
+name: mediasoup-demo-update
+
+# Triggered when `mediasoup-client-npm-publish.yaml` finishes successfully
+# (`workflow_run`).
+#
+# It triggers the `update-mediasoup-client` workflow in versatica/mediasoup-demo
+# (via `workflow_dispatch`), passing the released version, which bumps the
+# mediasoup-client dependency in app/package.json and app/package-lock.json and
+# commits the change.
+#
+# It can also be triggered manually (`workflow_dispatch`) to re-trigger the
+# mediasoup-demo update (for example if the previous attempt failed), optionally
+# entering the version to update to.
+on:
+  workflow_run:
+    workflows: ['mediasoup-client-npm-publish']
+    # `workflow_run` only has 'requested', 'in_progress' and 'completed' activity
+    # types (there is no 'success'/'failure' type). 'completed' fires once the
+    # upstream run has fully finished, regardless of its conclusion. The actual
+    # success is gated in the job's `if` below, via
+    # `github.event.workflow_run.conclusion`.
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'mediasoup-client version to update mediasoup-demo to (defaults to the latest published on NPM if empty)'
+        required: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  # Don't cancel an in-progress trigger if a new run lands in the same group.
+  cancel-in-progress: false
+
+jobs:
+  # Trigger the `update-mediasoup-client` workflow in versatica/mediasoup-demo.
+  trigger:
+    # Run only when triggered manually, or when the upstream
+    # `mediasoup-client-npm-publish` run finished successfully.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-26.04
+    steps:
+      # Allow a short-lived installation token for the GitHub App. The App's
+      # private key (stored as a secret) does not expire but this token does, but
+      # it is generated automatically on every run, so there is nothing to renew
+      # manually.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DEMO_APP_ID }}
+          private-key: ${{ secrets.DEMO_APP_PRIVATE_KEY }}
+          owner: versatica
+          repositories: mediasoup-demo
+
+      # The released version passed to the remote `update-mediasoup-client`
+      # workflow is either a SEMVER ("X.Y.Z") or an empty string (which makes
+      # the remote workflow resolve the latest version published on NPM by
+      # itself).
+      #
+      # On manual runs (`workflow_dispatch`) it comes from the optional `version`
+      # input: a SEMVER if the user typed one, empty otherwise.
+      #
+      # On automatic runs (`workflow_run`) `inputs.version` does not exist, so we
+      # fall back to `github.event.workflow_run.head_branch`. This is NOT a branch
+      # name: when a workflow is triggered by pushing a Git tag, GitHub sets
+      # `head_branch` to the tag name, and that value is propagated unchanged down
+      # the whole `workflow_run` chain. So even though this workflow runs two hops
+      # below the original tag push:
+      #
+      #   push tag X.Y.Z -> mediasoup-npm-publish -> here
+      #
+      # `head_branch` is still the original tag X.Y.Z, i.e. exactly the version
+      # that was just released.
+      #
+      # The chain only ever starts from tags matching X.Y.Z (see the tag filter
+      # in `mediasoup-client-npm-publish.yaml`), so `head_branch` is always a
+      # clean SEMVER.
+      - name: Trigger update-mediasoup-client workflow
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ inputs.version || github.event.workflow_run.head_branch }}
+        run: gh workflow run update-mediasoup-client.yaml --repo versatica/mediasoup-demo --field version="${VERSION}"

--- a/.github/workflows/mediasoup-website-update.yaml
+++ b/.github/workflows/mediasoup-website-update.yaml
@@ -1,0 +1,47 @@
+name: mediasoup-website-update
+
+# Triggered when `mediasoup-client-npm-publish.yaml` finishes successfully
+# (`workflow_run`). It triggers the `update-website` workflow in
+# versatica/mediasoup-website (via `workflow_dispatch`, no inputs), which builds
+# the website and deploys it.
+#
+# It can also be triggered manually (`workflow_dispatch`) to re-trigger the website
+# update (for example if the previous attempt failed).
+on:
+  workflow_run:
+    workflows: ['mediasoup-client-npm-publish']
+    # `workflow_run` only has 'requested', 'in_progress' and 'completed' activity
+    # types (there is no 'success'/'failure' type). 'completed' fires once the
+    # upstream run has fully finished, regardless of its conclusion. The actual
+    # success is gated in the job's `if` below, via
+    # `github.event.workflow_run.conclusion`.
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  # Don't cancel an in-progress trigger if a new run lands in the same group.
+  cancel-in-progress: false
+
+jobs:
+  trigger:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-26.04
+    steps:
+      # Allow a short-lived installation token for the GitHub App. The App's
+      # private key (stored as a secret) does not expire but this token does, but
+      # it is generated automatically on every run, so there is nothing to renew
+      # manually.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WEBSITE_APP_ID }}
+          private-key: ${{ secrets.WEBSITE_APP_PRIVATE_KEY }}
+          owner: versatica
+          repositories: mediasoup-website
+
+      - name: Trigger update-website workflow
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh workflow run update-website.yaml --repo versatica/mediasoup-website

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 [![][npm-shield-mediasoup-client]][npm-mediasoup-client]
 [![][github-actions-shield-mediasoup-client]][github-actions-mediasoup-client]
+[![][github-actions-shield-mediasoup-client-npm-publish]][github-actions-mediasoup-client-npm-publish]
+[![][github-actions-shield-mediasoup-website-update]][github-actions-mediasoup-website-update]
+[![][github-actions-shield-mediasoup-demo-update]][github-actions-mediasoup-demo-update]
 [![][opencollective-shield-mediasoup]][opencollective-mediasoup]
 
 TypeScript client side library for building [mediasoup][mediasoup-website] based applications.
@@ -154,6 +157,12 @@ You can support mediasoup by [sponsoring][sponsor] it. Thanks!
 [npm-mediasoup-client]: https://npmjs.org/package/mediasoup-client
 [github-actions-shield-mediasoup-client]: https://github.com/versatica/mediasoup-client/actions/workflows/mediasoup-client.yaml/badge.svg?branch=v3
 [github-actions-mediasoup-client]: https://github.com/versatica/mediasoup-client/actions/workflows/mediasoup-client.yaml?query=branch%3Av3
+[github-actions-shield-mediasoup-client-npm-publish]: https://github.com/versatica/mediasoup-client/actions/workflows/mediasoup-client-npm-publish.yaml/badge.svg
+[github-actions-mediasoup-client-npm-publish]: https://github.com/versatica/mediasoup-client/actions/workflows/mediasoup-client-npm-publish.yaml
+[github-actions-shield-mediasoup-website-update]: https://github.com/versatica/mediasoup-client/actions/workflows/mediasoup-website-update.yaml/badge.svg
+[github-actions-mediasoup-website-update]: https://github.com/versatica/mediasoup-client/actions/workflows/mediasoup-website-update.yaml
+[github-actions-shield-mediasoup-demo-update]: https://github.com/versatica/mediasoup-client/actions/workflows/mediasoup-demo-update.yaml/badge.svg
+[github-actions-mediasoup-demo-update]: https://github.com/versatica/mediasoup-client/actions/workflows/mediasoup-demo-update.yaml
 [opencollective-shield-mediasoup]: https://img.shields.io/opencollective/all/mediasoup.svg
 [opencollective-mediasoup]: https://opencollective.com/mediasoup/
 [sponsor]: https://mediasoup.org/sponsor/

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -4,7 +4,9 @@ import * as fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import pkg from './package.json' with { type: 'json' };
 
-const MAYOR_VERSION = pkg.version.split('.')[0];
+// Main Git branch is 'v' concatenated with the major SEMVER number of the
+// "version" field in package.json.
+const MAIN_BRANCH = `v${pkg.version.split('.')[0]}`;
 
 // Paths for ESLint to check.
 const ESLINT_PATHS = [
@@ -18,6 +20,7 @@ const ESLINT_PATHS = [
 const ESLINT_IGNORE_PATHS = [];
 
 // Paths for Prettier to check/write.
+// NOTE: Prettier ignores paths in .gitignore.
 const PRETTIER_PATHS = [
 	'README.md',
 	'eslint.config.mjs',
@@ -31,7 +34,7 @@ const PRETTIER_PATHS = [
 const task = process.argv[2];
 const taskArgs = process.argv.slice(3).join(' ');
 
-run();
+void run();
 
 async function run() {
 	logInfo(taskArgs ? `[args:"${taskArgs}"]` : '');
@@ -56,15 +59,21 @@ async function run() {
 			break;
 		}
 
+		case 'prepublishOnly': {
+			prepublishOnly();
+
+			break;
+		}
+
 		case 'typescript:build': {
-			buildTypescript({ force: true });
+			buildTypescript({ force: true, args: taskArgs });
 			replaceVersion();
 
 			break;
 		}
 
 		case 'typescript:watch': {
-			watchTypescript();
+			watchTypescript({ args: taskArgs });
 
 			break;
 		}
@@ -90,7 +99,13 @@ async function run() {
 
 		case 'coverage': {
 			replaceVersion();
-			coverage();
+			coverage({ args: taskArgs });
+
+			break;
+		}
+
+		case 'publish:dry-run': {
+			publishDryRun();
 
 			break;
 		}
@@ -102,7 +117,7 @@ async function run() {
 		}
 
 		case 'release': {
-			release();
+			await release({ args: taskArgs });
 
 			break;
 		}
@@ -147,7 +162,8 @@ function deleteLib() {
 	fs.rmSync('lib', { recursive: true, force: true });
 }
 
-function buildTypescript({ force }) {
+function buildTypescript({ force, args = '' }) {
+	// Skip JavaScript code generation if the output already exists, unless forced.
 	if (!force && fs.existsSync('lib')) {
 		return;
 	}
@@ -157,15 +173,15 @@ function buildTypescript({ force }) {
 	deleteLib();
 
 	// Generate .js CommonJS code and .d.ts TypeScript declaration files in lib/.
-	executeCmd(`tsc ${taskArgs}`);
+	executeCmd(`tsc ${args}`);
 }
 
-function watchTypescript() {
+function watchTypescript({ args = '' } = {}) {
 	logInfo('watchTypescript()');
 
 	deleteLib();
 
-	executeCmd(`tsc --watch ${taskArgs}`);
+	executeCmd(`tsc --watch ${args}`);
 }
 
 function lint() {
@@ -199,16 +215,16 @@ function format() {
 	executeCmd(`prettier --write ${prettierFiles}`);
 }
 
-function test() {
+function test({ args = '' } = {}) {
 	logInfo('test()');
 
-	executeCmd(`jest --silent false --detectOpenHandles ${taskArgs}`);
+	executeCmd(`jest --silent false --detectOpenHandles ${args}`);
 }
 
-function coverage() {
+function coverage({ args = '' } = {}) {
 	logInfo('coverage()');
 
-	executeCmd(`jest --coverage ${taskArgs}`);
+	executeCmd(`jest --coverage ${args}`);
 	executeCmd('open-cli coverage/lcov-report/index.html');
 }
 
@@ -225,6 +241,43 @@ function installDeps() {
 	executeCmd('npm audit --omit dev');
 }
 
+/**
+ * `prepublishOnly` is run by NPM only on `npm publish` (not on `npm pack`,
+ * `npm install` or `npm ci`). We use it to forbid publishing mediasoup-client
+ * from a local machine. The package must only be published by the
+ * `mediasoup-client-npm-publish.yaml` workflow, which runs inside GitHub Actions
+ * (where GITHUB_ACTIONS environment variable is set to 'true') and uses OIDC
+ * trusted publishing.
+ */
+function prepublishOnly() {
+	logInfo('prepublishOnly()');
+
+	if (process.env.GITHUB_ACTIONS !== 'true') {
+		logError(
+			"prepublishOnly() | refusing to 'npm publish' outside of GitHub Actions: mediasoup-client is published only by the mediasoup-client-npm-publish.yaml workflow (triggered by pushing a release tag via 'npm run release')"
+		);
+
+		exitWithError();
+	}
+}
+
+function publishDryRun() {
+	logInfo('publishDryRun()');
+
+	// NOTE: We use `npm pack --dry-run` rather than `npm publish --dry-run`
+	// because the latter contacts the registry and fails with "You cannot
+	// publish over the previously published versions" whenever the version in
+	// package.json is already published (which is the usual state between
+	// releases), making it useless in CI.
+	//
+	// `npm pack --dry-run` still runs the `prepare` script (flatbuffers
+	// generation and TypeScript build) and assembles the tarball exactly as a
+	// real publish would, reporting its contents without writing any file or
+	// contacting the registry. Useful to validate the `files` list in
+	// package.json and that the package builds before tagging a release.
+	executeCmd('npm pack --dry-run --loglevel warn');
+}
+
 function checkRelease() {
 	logInfo('checkRelease()');
 
@@ -233,17 +286,77 @@ function checkRelease() {
 	replaceVersion();
 	lint();
 	test();
+	// Validate packaging (the `files` list in package.json) before the
+	// irreversible release steps (git push, GitHub release, npm publish).
+	publishDryRun();
 }
 
-function release() {
+async function release({ args = '' } = {}) {
 	logInfo('release()');
 
+	const version = args.trim();
+
+	if (!/^\d+\.\d+\.\d+$/.test(version)) {
+		logError(
+			`release() | a SEMVER 'x.y.z' argument is required, but got '${version}'`
+		);
+
+		exitWithError();
+	}
+
+	// Must be on the main branch.
+	const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+		encoding: 'utf-8',
+	}).trim();
+
+	if (branch !== MAIN_BRANCH) {
+		logError(
+			`release() | must be on '${MAIN_BRANCH}' branch, but it is on '${branch}' branch`
+		);
+
+		exitWithError();
+	}
+
+	// Clean working tree required before bumping the version.
+	checkGitClean();
+
+	// Lint, test, build, publish dry-run.
 	checkRelease();
-	executeCmd(`git commit -am '${pkg.version}'`);
-	executeCmd(`git tag -a ${pkg.version} -m '${pkg.version}'`);
-	executeCmd(`git push origin v${MAYOR_VERSION}`);
-	executeCmd(`git push origin '${pkg.version}'`);
-	executeInteractiveCmd('npm publish');
+
+	// Bump the version in package.json + package-lock.json.
+	executeCmd(`npm version ${version} --no-git-tag-version`);
+
+	// Commit the bump, tag it, and push both. The pushed tag triggers
+	// `mediasoup-client-npm-publish.yaml`, which checks, creates the GitHub
+	// release and publishes to NPM.
+	//
+	// The commit message carries a "[no-ci]" marker so the regular branch CI
+	// workflow skips this commit.
+	//
+	// NOTE: "[no-ci]" (with a hyphen) is a custom marker, NOT GitHub's native
+	// "[skip ci]"/"[no ci]" (which would also skip mediasoup-npm-publish, since
+	// the tag push shares this same commit).
+	executeCmd(`git commit -am 'release ${version} [no-ci]'`);
+	executeCmd(`git tag -a ${version} -m '${version}'`);
+	executeCmd(`git push origin ${MAIN_BRANCH}`);
+	executeCmd(`git push origin '${version}'`);
+}
+
+function checkGitClean() {
+	logInfo('checkGitClean()');
+
+	const status = execSync('git status --porcelain', {
+		encoding: 'utf-8',
+		stdio: ['ignore', 'pipe', 'ignore'],
+	});
+
+	if (status.trim()) {
+		logError(
+			'checkGitClean() | Git working tree is not clean, commit or stash your changes first'
+		);
+
+		exitWithError();
+	}
 }
 
 function executeCmd(command) {
@@ -258,6 +371,7 @@ function executeCmd(command) {
 	}
 }
 
+// eslint-disable-next-line no-unused-vars
 function executeInteractiveCmd(command) {
 	logInfo(`executeInteractiveCmd(): ${command}`);
 

--- a/package.json
+++ b/package.json
@@ -61,12 +61,14 @@
 	],
 	"scripts": {
 		"prepare": "node npm-scripts.mjs prepare",
+		"prepublishOnly": "node npm-scripts.mjs prepublishOnly",
 		"typescript:build": "node npm-scripts.mjs typescript:build",
 		"typescript:watch": "node npm-scripts.mjs typescript:watch",
 		"lint": "node npm-scripts.mjs lint",
 		"format": "node npm-scripts.mjs format",
 		"test": "node npm-scripts.mjs test",
 		"coverage": "node npm-scripts.mjs coverage",
+		"publish:dry-run": "node npm-scripts.mjs publish:dry-run",
 		"release:check": "node npm-scripts.mjs release:check",
 		"release": "node npm-scripts.mjs release"
 	},


### PR DESCRIPTION
# Details

- New `mediasoup-client-npm-publish` workflow that publishes GitHub and NPM releases. Triggered by Gti tag of type SEMVER, created and pushed by `npm run release VERSION`.
- `npm run release` now requires a SEMVER as argument and a clean git repository.
- New workflows to update mediasoup website and mediasoup-demo projects.